### PR TITLE
Use migrate.sh for Spin initContainer migrations

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -71,11 +71,12 @@ COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /uvx /bin/
 # Copy preinstalled virtualenv and source files
 COPY --from=builder /app /app
 
-# COPY entrypoint.sh BEFORE switching users
+# COPY entrypoint and migration scripts BEFORE switching users
 COPY entrypoint.sh /app/entrypoint.sh
+COPY migrate.sh /app/migrate.sh
 
-# Make it executable WHILE STILL ROOT
-RUN chmod +x /app/entrypoint.sh
+# Make them executable WHILE STILL ROOT
+RUN chmod +x /app/entrypoint.sh /app/migrate.sh
 
 EXPOSE 8000
 

--- a/backend/migrate.sh
+++ b/backend/migrate.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+set -e
+
+# -----------------------------------------------------------
+# Require DATABASE_URL
+# -----------------------------------------------------------
+if [ -z "${DATABASE_URL}" ]; then
+    echo "❌ DATABASE_URL is required but not set"
+    exit 1
+fi
+
+# -----------------------------------------------------------
+# Database readiness check
+# -----------------------------------------------------------
+# Strip SQLAlchemy driver suffix (e.g., +psycopg, +asyncpg) for pg_isready
+PG_URL=$(echo "${DATABASE_URL}" | sed 's|^\(postgresql\)+[a-z]*://|\1://|')
+
+echo "⏳ Waiting for database..."
+retries=0
+max_retries=30
+until pg_isready -d "${PG_URL}" -q; do
+    retries=$((retries + 1))
+    if [ "$retries" -ge "$max_retries" ]; then
+        echo "❌ Database not reachable after ${max_retries} attempts"
+        exit 1
+    fi
+    sleep 1
+done
+echo "✅ Database is ready"
+
+# Default to "upgrade head" when called without arguments
+if [ $# -eq 0 ]; then
+    set -- upgrade head
+fi
+
+echo "🔄 Running: alembic $*"
+if ! alembic "$@"; then
+    echo "❌ Alembic command failed"
+    exit 1
+fi
+echo "✅ Alembic command complete"

--- a/docs/cicd/DEPLOYMENT.md
+++ b/docs/cicd/DEPLOYMENT.md
@@ -262,8 +262,8 @@ Database migrations are executed by a backend Deployment initContainer during ro
 ### Runtime Behavior
 
 - Backend container starts the API directly and does not run migrations at startup.
-- InitContainer runs before backend container start and executes:
-  - `test -n "$DATABASE_URL" || { echo "DATABASE_URL is required"; exit 1; }; alembic upgrade head`
+- InitContainer runs before backend container start and executes `/app/migrate.sh`.
+- `migrate.sh` validates `DATABASE_URL`, waits for DB readiness, then runs `alembic upgrade head` by default.
 
 ### Spin Workloads
 

--- a/docs/cicd/README.md
+++ b/docs/cicd/README.md
@@ -104,6 +104,7 @@ Frontend and backend are released independently using component-scoped tags.
    - Only the matching component workflow will trigger
 
 4. **Deploy to NERSC Spin:**
+   - Backend migrations run automatically in the backend initContainer via `/app/migrate.sh` during rollout
    - Open the [Rancher UI](https://rancher2.spin.nersc.gov/dashboard/home)
    - Navigate to **Workloads → Deployments** in the prod namespace
    - Edit the deployment's image tag to the new version (e.g., `1.0.0`)

--- a/docs/deploy/spin.md
+++ b/docs/deploy/spin.md
@@ -19,9 +19,9 @@ No workload manifests are versioned under `deploy/spin/`.
 | Image pull secret          | `registry-nersc`                                                                                      |
 | Init container name        | `migrate`                                                                                             |
 | Init container image       | `registry.nersc.gov/e3sm/simboard/backend:<tag>`                                                      |
-| Init container command     | `sh`                                                                                                  |
-| Init container args        | `-c`                                                                                                  |
-| Init container script      | `test -n "$DATABASE_URL" \|\| { echo "DATABASE_URL is required"; exit 1; }; alembic upgrade head` |
+| Init container command     | `/app/migrate.sh`                                                                                     |
+| Init container args        | leave empty                                                                                           |
+| Init container script      | handled by `/app/migrate.sh` (checks `DATABASE_URL`, waits for DB, runs `alembic upgrade head`)     |
 | Init envFrom secret        | `simboard-backend-env`                                                                                |
 | App container name         | `backend`                                                                                             |
 | App container image        | `registry.nersc.gov/e3sm/simboard/backend:<tag>`                                                      |
@@ -35,9 +35,8 @@ No workload manifests are versioned under `deploy/spin/`.
 Canonical init container command/args to copy into Rancher:
 
 ```sh
-Command: sh
-Args[0]: -c
-Args[1]: test -n "$DATABASE_URL" || { echo "DATABASE_URL is required"; exit 1; }; alembic upgrade head
+Command: /app/migrate.sh
+Args: leave empty
 ```
 
 ### Backend Service (`backend`)


### PR DESCRIPTION
## Summary
- add `backend/migrate.sh` as a reusable migration entrypoint for Spin
- keep the current initContainer-based migration model (no migration Job workflow changes)
- update backend image wiring to include `/app/migrate.sh`
- update Spin and deployment docs to use `/app/migrate.sh` instead of hard-coded inline Alembic shell
- preserve direct runtime commands (`uvicorn` and `alembic`) without `uv run ...`

## Why this approach
PR #118 introduced a useful standalone migration script, but its broader Job-centric deployment guidance conflicts with the newer initContainer strategy already adopted on `main` in #138. This PR intentionally ports only the reusable script plus wiring/docs needed for the current Spin rollout model.

## Validation
- `sh -n backend/entrypoint.sh backend/migrate.sh`
- `make backend-test`
- `make pre-commit-run`
