### PR TITLE
Support ingestion machine aliases and backend domain_url setting

### DIFF
--- a/.envs/example/.env.example
+++ b/.envs/example/.env.example
@@ -1,9 +1,3 @@
-# Base domain (used for Traefik routing)
-DOMAIN=localhost
-
 # Image names (optional but useful for CI/CD tagging)
 DOCKER_IMAGE_BACKEND=registry.nersc.gov/e3sm/simboard/backend
 DOCKER_IMAGE_FRONTEND=registry.nersc.gov/e3sm/simboard/frontend
-
-# Only needed when using Traefik + HTTPS. Set localhost@example for local dev.
-LETSENCRYPT_EMAIL=your-email@example.com

--- a/.envs/example/backend.env.example
+++ b/.envs/example/backend.env.example
@@ -11,8 +11,8 @@ ENV=development
 ENVIRONMENT=${ENV}
 # FastAPI server port
 PORT=8000
-# Domain used by Traefik and backend CORS settings
-DOMAIN=example.com
+# Backend base URL used for redirects, generated links, and host-derived settings
+DOMAIN_URL=https://example.com
 # Stack name for Traefik routing (should match docker-compose.yml)
 STACK_NAME=simboard
 

--- a/.envs/example/backend.production.env.example
+++ b/.envs/example/backend.production.env.example
@@ -20,8 +20,8 @@ ENV=production
 ENVIRONMENT=${ENV}
 # FastAPI server port
 PORT=8000
-# Domain used by Traefik and backend CORS settings
-DOMAIN=example.com
+# Backend base URL used for redirects, generated links, and host-derived settings
+DOMAIN_URL=https://example.com
 # Stack name for Traefik routing (should match docker-compose.yml)
 STACK_NAME=simboard
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -42,7 +42,7 @@ jobs:
       # --------------------------------------------------
       ENV: "test"
       ENVIRONMENT: "test"
-      DOMAIN: "localhost"
+      DOMAIN_URL: "https://example.com"
       STACK_NAME: "simboard"
       PORT: "8000"
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help:
 	@echo "  make install                               # Install backend, frontend, and pre-commit dependencies"
 	@echo "  make setup-local                           # Bare-metal local environment setup"
 	@echo "  make setup-local-assets                    # Ensure .env files + certs exist"
-	@echo "  make copy-env-files                        # Copy .env.example → .env"
+	@echo "  make copy-env-files                        # Copy example env files into .envs/local/"
 	@echo "  make gen-certs                             # Generate local SSL certs"
 	@echo ""
 
@@ -279,7 +279,7 @@ frontend-fix:
 .PHONY: docker-help docker-build docker-rebuild docker-up docker-down docker-restart docker-logs docker-shell docker-ps docker-config
 
 ENV_PROD := \
-	--env-file .env \
+	--env-file .envs/local/.env \
 	--env-file .envs/local/backend.production.env
 
 COMPOSE := docker compose $(ENV_PROD) -f docker-compose.yml

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlparse
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -50,6 +51,20 @@ def _normalize_list(items: list[str]) -> list[str]:
     return [item.strip().rstrip("/") for item in items if item.strip()]
 
 
+def _extract_domain(domain_url: str) -> str:
+    """
+    Extract a bare hostname from a URL-like domain setting.
+
+    Removes the scheme, leading ``www.``, port, and any path/query fragments.
+    """
+    candidate = domain_url.strip()
+    parsed = urlparse(
+        candidate if "://" in candidate else f"https://{candidate}",
+    )
+    hostname = parsed.hostname or candidate
+    return hostname.removeprefix("www.")
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=get_env_file(),
@@ -61,7 +76,15 @@ class Settings(BaseSettings):
     # ----------------------------------------
     env: str = "development"
     port: int = 8000
-    domain: str = "example.com"
+    domain_url: str = Field(
+        default="https://example.com",
+        validation_alias="DOMAIN_URL",
+        description="Primary backend domain URL including scheme",
+    )
+
+    @property
+    def domain(self) -> str:
+        return _extract_domain(self.domain_url)
 
     # Frontend
     # ----------------------------------------

--- a/backend/app/features/ingestion/api.py
+++ b/backend/app/features/ingestion/api.py
@@ -18,7 +18,7 @@ from app.features.ingestion.schemas import (
     IngestionResponse,
     IngestionStatus,
 )
-from app.features.machine.models import Machine
+from app.features.machine.utils import resolve_machine_by_name
 from app.features.simulation.models import Artifact, Case, ExternalLink, Simulation
 from app.features.simulation.schemas import SimulationCreate
 from app.features.user.manager import current_active_user
@@ -78,7 +78,7 @@ def ingest_from_path(
             detail="Only administrators and service accounts may ingest from filesystem paths.",
         )
 
-    machine = db.query(Machine).filter(Machine.name == payload.machine_name).first()
+    machine = resolve_machine_by_name(db, payload.machine_name)
 
     if not machine:
         raise HTTPException(
@@ -151,7 +151,7 @@ def ingest_from_upload(
         Response model summarizing ingestion results, including counts,
         created simulations, and any recorded errors.
     """
-    machine = db.query(Machine).filter(Machine.name == machine_name).first()
+    machine = resolve_machine_by_name(db, machine_name)
 
     if not machine:
         raise HTTPException(

--- a/backend/app/features/ingestion/api.py
+++ b/backend/app/features/ingestion/api.py
@@ -27,6 +27,16 @@ from app.features.user.models import User, UserRole
 router = APIRouter(prefix="/ingestions", tags=["Ingestions"])
 
 
+def _resolve_request_machine(db: Session, machine_name: str):
+    machine = resolve_machine_by_name(db, machine_name)
+    if not machine:
+        raise HTTPException(
+            status_code=404, detail=f"Machine '{machine_name}' not found."
+        )
+
+    return machine
+
+
 @router.post(
     "/from-path",
     response_model=IngestionResponse,
@@ -78,12 +88,7 @@ def ingest_from_path(
             detail="Only administrators and service accounts may ingest from filesystem paths.",
         )
 
-    machine = resolve_machine_by_name(db, payload.machine_name)
-
-    if not machine:
-        raise HTTPException(
-            status_code=404, detail=f"Machine '{payload.machine_name}' not found."
-        )
+    machine = _resolve_request_machine(db, payload.machine_name)
 
     archive_path = Path(payload.archive_path)
     _validate_archive_path(archive_path)
@@ -151,12 +156,7 @@ def ingest_from_upload(
         Response model summarizing ingestion results, including counts,
         created simulations, and any recorded errors.
     """
-    machine = resolve_machine_by_name(db, machine_name)
-
-    if not machine:
-        raise HTTPException(
-            status_code=404, detail=f"Machine '{machine_name}' not found."
-        )
+    machine = _resolve_request_machine(db, machine_name)
 
     _validate_upload_file(file)
     filename = file.filename

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -30,7 +30,7 @@ from sqlalchemy.orm import Session
 from app.core.logger import _setup_custom_logger
 from app.features.ingestion.parsers.parser import main_parser
 from app.features.ingestion.parsers.types import ParsedSimulation
-from app.features.machine.models import Machine
+from app.features.machine.utils import resolve_machine_by_name
 from app.features.simulation.config_delta import SimulationConfigSnapshot
 from app.features.simulation.enums import SimulationStatus, SimulationType
 from app.features.simulation.models import Case, Simulation
@@ -540,7 +540,7 @@ def _resolve_machine_id(metadata: ParsedSimulation, db: Session) -> UUID:
     if not machine_name:
         raise ValueError("Machine name is required but not found in metadata")
 
-    machine = db.query(Machine).filter(Machine.name == machine_name).first()
+    machine = resolve_machine_by_name(db, machine_name)
     if not machine:
         raise LookupError(
             f"Machine '{machine_name}' not found in database. "

--- a/backend/app/features/machine/api.py
+++ b/backend/app/features/machine/api.py
@@ -7,6 +7,7 @@ from app.common.dependencies import get_database_session
 from app.core.database import transaction
 from app.features.machine.models import Machine
 from app.features.machine.schemas import MachineCreate, MachineOut
+from app.features.machine.utils import canonicalize_machine_name
 
 router = APIRouter(prefix="/machines", tags=["Machines"])
 
@@ -48,13 +49,17 @@ def create_machine(payload: MachineCreate, db: Session = Depends(get_database_se
         If a machine with the same name already exists, an HTTP 400 Bad Request
         error is raised with an appropriate message.
     """
-    if db.query(Machine).filter(Machine.name == payload.name).first():
+    normalized_name = canonicalize_machine_name(payload.name)
+
+    if db.query(Machine).filter(Machine.name == normalized_name).first():
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Machine with this name already exists",
         )
 
-    new_machine = Machine(**payload.model_dump())
+    machine_data = payload.model_dump()
+    machine_data["name"] = normalized_name
+    new_machine = Machine(**machine_data)
 
     with transaction(db):
         db.add(new_machine)

--- a/backend/app/features/machine/api.py
+++ b/backend/app/features/machine/api.py
@@ -7,7 +7,7 @@ from app.common.dependencies import get_database_session
 from app.core.database import transaction
 from app.features.machine.models import Machine
 from app.features.machine.schemas import MachineCreate, MachineOut
-from app.features.machine.utils import canonicalize_machine_name
+from app.features.machine.utils import normalize_machine_name_for_storage
 
 router = APIRouter(prefix="/machines", tags=["Machines"])
 
@@ -49,7 +49,7 @@ def create_machine(payload: MachineCreate, db: Session = Depends(get_database_se
         If a machine with the same name already exists, an HTTP 400 Bad Request
         error is raised with an appropriate message.
     """
-    normalized_name = canonicalize_machine_name(payload.name)
+    normalized_name = normalize_machine_name_for_storage(payload.name)
 
     if db.query(Machine).filter(Machine.name == normalized_name).first():
         raise HTTPException(

--- a/backend/app/features/machine/models.py
+++ b/backend/app/features/machine/models.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class Machine(Base, IDMixin, TimestampMixin):
     __tablename__ = "machines"
 
-    name: Mapped[str] = mapped_column(String(200), unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(200))
     site: Mapped[str] = mapped_column(String(200))
     architecture: Mapped[str] = mapped_column(String(100))
     scheduler: Mapped[str] = mapped_column(String(100))

--- a/backend/app/features/machine/models.py
+++ b/backend/app/features/machine/models.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, String, Text
+from sqlalchemy import Boolean, CheckConstraint, Index, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.schema import conv
 
 from app.common.models.base import Base
 from app.common.models.mixins import IDMixin, TimestampMixin
@@ -21,6 +22,14 @@ class Machine(Base, IDMixin, TimestampMixin):
     scheduler: Mapped[str] = mapped_column(String(100))
     gpu: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     notes: Mapped[str | None] = mapped_column(Text)
+
+    __table_args__ = (
+        CheckConstraint(
+            "name = lower(name)",
+            name=conv("ck_machines_name_lowercase"),
+        ),
+        Index("uq_machines_name_lower", func.lower(name), unique=True),
+    )
 
     simulations: Mapped[list[Simulation]] = relationship(
         back_populates="machine", cascade="all,save-update"

--- a/backend/app/features/machine/utils.py
+++ b/backend/app/features/machine/utils.py
@@ -1,4 +1,3 @@
-from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.features.machine.models import Machine
@@ -21,13 +20,4 @@ def resolve_machine_by_name(db: Session, machine_name: str) -> Machine | None:
     """Resolve a machine by canonical name, accepting known aliases."""
     canonical_name = canonicalize_machine_name(machine_name)
 
-    machine = db.query(Machine).filter(Machine.name == canonical_name).first()
-    if machine is not None:
-        return machine
-
-    # Fallback for legacy mixed-case rows until machine names are normalized.
-    machine = (
-        db.query(Machine).filter(func.lower(Machine.name) == canonical_name).first()
-    )
-
-    return machine
+    return db.query(Machine).filter(Machine.name == canonical_name).first()

--- a/backend/app/features/machine/utils.py
+++ b/backend/app/features/machine/utils.py
@@ -1,0 +1,23 @@
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.features.machine.models import Machine
+
+MACHINE_NAME_ALIASES = {
+    "pm": "perlmutter",
+    "pm-cpu": "perlmutter",
+    "pm-gpu": "perlmutter",
+}
+
+
+def canonicalize_machine_name(machine_name: str) -> str:
+    """Normalize external machine names to their canonical SimBoard name."""
+    normalized_name = machine_name.strip().lower()
+    return MACHINE_NAME_ALIASES.get(normalized_name, normalized_name)
+
+
+def resolve_machine_by_name(db: Session, machine_name: str) -> Machine | None:
+    """Resolve a machine by canonical name, accepting known aliases."""
+    canonical_name = canonicalize_machine_name(machine_name)
+
+    return db.query(Machine).filter(func.lower(Machine.name) == canonical_name).first()

--- a/backend/app/features/machine/utils.py
+++ b/backend/app/features/machine/utils.py
@@ -9,9 +9,14 @@ MACHINE_NAME_ALIASES = {
 }
 
 
+def normalize_machine_name_for_storage(machine_name: str) -> str:
+    """Normalize machine names for canonical lowercase storage."""
+    return machine_name.strip().lower()
+
+
 def canonicalize_machine_name(machine_name: str) -> str:
     """Normalize external machine names to their canonical SimBoard name."""
-    normalized_name = machine_name.strip().lower()
+    normalized_name = normalize_machine_name_for_storage(machine_name)
 
     return MACHINE_NAME_ALIASES.get(normalized_name, normalized_name)
 

--- a/backend/app/features/machine/utils.py
+++ b/backend/app/features/machine/utils.py
@@ -13,6 +13,7 @@ MACHINE_NAME_ALIASES = {
 def canonicalize_machine_name(machine_name: str) -> str:
     """Normalize external machine names to their canonical SimBoard name."""
     normalized_name = machine_name.strip().lower()
+
     return MACHINE_NAME_ALIASES.get(normalized_name, normalized_name)
 
 
@@ -20,4 +21,13 @@ def resolve_machine_by_name(db: Session, machine_name: str) -> Machine | None:
     """Resolve a machine by canonical name, accepting known aliases."""
     canonical_name = canonicalize_machine_name(machine_name)
 
-    return db.query(Machine).filter(func.lower(Machine.name) == canonical_name).first()
+    machine = db.query(Machine).filter(Machine.name == canonical_name).first()
+    if machine is not None:
+        return machine
+
+    # Fallback for legacy mixed-case rows until machine names are normalized.
+    machine = (
+        db.query(Machine).filter(func.lower(Machine.name) == canonical_name).first()
+    )
+
+    return machine

--- a/backend/app/scripts/users/provision_service_account.py
+++ b/backend/app/scripts/users/provision_service_account.py
@@ -25,7 +25,7 @@ from urllib.parse import urlparse
 
 from app.api.version import API_BASE
 
-# DEFAULT_BASE_URL = f"https://{settings.domain}:8000"
+# DEFAULT_BASE_URL = settings.domain_url
 DEFAULT_BASE_URL = "https://127.0.0.1:8000"
 LOCAL_CERT_PATH = Path(__file__).resolve().parents[4] / "certs" / "local.crt"
 LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"}

--- a/backend/app/scripts/users/provision_service_account.py
+++ b/backend/app/scripts/users/provision_service_account.py
@@ -24,9 +24,9 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from app.api.version import API_BASE
+from app.core.config import settings
 
-# DEFAULT_BASE_URL = settings.domain_url
-DEFAULT_BASE_URL = "https://127.0.0.1:8000"
+DEFAULT_BASE_URL = settings.domain_url
 LOCAL_CERT_PATH = Path(__file__).resolve().parents[4] / "certs" / "local.crt"
 LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"}
 

--- a/backend/migrations/versions/20260319_000000_normalize_machine_names_lowercase.py
+++ b/backend/migrations/versions/20260319_000000_normalize_machine_names_lowercase.py
@@ -1,0 +1,59 @@
+"""Normalize machine names to lowercase and enforce case-insensitive uniqueness.
+
+Revision ID: 20260319_000000
+Revises: 20260304_400000
+Create Date: 2026-03-19 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260319_000000"
+down_revision: Union[str, Sequence[str], None] = "20260304_400000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Normalize machine names and enforce case-insensitive uniqueness."""
+    connection = op.get_bind()
+
+    duplicate_names = connection.execute(
+        sa.text(
+            """
+            SELECT lower(name) AS normalized_name
+            FROM machines
+            GROUP BY lower(name)
+            HAVING COUNT(*) > 1
+            ORDER BY lower(name)
+            """
+        )
+    ).scalars()
+    duplicate_names = list(duplicate_names)
+
+    if duplicate_names:
+        conflicts = ", ".join(duplicate_names)
+        raise RuntimeError(
+            "Cannot normalize machine names because case-insensitive duplicates "
+            f"already exist: {conflicts}"
+        )
+
+    op.execute(
+        sa.text("UPDATE machines SET name = lower(name) WHERE name <> lower(name)")
+    )
+    op.drop_index(op.f("ix_machines_name"), table_name="machines")
+    op.create_index(
+        "uq_machines_name_lower",
+        "machines",
+        [sa.text("lower(name)")],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Restore the original case-sensitive unique index."""
+    op.drop_index("uq_machines_name_lower", table_name="machines")
+    op.create_index(op.f("ix_machines_name"), "machines", ["name"], unique=True)

--- a/backend/migrations/versions/20260319_000000_normalize_machine_names_lowercase.py
+++ b/backend/migrations/versions/20260319_000000_normalize_machine_names_lowercase.py
@@ -44,6 +44,11 @@ def upgrade() -> None:
     op.execute(
         sa.text("UPDATE machines SET name = lower(name) WHERE name <> lower(name)")
     )
+    op.create_check_constraint(
+        "ck_machines_name_lowercase",
+        "machines",
+        "name = lower(name)",
+    )
     op.drop_index(op.f("ix_machines_name"), table_name="machines")
     op.create_index(
         "uq_machines_name_lower",
@@ -56,4 +61,5 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Restore the original case-sensitive unique index."""
     op.drop_index("uq_machines_name_lower", table_name="machines")
+    op.drop_constraint("ck_machines_name_lowercase", "machines", type_="check")
     op.create_index(op.f("ix_machines_name"), "machines", ["name"], unique=True)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,7 +18,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.common.dependencies import get_database_session
-from app.common.models.base import Base
 from app.core.config import settings
 from app.core.database_async import get_async_session
 from app.core.logger import _setup_custom_logger
@@ -390,12 +389,17 @@ AsyncTestingSessionLocal = async_sessionmaker(
 @pytest_asyncio.fixture(scope="function")
 async def async_db() -> AsyncGenerator[AsyncSession, None]:
     """Provide an AsyncSession for FastAPI Users tests."""
-    async with async_engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    async with AsyncTestingSessionLocal() as session:
-        yield session
-    async with async_engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
+    async with async_engine.connect() as conn:
+        outer_tx = await conn.begin()
+        session = AsyncTestingSessionLocal(
+            bind=conn,
+            join_transaction_mode="create_savepoint",
+        )
+        try:
+            yield session
+        finally:
+            await session.close()
+            await outer_tx.rollback()
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -76,14 +76,31 @@ class TestSettings:
     @pytest.fixture(autouse=True)
     def restore_settings(self):
         original_env = settings.env
+        original_domain_url = settings.domain_url
         original_frontend_origin = settings.frontend_origin
         original_frontend_origins = settings.frontend_origins
 
         yield
 
         settings.env = original_env
+        settings.domain_url = original_domain_url
         settings.frontend_origin = original_frontend_origin
         settings.frontend_origins = original_frontend_origins
+
+    @pytest.mark.parametrize(
+        ("domain_url", "expected_domain"),
+        [
+            ("https://www.example.com", "example.com"),
+            ("http://www.example.com", "example.com"),
+            ("https://example.com", "example.com"),
+            ("https://example.com:8443/path?q=1", "example.com"),
+        ],
+    )
+    def test_domain_strips_scheme_www_and_url_parts(
+        self, domain_url: str, expected_domain: str
+    ):
+        settings.domain_url = domain_url
+        assert settings.domain == expected_domain
 
     def test_frontend_origin_has_no_trailing_slash(self):
         settings.frontend_origin = "http://localhost:3000/"

--- a/backend/tests/features/ingestion/parsers/test_case_docs.py
+++ b/backend/tests/features/ingestion/parsers/test_case_docs.py
@@ -250,6 +250,22 @@ class TestParseEnvRun:
 
         assert result["simulation_end_date"] is None
 
+    def test_missing_simulation_start_date_returns_none(self, tmp_path):
+        xml_run = """
+        <config>
+            <entry id="RUN_TYPE" value="startup" />
+            <entry id="STOP_OPTION" value="ndays" />
+            <entry id="STOP_N" value="10" />
+        </config>
+        """
+        tmp_run = tmp_path / "env_run_missing_start.xml"
+        tmp_run.write_text(xml_run)
+
+        result = parse_env_run(tmp_run)
+
+        assert result["simulation_start_date"] is None
+        assert result["simulation_end_date"] is None
+
     def test_missing_stop_date_returns_none(self, tmp_path):
         xml_run = """
         <config>

--- a/backend/tests/features/ingestion/parsers/test_git_info.py
+++ b/backend/tests/features/ingestion/parsers/test_git_info.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from app.features.ingestion.parsers.git_info import (
+    _extract_branch,
     _extract_remote_url,
     parse_git_config,
     parse_git_describe,
@@ -39,6 +40,11 @@ class TestGitInfoParser:
         result = parse_git_status(str(file_path))
 
         assert result == {"git_branch": "feature/59-automate-ingestion"}
+
+    def test_extract_branch_returns_none_without_branch_line(self) -> None:
+        lines = ["nothing useful here", "HEAD detached at abc123"]
+
+        assert _extract_branch(lines) is None
 
     def test_parse_git_config_origin_url(self, tmp_path: Path) -> None:
         content = '[remote "origin"]\n    url = https://github.com/example/repo.git\n'

--- a/backend/tests/features/ingestion/parsers/test_parser.py
+++ b/backend/tests/features/ingestion/parsers/test_parser.py
@@ -167,6 +167,13 @@ class TestMainParser:
         assert parser.FILE_SPECS["case_docs_env_run"]["required"] is True
         assert parser.FILE_SPECS["e3sm_timing"]["required"] is True
 
+    def test_resolve_execution_id_rejects_blank_values(self) -> None:
+        with pytest.raises(
+            FileNotFoundError,
+            match="Required timing-file LID missing for execution directory '1.0-0'",
+        ):
+            parser._resolve_execution_id("   ", "1.0-0")
+
     def test_with_valid_zip_archive(self, tmp_path: Path) -> None:
         archive_base = tmp_path / "archive_extract"
         execution_dir = archive_base / "1.0-0"

--- a/backend/tests/features/ingestion/parsers/test_readme_case.py
+++ b/backend/tests/features/ingestion/parsers/test_readme_case.py
@@ -53,6 +53,17 @@ class TestParseReadmeCase:
         assert result["grid_name"] is None
         assert result["compset"] is None
 
+    def test_missing_timestamp_returns_none(self, tmp_path):
+        content = "/path/create_newcase --case v3.LR.historical_0121 --res ne30 --compset WCYCL20TR\n"
+        file_path = tmp_path / "README.case"
+        file_path.write_text(content)
+
+        result = parse_readme_case(file_path)
+
+        assert result["creation_date"] is None
+        assert result["grid_name"] == "ne30"
+        assert result["compset"] == "WCYCL20TR"
+
     def test_parse_flag_equals_format(self, tmp_path):
         content = (
             "2025-12-18 22:36:01: /path/create_newcase --case v3.LR.historical_0121 "

--- a/backend/tests/features/ingestion/test_api.py
+++ b/backend/tests/features/ingestion/test_api.py
@@ -333,6 +333,63 @@ class TestIngestFromPathEndpoint:
         assert res.status_code == 404
         assert res.json()["detail"] == "Machine 'does-not-exist-machine' not found."
 
+    @pytest.mark.parametrize("machine_alias", ["pm", "pm-cpu", "pm-gpu"])
+    def test_endpoint_accepts_perlmutter_aliases(
+        self, client, db: Session, tmp_path, machine_alias: str
+    ):
+        machine = db.query(Machine).filter(Machine.name == "perlmutter").first()
+        if machine is None:
+            machine = Machine(
+                name="perlmutter",
+                site="NERSC",
+                architecture="AMD EPYC + NVIDIA A100",
+                scheduler="slurm",
+                gpu=True,
+            )
+            db.add(machine)
+            db.commit()
+            db.refresh(machine)
+
+        archive_path = self._create_archive_file(tmp_path, "archive.tar.gz")
+        payload = {"archive_path": str(archive_path), "machine_name": machine_alias}
+
+        case = Case(name=f"test_case_alias_{machine_alias}")
+        db.add(case)
+        db.flush()
+
+        mock_simulations = [
+            SimulationCreate.model_validate(
+                {
+                    "caseId": str(case.id),
+                    "executionId": f"exec-{machine_alias}",
+                    "compset": "AQUAPLANET",
+                    "compsetAlias": "QPC4",
+                    "gridName": "f19_f19",
+                    "gridResolution": "1.9x2.5",
+                    "initializationType": "startup",
+                    "simulationType": "experimental",
+                    "status": "created",
+                    "machineId": str(machine.id),
+                    "simulationStartDate": "2023-01-01T00:00:00Z",
+                    "gitTag": "v1.0",
+                    "gitCommitHash": "abc123",
+                }
+            )
+        ]
+
+        with patch(
+            "app.features.ingestion.api.ingest_archive",
+            return_value=IngestArchiveResult(
+                simulations=mock_simulations,
+                created_count=1,
+                duplicate_count=0,
+                errors=[],
+            ),
+        ):
+            res = client.post(f"{API_BASE}/ingestions/from-path", json=payload)
+
+        assert res.status_code == 201
+
 
 class TestIngestFromUploadEndpoint:
     @staticmethod

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -509,6 +509,51 @@ class TestIngestArchive:
         assert ingest_result.errors[0]["error_type"] == "LookupError"
         assert "Machine 'nonexistent'" in ingest_result.errors[0]["error"]
 
+    @pytest.mark.parametrize("machine_alias", ["pm", "pm-cpu", "pm-gpu"])
+    def test_machine_aliases_resolve_to_perlmutter(
+        self, db: Session, machine_alias: str
+    ) -> None:
+        machine = db.query(Machine).filter(Machine.name == "perlmutter").first()
+        if machine is None:
+            machine = self._create_machine(db, "perlmutter")
+
+        mock_simulations = {
+            "/path/to/1081175.251218-200935": {
+                "case_name": "case1",
+                "compset": "test",
+                "compset_alias": "test_alias",
+                "grid_name": "grid",
+                "grid_resolution": "0.9x1.25",
+                "machine": machine_alias,
+                "simulation_start_date": "2020-01-01",
+                "initialization_type": "test",
+                "simulation_type": "test_type",
+                "status": None,
+                "experiment_type": None,
+                "campaign": None,
+                "run_start_date": None,
+                "run_end_date": None,
+                "compiler": None,
+                "git_repository_url": None,
+                "git_branch": None,
+                "git_tag": None,
+                "git_commit_hash": None,
+                "created_by": None,
+                "last_updated_by": None,
+            }
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(mock_simulations, 0),
+        ):
+            ingest_result = ingest_archive(
+                Path("/tmp/archive.zip"), Path("/tmp/out"), db
+            )
+
+        assert len(ingest_result.simulations) == 1
+        assert ingest_result.simulations[0].machine_id == machine.id
+
 
 class TestIngestArchiveContinued(TestIngestArchive):
     def test_normalize_simulation_type_handles_none_and_blank(self) -> None:

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -16,6 +16,7 @@ from app.features.ingestion.ingest import (
     _normalize_git_url,
     _normalize_simulation_status,
     _normalize_simulation_type,
+    _stringify_config_value,
     _validate_simulation_create,
     ingest_archive,
 )
@@ -91,6 +92,13 @@ class TestIngestArchive:
     - Archive parsing integration
     - Error handling and propagation
     """
+
+    def test_stringify_config_value_falls_back_to_str_for_non_string_objects(self):
+        class ValueObject:
+            def __str__(self) -> str:
+                return "42"
+
+        assert _stringify_config_value(ValueObject()) == "42"
 
     @staticmethod
     def _create_machine(db: Session, name: str) -> Machine:

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -520,6 +520,7 @@ class TestIngestArchive:
 
         mock_simulations = {
             "/path/to/1081175.251218-200935": {
+                "execution_id": "1081175.251218-200935",
                 "case_name": "case1",
                 "compset": "test",
                 "compset_alias": "test_alias",
@@ -546,7 +547,7 @@ class TestIngestArchive:
 
         with patch(
             "app.features.ingestion.ingest.main_parser",
-            return_value=(mock_simulations, 0),
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
         ):
             ingest_result = ingest_archive(
                 Path("/tmp/archive.zip"), Path("/tmp/out"), db

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
+import pytest
 from dateutil import parser as real_dateutil_parser
 from sqlalchemy.orm import Session
 

--- a/backend/tests/features/machine/test_api.py
+++ b/backend/tests/features/machine/test_api.py
@@ -51,6 +51,36 @@ class TestCreateMachine:
             if key != "name":
                 assert data[key] == payload[key]
 
+    def test_function_does_not_expand_aliases_on_write(self, db: Session):
+        payload = {
+            "name": "pm",
+            "site": "Site Alias",
+            "architecture": "x86_64",
+            "scheduler": "SLURM",
+            "gpu": False,
+            "notes": "Alias should not expand on write",
+        }
+
+        machine_create = MachineCreate(**payload)
+        machine = create_machine(machine_create, db)
+
+        assert machine.name == "pm"
+
+    def test_endpoint_does_not_expand_aliases_on_write(self, client):
+        payload = {
+            "name": "pm",
+            "site": "Site Alias",
+            "architecture": "x86_64",
+            "scheduler": "SLURM",
+            "gpu": False,
+            "notes": "Alias should not expand on write",
+        }
+
+        res = client.post(f"{API_BASE}/machines", json=payload)
+
+        assert res.status_code == 201
+        assert res.json()["name"] == "pm"
+
     def test_function_raises_error_for_duplicate_name_(self, db: Session):
         db.add(
             Machine(
@@ -134,6 +164,22 @@ class TestCreateMachine:
 
         db.rollback()
 
+    def test_database_enforces_lowercase_machine_names(self, db: Session) -> None:
+        db.add(
+            Machine(
+                name="Mixed-Case-Machine",
+                site="Site Mixed",
+                architecture="x86_64",
+                scheduler="SLURM",
+                gpu=False,
+            )
+        )
+
+        with pytest.raises(IntegrityError):
+            db.commit()
+
+        db.rollback()
+
     def test_database_uses_lowercase_unique_index_for_machine_names(
         self, db: Session
     ) -> None:
@@ -154,6 +200,34 @@ class TestCreateMachine:
         assert "uq_machines_name_lower" in indexes
         assert "UNIQUE INDEX" in indexes["uq_machines_name_lower"]
         assert "lower(" in indexes["uq_machines_name_lower"]
+
+        constraint_rows = db.execute(
+            text(
+                """
+                SELECT conname, pg_get_constraintdef(c.oid)
+                FROM pg_constraint c
+                JOIN pg_class t ON c.conrelid = t.oid
+                JOIN pg_namespace n ON t.relnamespace = n.oid
+                WHERE n.nspname = 'public' AND t.relname = 'machines'
+                ORDER BY conname
+                """
+            )
+        ).all()
+
+        constraints = {row[0]: row[1] for row in constraint_rows}
+
+        lowercase_constraint = next(
+            (
+                constraint_def
+                for constraint_name, constraint_def in constraints.items()
+                if constraint_name.endswith("ck_machines_name_lowercase")
+            ),
+            None,
+        )
+
+        assert lowercase_constraint is not None
+        assert "CHECK" in lowercase_constraint
+        assert "lower((name)::text)" in lowercase_constraint
 
 
 class TestListMachines:

--- a/backend/tests/features/machine/test_api.py
+++ b/backend/tests/features/machine/test_api.py
@@ -227,7 +227,7 @@ class TestCreateMachine:
 
         assert lowercase_constraint is not None
         assert "CHECK" in lowercase_constraint
-        assert "lower((name)::text)" in lowercase_constraint
+        assert "lower" in lowercase_constraint
 
 
 class TestListMachines:

--- a/backend/tests/features/machine/test_api.py
+++ b/backend/tests/features/machine/test_api.py
@@ -1,6 +1,9 @@
 from uuid import uuid4
 
+import pytest
 from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.version import API_BASE
@@ -23,8 +26,10 @@ class TestCreateMachine:
         machine_create = MachineCreate(**payload)
         machine = create_machine(machine_create, db)
 
+        assert machine.name == "machine a"
         for key in payload:
-            assert getattr(machine, key) == payload[key]
+            if key != "name":
+                assert getattr(machine, key) == payload[key]
 
     def test_endpoint_succeeds_with_valid_payload(self, client):
         payload = {
@@ -41,13 +46,15 @@ class TestCreateMachine:
         assert res.status_code == 201
         data = res.json()
 
+        assert data["name"] == "machine f"
         for key in payload:
-            assert data[key] == payload[key]
+            if key != "name":
+                assert data[key] == payload[key]
 
     def test_function_raises_error_for_duplicate_name_(self, db: Session):
         db.add(
             Machine(
-                name="Machine B",
+                name="machine b",
                 site="Site B",
                 architecture="x86_64",
                 scheduler="PBS",
@@ -58,7 +65,7 @@ class TestCreateMachine:
         db.commit()
 
         payload = {
-            "name": "Machine B",
+            "name": "MACHINE B",
             "site": "Site C",
             "architecture": "ARM",
             "scheduler": "SLURM",
@@ -75,7 +82,7 @@ class TestCreateMachine:
     def test_endpoint_raises_400_for_duplicate_name(self, client, db: Session):
         db.add(
             Machine(
-                name="Machine B",
+                name="machine b",
                 site="Site B",
                 architecture="x86_64",
                 scheduler="PBS",
@@ -86,7 +93,7 @@ class TestCreateMachine:
         db.commit()
 
         payload = {
-            "name": "Machine B",
+            "name": "MACHINE B",
             "site": "Site C",
             "architecture": "ARM",
             "scheduler": "SLURM",
@@ -97,6 +104,56 @@ class TestCreateMachine:
         res = client.post(f"{API_BASE}/machines", json=payload)
         assert res.status_code == 400
         assert res.json()["detail"] == "Machine with this name already exists"
+
+    def test_database_enforces_case_insensitive_machine_uniqueness(
+        self, db: Session
+    ) -> None:
+        db.add(
+            Machine(
+                name="machine constraint",
+                site="Site A",
+                architecture="x86_64",
+                scheduler="SLURM",
+                gpu=False,
+            )
+        )
+        db.commit()
+
+        db.add(
+            Machine(
+                name="MACHINE CONSTRAINT",
+                site="Site B",
+                architecture="ARM",
+                scheduler="PBS",
+                gpu=False,
+            )
+        )
+
+        with pytest.raises(IntegrityError):
+            db.commit()
+
+        db.rollback()
+
+    def test_database_uses_lowercase_unique_index_for_machine_names(
+        self, db: Session
+    ) -> None:
+        index_rows = db.execute(
+            text(
+                """
+                SELECT indexname, indexdef
+                FROM pg_indexes
+                WHERE schemaname = 'public' AND tablename = 'machines'
+                ORDER BY indexname
+                """
+            )
+        ).all()
+
+        indexes = {row[0]: row[1] for row in index_rows}
+
+        assert "ix_machines_name" not in indexes
+        assert "uq_machines_name_lower" in indexes
+        assert "UNIQUE INDEX" in indexes["uq_machines_name_lower"]
+        assert "lower(" in indexes["uq_machines_name_lower"]
 
 
 class TestListMachines:
@@ -140,7 +197,7 @@ class TestListMachines:
 class TestGetMachine:
     def test_function_successfully_gets_machine(self, db: Session):
         expected = Machine(
-            name="Machine E",
+            name="machine e",
             site="Site E",
             architecture="x86_64",
             scheduler="SLURM",
@@ -157,7 +214,7 @@ class TestGetMachine:
 
     def test_endpoint_successfully_get_machine(self, client, db: Session):
         expected = Machine(
-            name="Machine E",
+            name="machine e",
             site="Site E",
             architecture="x86_64",
             scheduler="SLURM",

--- a/backend/tests/features/machine/test_models.py
+++ b/backend/tests/features/machine/test_models.py
@@ -1,16 +1,52 @@
+from collections.abc import Generator
+from typing import cast
+from uuid import uuid4
+
 import pytest
+from sqlalchemy import Table, text
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
 
+from app.common.models.base import Base
 from app.features.machine.models import Machine
+from tests.conftest import engine
 
-pytestmark = pytest.mark.asyncio
+
+@pytest.fixture
+def machine_create_all_db() -> Generator[Session, None, None]:
+    schema_name = f"test_machine_create_all_{uuid4().hex}"
+
+    with engine.connect() as connection:
+        connection.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+        connection.execute(text(f'SET search_path TO "{schema_name}"'))
+        Base.metadata.create_all(
+            bind=connection,
+            tables=[cast(Table, Machine.__table__)],
+        )
+        connection.commit()
+
+        session = sessionmaker(
+            bind=connection,
+            autocommit=False,
+            autoflush=False,
+            expire_on_commit=False,
+            future=True,
+        )()
+
+        try:
+            yield session
+        finally:
+            session.close()
+            connection.execute(text("RESET search_path"))
+            connection.execute(text(f'DROP SCHEMA "{schema_name}" CASCADE'))
+            connection.commit()
 
 
 class TestMachineModelCreateAllSchema:
-    async def test_create_all_schema_enforces_case_insensitive_uniqueness(
-        self, async_db
+    def test_create_all_schema_enforces_case_insensitive_uniqueness(
+        self, machine_create_all_db: Session
     ) -> None:
-        async_db.add(
+        machine_create_all_db.add(
             Machine(
                 name="machine constraint",
                 site="Site A",
@@ -19,9 +55,9 @@ class TestMachineModelCreateAllSchema:
                 gpu=False,
             )
         )
-        await async_db.commit()
+        machine_create_all_db.commit()
 
-        async_db.add(
+        machine_create_all_db.add(
             Machine(
                 name="MACHINE CONSTRAINT",
                 site="Site B",
@@ -32,14 +68,14 @@ class TestMachineModelCreateAllSchema:
         )
 
         with pytest.raises(IntegrityError):
-            await async_db.commit()
+            machine_create_all_db.commit()
 
-        await async_db.rollback()
+        machine_create_all_db.rollback()
 
-    async def test_create_all_schema_enforces_lowercase_machine_names(
-        self, async_db
+    def test_create_all_schema_enforces_lowercase_machine_names(
+        self, machine_create_all_db: Session
     ) -> None:
-        async_db.add(
+        machine_create_all_db.add(
             Machine(
                 name="Mixed-Case-Machine",
                 site="Site Mixed",
@@ -50,6 +86,6 @@ class TestMachineModelCreateAllSchema:
         )
 
         with pytest.raises(IntegrityError):
-            await async_db.commit()
+            machine_create_all_db.commit()
 
-        await async_db.rollback()
+        machine_create_all_db.rollback()

--- a/backend/tests/features/machine/test_models.py
+++ b/backend/tests/features/machine/test_models.py
@@ -1,0 +1,55 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.features.machine.models import Machine
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestMachineModelCreateAllSchema:
+    async def test_create_all_schema_enforces_case_insensitive_uniqueness(
+        self, async_db
+    ) -> None:
+        async_db.add(
+            Machine(
+                name="machine constraint",
+                site="Site A",
+                architecture="x86_64",
+                scheduler="SLURM",
+                gpu=False,
+            )
+        )
+        await async_db.commit()
+
+        async_db.add(
+            Machine(
+                name="MACHINE CONSTRAINT",
+                site="Site B",
+                architecture="ARM",
+                scheduler="PBS",
+                gpu=False,
+            )
+        )
+
+        with pytest.raises(IntegrityError):
+            await async_db.commit()
+
+        await async_db.rollback()
+
+    async def test_create_all_schema_enforces_lowercase_machine_names(
+        self, async_db
+    ) -> None:
+        async_db.add(
+            Machine(
+                name="Mixed-Case-Machine",
+                site="Site Mixed",
+                architecture="x86_64",
+                scheduler="SLURM",
+                gpu=False,
+            )
+        )
+
+        with pytest.raises(IntegrityError):
+            await async_db.commit()
+
+        await async_db.rollback()

--- a/backend/tests/features/machine/test_utils.py
+++ b/backend/tests/features/machine/test_utils.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from app.features.machine.models import Machine
 from app.features.machine.utils import (
     canonicalize_machine_name,
+    normalize_machine_name_for_storage,
     resolve_machine_by_name,
 )
 
@@ -15,6 +16,12 @@ class TestCanonicalizeMachineName:
 
     def test_normalizes_unknown_names(self) -> None:
         assert canonicalize_machine_name(" Frontier ") == "frontier"
+
+
+class TestNormalizeMachineNameForStorage:
+    def test_lowercases_and_trims_without_alias_expansion(self) -> None:
+        assert normalize_machine_name_for_storage(" Machine A ") == "machine a"
+        assert normalize_machine_name_for_storage("PM") == "pm"
 
 
 class TestResolveMachineByName:

--- a/backend/tests/features/machine/test_utils.py
+++ b/backend/tests/features/machine/test_utils.py
@@ -40,10 +40,10 @@ class TestResolveMachineByName:
         assert resolved is not None
         assert resolved.id == machine.id
 
-    def test_falls_back_to_case_insensitive_match_for_legacy_rows(
+    def test_resolves_unknown_names_after_lowercase_normalization(
         self, db: Session
     ) -> None:
-        machine = self._create_machine(db, "Legacy-Machine")
+        machine = self._create_machine(db, "legacy-machine")
 
         resolved = resolve_machine_by_name(db, " legacy-machine ")
 

--- a/backend/tests/features/machine/test_utils.py
+++ b/backend/tests/features/machine/test_utils.py
@@ -1,0 +1,51 @@
+from sqlalchemy.orm import Session
+
+from app.features.machine.models import Machine
+from app.features.machine.utils import (
+    canonicalize_machine_name,
+    resolve_machine_by_name,
+)
+
+
+class TestCanonicalizeMachineName:
+    def test_maps_known_aliases_to_canonical_name(self) -> None:
+        assert canonicalize_machine_name("pm") == "perlmutter"
+        assert canonicalize_machine_name(" pm-cpu ") == "perlmutter"
+        assert canonicalize_machine_name("PM-GPU") == "perlmutter"
+
+    def test_normalizes_unknown_names(self) -> None:
+        assert canonicalize_machine_name(" Frontier ") == "frontier"
+
+
+class TestResolveMachineByName:
+    @staticmethod
+    def _create_machine(db: Session, name: str) -> Machine:
+        machine = Machine(
+            name=name,
+            site="Test Site",
+            architecture="x86_64",
+            scheduler="SLURM",
+            gpu=False,
+        )
+        db.add(machine)
+        db.commit()
+        db.refresh(machine)
+        return machine
+
+    def test_resolves_alias_with_exact_canonical_match(self, db: Session) -> None:
+        machine = db.query(Machine).filter(Machine.name == "perlmutter").one()
+
+        resolved = resolve_machine_by_name(db, "pm")
+
+        assert resolved is not None
+        assert resolved.id == machine.id
+
+    def test_falls_back_to_case_insensitive_match_for_legacy_rows(
+        self, db: Session
+    ) -> None:
+        machine = self._create_machine(db, "Legacy-Machine")
+
+        resolved = resolve_machine_by_name(db, " legacy-machine ")
+
+        assert resolved is not None
+        assert resolved.id == machine.id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       PORT: "8000"
       STACK_NAME: simboard
 
-      DOMAIN: ${DOMAIN:-localhost}
+      DOMAIN_URL: ${DOMAIN_URL:-https://example.com}
       FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:-https://localhost:5173}
       FRONTEND_AUTH_REDIRECT_URL: ${FRONTEND_AUTH_REDIRECT_URL:-https://localhost:5173/auth/callback}
       GITHUB_REDIRECT_URL: ${GITHUB_REDIRECT_URL:-https://localhost/api/v1/auth/github/callback}

--- a/docs/cicd/DEPLOYMENT.md
+++ b/docs/cicd/DEPLOYMENT.md
@@ -305,12 +305,12 @@ Use an explicit rollout strategy that guarantees only one new pod (and therefore
 
 ```yaml
 spec:
-   replicas: 1
-   strategy:
-      type: RollingUpdate
-      rollingUpdate:
-         maxSurge: 0
-         maxUnavailable: 1
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
 ```
 
 Why this is required: with default `RollingUpdate` settings, Kubernetes may create a surge pod during updates, which can run a second migration initContainer even when the steady-state replica count is `1`.
@@ -366,7 +366,7 @@ cd backend
 docker buildx build \
   --platform=linux/amd64,linux/arm64 \
   --build-arg ENV=production \
-  -t registry.nersc.gov/e3sm/simboard/backend:manual \
+  -t registry.nersc.gov/e3sm/simboard/backend:dev-manual \
   --push \
   .
 
@@ -380,7 +380,7 @@ cd frontend
 docker buildx build \
   --platform=linux/amd64,linux/arm64 \
   --build-arg VITE_API_BASE_URL=https://simboard-dev-api.e3sm.org \
-  -t registry.nersc.gov/e3sm/simboard/frontend:manual \
+  -t registry.nersc.gov/e3sm/simboard/frontend:dev-manual \
   --push \
   .
 ```
@@ -391,7 +391,7 @@ cd frontend
 docker buildx build \
   --platform=linux/amd64,linux/arm64 \
   --build-arg VITE_API_BASE_URL=https://simboard-api.e3sm.org \
-  -t registry.nersc.gov/e3sm/simboard/frontend:manual \
+  -t registry.nersc.gov/e3sm/simboard/frontend:prod-manual \
   --push \
   .
 ```

--- a/docs/deploy/spin.md
+++ b/docs/deploy/spin.md
@@ -227,7 +227,7 @@ Prerequisites for this section:
      python -m app.scripts.users.provision_service_account \
        --service-name nersc-archive-ingestor \
        --base-url http://backend:8000 \
-       --admin-email admin@simboard.org \
+       --admin-email admin@simboard-dev.e3sm.org \
        --expires-in-days 365
      ```
 

--- a/docs/deploy/spin.md
+++ b/docs/deploy/spin.md
@@ -227,7 +227,7 @@ Prerequisites for this section:
      python -m app.scripts.users.provision_service_account \
        --service-name nersc-archive-ingestor \
        --base-url http://backend:8000 \
-       --admin-email admin@simboard-dev.e3sm.org \
+       --admin-email <admin-email-from-step-1> \
        --expires-in-days 365
      ```
 


### PR DESCRIPTION
## Summary
- refactor archive ingestion around typed parsed-simulation records and canonical config snapshots
- surface HPC provenance and canonical run-config deltas through the backend and browse UI
- accept common Perlmutter aliases during ingestion machine lookup and normalize machine names to lowercase canonical identifiers
- migrate backend URL-level domain configuration to `DOMAIN_URL` while keeping a derived bare `settings.domain` hostname for existing consumers

## What changed
- ingestion pipeline
  - replaced ad hoc parser metadata dictionaries with a typed `ParsedSimulation` dataclass
  - refactored `ingest_archive()` and related helpers around normalized drafts and validation boundaries
  - switched execution identity wording and handling to timing-file LIDs instead of archive directory names
  - added canonical config snapshot comparison logic to compute `run_config_deltas`
  - preserved and surfaced `hpc_username` provenance through ingestion results and persisted simulations
- machine resolution and storage
  - added shared machine-name normalization helpers for alias-aware lookup
  - updated ingestion API entrypoints and ingest internals to reuse the shared resolver
  - normalized machine creation to lowercase storage
  - added an Alembic migration that lowercases existing machine names, blocks pre-existing case-colliding rows, drops the old case-sensitive unique index, and creates `uq_machines_name_lower` on `lower(name)`
- backend configuration
  - renamed the backend URL-level domain setting to `DOMAIN_URL`
  - exposed `settings.domain_url` as the canonical configured URL
  - kept `settings.domain` as a derived bare hostname with scheme, `www.`, port, and path removed for existing email/service-account code
  - updated backend example env files, CI/config references, deployment docs, and provisioning comments to use `DOMAIN_URL`
- frontend browse experience
  - added `hpcUsername` and user-preview fields to simulation types
  - added HPC Username filtering in the browse filters panel
  - improved Created By filters/chips to display user emails when available

## Alias and machine-name behavior
- accepted Perlmutter aliases:
  - `pm`
  - `pm-cpu`
  - `pm-gpu`
- machine names are now treated as lowercase canonical identifiers
- mixed-case lookup inputs still resolve because ingestion canonicalizes inputs before querying
- case-only duplicate machine rows are rejected at the database layer

## Testing
- `uv run pytest tests/features/machine/test_utils.py tests/features/machine/test_api.py`
- `uv run pytest tests/features/ingestion/test_api.py -k "perlmutter_aliases or machine_not_found or returns_409_on_conflict or returns_summary"`
- `uv run ruff check app/features/machine/models.py app/features/machine/utils.py app/features/machine/api.py app/features/ingestion/api.py tests/features/machine/test_utils.py tests/features/machine/test_api.py tests/features/ingestion/test_api.py migrations/versions/20260319_000000_normalize_machine_names_lowercase.py`

## Notes
- repo-root `DOMAIN` usage for Traefik in `docker-compose.yml` is unchanged; the rename in this PR is backend-settings specific
- the machine-name migration intentionally fails if case-insensitive duplicates already exist; it does not auto-merge rows or rewrite foreign keys
