### PR TITLE
Add initial repo-local Codex skills

### DIFF
--- a/.agents/skills/backend-engineer/SKILL.md
+++ b/.agents/skills/backend-engineer/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: backend-engineer
+description: Implement SimBoard backend APIs, schemas, models, ingestion logic, and service behavior in the existing FastAPI, SQLAlchemy, Alembic, and uv-based backend.
+---
+
+# Backend Engineer
+
+## Purpose
+
+Implement or modify SimBoard backend behavior with minimal, maintainable changes that fit the current FastAPI and SQLAlchemy architecture.
+
+## When To Use
+
+- Adding or changing REST endpoints
+- Updating Pydantic schemas, feature logic, or auth/token behavior
+- Modifying ORM models or ingestion/parsing logic
+- Creating database migrations or changing persistence behavior
+
+## Inputs Expected
+
+- The requested backend behavior
+- Affected feature area such as simulation, machine, ingestion, or user
+- Expected request/response shape
+- Auth/authorization rules
+- Database or migration impact
+
+## Outputs Required
+
+- Backend code changes in `backend/app/**` and migrations if needed
+- Updated tests or identified test gaps
+- Registration updates when new routers or models are introduced
+- Validation notes for commands that were run
+
+## Repo-Specific Conventions
+
+- Keep domain code inside `backend/app/features/<feature>/`.
+- Put shared helpers in `backend/app/common/` or `backend/app/core/` only when they are truly cross-feature.
+- Register top-level routers in `backend/app/main.py`.
+- If a new model module must be imported for metadata discovery, update `backend/app/models/__init__.py`.
+- Request models should normally inherit from `CamelInBaseModel`; response models should normally inherit from `CamelOutBaseModel`.
+- Use the existing sync SQLAlchemy session pattern with `Session` and `transaction(db)` unless the touched code already uses the async path.
+- Match existing FastAPI dependency injection patterns such as `Depends(get_database_session)` and `Depends(current_active_user)`.
+- Respect current role checks in `app.features.user.models.UserRole` and related auth helpers.
+- Use Alembic through the repo workflow: `make backend-migrate m='message'` and `make backend-upgrade`.
+- Use `uv` and repo make targets, not `pip` or ad hoc virtualenv commands.
+
+## Constraints / Anti-Patterns
+
+- Do not return snake_case payloads to the frontend unless the existing endpoint already does so intentionally.
+- Do not scatter raw `db.commit()` calls when the existing transactional helper is the better fit.
+- Do not add async endpoints, background workers, or new dependencies without a concrete need.
+- Do not change env loading, OAuth flow, or token semantics casually; these changes need tests and usually docs.
+- Do not bypass feature boundaries by placing feature logic in `main.py` or unrelated modules.
+- Do not ship schema or model changes without considering migrations, seed scripts, and API compatibility.
+
+## Example Task
+
+Add a backend endpoint that exposes a filtered list of simulations for the browse UI by updating `backend/app/features/simulation/api.py`, any needed schemas in `backend/app/features/simulation/schemas.py`, relevant model/query logic, and tests under `backend/tests/features/simulation/`.

--- a/.agents/skills/docs-writer/SKILL.md
+++ b/.agents/skills/docs-writer/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: docs-writer
+description: Write or improve SimBoard documentation for developers and users, keeping it accurate to the repo's current structure, workflows, and anti-drift documentation rules.
+---
+
+# Docs Writer
+
+## Purpose
+
+Write durable human-facing documentation for SimBoard. Cover onboarding, architecture, workflows, features, deployment notes, and developer usage guidance based on what the repository actually does today.
+
+## When To Use
+
+- Updating READMEs after behavior or workflow changes
+- Writing feature docs, onboarding steps, architecture notes, or usage documentation
+- Clarifying developer setup, validation commands, or deployment/development workflows
+- Cleaning up stale docs so they match the codebase
+
+## Inputs Expected
+
+- The audience and documentation goal
+- The behavior, workflow, or architecture being documented
+- Source files or commands that should be treated as authoritative
+- Scope constraints such as README-only, docs-only, or feature-local docs
+
+## Outputs Required
+
+- Updated Markdown in the right repo location
+- Accurate commands, paths, and file references
+- Clear note of any behavior that could not be verified directly
+- Minimal duplication across docs
+
+## Repo-Specific Conventions
+
+- Use the repo's existing documentation locations first: `README.md`, `frontend/README.md`, `backend/README.md`, and `docs/**`.
+- Follow the anti-drift policy in `AGENTS.md`: do not hardcode dependency versions, counts, or volatile config when the authoritative source is a manifest, lockfile, workflow file, or source default.
+- When setup or development steps are involved, prefer the repo make targets from `Makefile`.
+- Document backend tooling as `uv`-based and frontend tooling as `pnpm`-based.
+- When environment setup matters, reference `.envs/example/*` as templates and `.envs/local/*` as developer-local values.
+- Keep pre-commit guidance rooted at the repository root, matching the current repo instructions.
+- If a change affects user-facing flows, keep terminology consistent with SimBoard's domain: simulations, cases, machines, ingestion, compare, upload, and E3SM metadata.
+
+## Constraints / Anti-Patterns
+
+- Do not turn planning notes into durable docs; that belongs to `feature-planner`.
+- Do not document unimplemented behavior or aspirational architecture as if it already exists.
+- Do not duplicate the same long workflow in multiple files unless one file is serving as navigation.
+- Do not invent operational steps that are not backed by the repository.
+- Do not hardcode versions or other volatile values when a referenced source is the stable answer.
+
+## Example Task
+
+Update `README.md` and `docs/README.md` after a new local development workflow is added, using existing make targets and environment file locations rather than embedding fragile, version-specific setup details.

--- a/.agents/skills/feature-planner/SKILL.md
+++ b/.agents/skills/feature-planner/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: feature-planner
+description: Turn SimBoard product or engineering requests into concrete implementation plans scoped to the repo's backend, frontend, testing, docs, and workflow constraints.
+---
+
+# Feature Planner
+
+## Purpose
+
+Convert a request into an executable SimBoard implementation plan. Produce scope, sequencing, and risk analysis, not durable human documentation and not production code.
+
+## When To Use
+
+- A request is ambiguous or spans multiple parts of the monorepo
+- The user wants a concrete execution plan before implementation
+- A feature may affect backend APIs, frontend routes, auth, migrations, or docs
+- The work needs decomposition into PR-sized steps
+
+## Inputs Expected
+
+- The feature or problem statement
+- Target users or workflows
+- Any constraints on scope, timing, dependencies, or rollout
+- Known affected areas in backend, frontend, docs, or deployment
+
+## Outputs Required
+
+- A scoped implementation plan with phases or milestones
+- Expected files/directories or modules to touch
+- Backend, frontend, test, and docs impacts
+- Risks, open questions, and assumptions
+- Recommended validation commands and rollout order
+
+## Repo-Specific Conventions
+
+- Plan in terms of the existing monorepo split: `backend/`, `frontend/`, and `docs/`.
+- Respect the frontend feature-boundary rules and route composition model.
+- Respect the backend feature modules under `backend/app/features/*`.
+- Call out router registration, schema/model changes, and Alembic migrations when backend contracts or persistence change.
+- If a change affects developer setup or behavior, include README/docs updates in the plan.
+- Prefer repo commands and make targets in the execution plan rather than ad hoc shell steps.
+- Treat pre-commit, backend tests, frontend linting, and type-checking as part of the definition of done.
+
+## Constraints / Anti-Patterns
+
+- Do not drift into writing durable docs for humans; that belongs to `docs-writer`.
+- Do not drift into implementation details that assume code already exists when it does not.
+- Do not invent new architecture layers or service splits without strong evidence from the repo.
+- Do not ignore auth, role, migration, or environment impacts for features that touch upload, tokens, or ingestion.
+- Do not produce a generic checklist with no file/module specificity.
+
+## Example Task
+
+Plan a feature that lets users save and revisit comparison sets by outlining required backend persistence changes, frontend route/state updates, test coverage, migration needs, and README/docs follow-up before anyone writes code.

--- a/.agents/skills/frontend-engineer/SKILL.md
+++ b/.agents/skills/frontend-engineer/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: frontend-engineer
+description: Build or modify SimBoard frontend UI in the existing React, TypeScript, Vite, Tailwind, and shadcn codebase while respecting feature boundaries and existing data-flow patterns.
+---
+
+# Frontend Engineer
+
+## Purpose
+
+Implement SimBoard frontend behavior and UI in code. Work inside the existing React 19 + TypeScript + Vite app without introducing new architectural patterns unless the repo already uses them in the touched area.
+
+## When To Use
+
+- Adding or modifying pages, routes, components, hooks, or API modules in `frontend/src`
+- Wiring new backend data into browse, compare, upload, docs, or simulation detail flows
+- Improving responsive behavior, loading/error states, and interaction details in existing screens
+- Refactoring frontend code to better fit the repo's current architecture
+
+## Inputs Expected
+
+- The requested user-facing behavior
+- Target routes, screens, or feature directories
+- Relevant backend contract or endpoint details
+- Acceptance criteria, visual constraints, and any auth requirements
+
+## Outputs Required
+
+- Minimal code changes in `frontend/src/**`
+- Any required backend follow-up called out explicitly
+- Validation notes for lint/type-check or other commands that were run
+- Brief explanation of the chosen implementation approach when multiple options exist
+
+## Repo-Specific Conventions
+
+- Use TypeScript and the `@/` path alias defined in `frontend/tsconfig.json`.
+- Follow the frontend boundary rules in `frontend/eslint.config.js`.
+- Put route definitions in feature route files such as `frontend/src/features/*/routes.tsx`, and compose them in `frontend/src/routes/routes.tsx`.
+- Keep API calls in `frontend/src/api/api.ts` or feature-local modules like `frontend/src/features/simulations/api/api.ts`.
+- Keep feature-specific stateful logic in `frontend/src/features/*/hooks/`.
+- Reuse `frontend/src/components/shared/*` for UI that is genuinely cross-feature. Do not move feature-specific UI there just to avoid imports.
+- Treat `frontend/src/components/ui/**` as low-level primitives. Extend or reuse them rather than inventing parallel button/input/modal stacks.
+- Inspect the nearby feature before choosing data-fetching style. The repo includes `@tanstack/react-query`, but several current hooks still use `useEffect` plus local state. Match the touched area instead of forcing a new abstraction.
+- Preserve existing auth and app-shell wiring in `frontend/src/App.tsx`, `frontend/src/auth/**`, and `frontend/src/components/layout/**`.
+- Prefer `make frontend-lint` and `pnpm --dir frontend run type-check` after TypeScript changes.
+
+## Constraints / Anti-Patterns
+
+- Do not add direct cross-feature imports.
+- Do not put API calls directly into presentational components when the feature already has an API/hook layer.
+- Do not add a new component library, state library, or frontend test framework as part of routine work.
+- Do not rewrite generated-style UI primitives in `components/ui` unless the task specifically requires it.
+- Do not break local HTTPS assumptions in `frontend/vite.config.ts` or auth/logout behavior in `frontend/src/api/api.ts`.
+- Do not leave placeholder UI in production-facing routes unless the task is explicitly for scaffolding.
+
+## Example Task
+
+Implement a richer `/docs` experience by replacing the placeholder `frontend/src/features/docs/DocsPage.tsx`, keeping the route in `frontend/src/features/docs/routes.tsx`, and reusing shared layout and existing UI primitives rather than creating a separate mini-app.

--- a/.agents/skills/reviewer/SKILL.md
+++ b/.agents/skills/reviewer/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: reviewer
+description: Review SimBoard changes for correctness, maintainability, architecture fit, regression risk, and adherence to the repo's FastAPI, SQLAlchemy, React, and feature-boundary conventions.
+---
+
+# Reviewer
+
+## Purpose
+
+Review proposed or completed SimBoard changes with a code-review mindset. Optimize for correctness, architecture fit, maintainability, and regression risk before style nits.
+
+## When To Use
+
+- Reviewing a branch, diff, or PR before merge
+- Auditing whether a change fits SimBoard's backend/frontend architecture
+- Checking whether a change needs tests, docs, migrations, or follow-up cleanup
+- Verifying that a fix did not break auth, data contracts, or feature boundaries
+
+## Inputs Expected
+
+- The user intent or ticket summary
+- The changed files or git diff
+- Any commands already run and their results
+- Known risk areas such as auth, ingestion, migrations, or compare/browse workflows
+
+## Outputs Required
+
+- Prioritized findings, highest severity first
+- File references for each finding
+- Clear explanation of the risk or likely regression
+- Missing tests, docs, or validation gaps
+- If there are no findings, say so explicitly and note residual risk
+
+## Repo-Specific Conventions
+
+- Treat `AGENTS.md` in the repo root as authoritative for repo behavior.
+- Backend work should stay inside `backend/app/features/*`, `backend/app/common/*`, `backend/app/core/*`, and related tests under `backend/tests/*`.
+- New backend routers belong in feature modules and must be registered in `backend/app/main.py`.
+- Backend request/response schemas use `CamelInBaseModel` and `CamelOutBaseModel`; review API contract drift carefully because the frontend expects camelCase payloads.
+- Backend writes commonly use the sync SQLAlchemy session plus `transaction(db)` from `backend/app/core/database.py`.
+- Frontend work must respect `frontend/eslint.config.js` architectural boundaries.
+- Frontend features may use shared/UI/lib/types/api layers, but features must not import other features directly.
+- Frontend API code belongs in `frontend/src/features/*/api/`; hooks belong in `frontend/src/features/*/hooks/`; reusable cross-feature UI belongs in `frontend/src/components/shared/`.
+- Ignore stylistic churn inside generated/vendor-style UI primitives under `frontend/src/components/ui/**` unless the change breaks behavior.
+- Validation commands should match the repo workflow: `make backend-test`, `make frontend-lint`, `pnpm --dir frontend run type-check`, and `make pre-commit-run` from the repo root.
+
+## Constraints / Anti-Patterns
+
+- Do not lead with summaries. Findings come first.
+- Do not suggest refactors that are larger than the problem unless the current design is the bug.
+- Do not ignore missing migrations, missing router registration, or missing model imports in `backend/app/models/__init__.py`.
+- Do not ignore frontend boundary violations just because the code "works".
+- Do not accept new dependencies, new testing frameworks, or new architecture layers without a concrete repo-specific reason.
+- Do not review only happy paths. Check failure handling, auth/role checks, empty states, and API shape compatibility.
+
+## Example Task
+
+Review a branch that adds a new simulation upload flow touching `frontend/src/features/upload/**`, `backend/app/features/ingestion/**`, and `backend/tests/features/ingestion/**`. Identify correctness issues, boundary violations, missing tests, and documentation gaps before the PR is opened.

--- a/.agents/skills/test-engineer/SKILL.md
+++ b/.agents/skills/test-engineer/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: test-engineer
+description: Add or improve SimBoard automated tests and validation coverage, prioritizing deterministic backend pytest coverage and practical regression reduction over speculative tooling.
+---
+
+# Test Engineer
+
+## Purpose
+
+Reduce regression risk in SimBoard by adding or tightening automated checks that match the repo's current testing setup.
+
+## When To Use
+
+- After backend behavior changes, bug fixes, or schema/API contract changes
+- When parser, ingestion, auth, or role logic is modified
+- When a review identifies missing regression coverage
+- When a change needs validation strategy, even if only part of it can be automated today
+
+## Inputs Expected
+
+- The behavior being changed or protected
+- The files touched and likely failure modes
+- Existing tests in the same feature area
+- The intended validation scope and any constraints on adding new tooling
+
+## Outputs Required
+
+- Deterministic automated tests where the repo already supports them
+- Clear note of what was validated and what remains uncovered
+- Minimal test-only helpers or fixtures when necessary
+- Commands run and their outcomes
+
+## Repo-Specific Conventions
+
+- Backend tests live under `backend/tests/**`, generally mirroring feature areas such as `backend/tests/features/simulation/` or `backend/tests/features/ingestion/`.
+- Reuse fixtures from `backend/tests/conftest.py` before inventing new database setup.
+- Prefer focused API, schema, parser, or model tests over broad end-to-end flows.
+- Backend tests should work with the existing PostgreSQL + Alembic test setup and dependency overrides.
+- Frontend currently has linting and type-checking, but no established unit/e2e test harness in the repo. For frontend-only work, use `make frontend-lint` and `pnpm --dir frontend run type-check` as the baseline unless the user explicitly wants new testing infrastructure.
+- If frontend behavior depends on backend contracts, prefer strengthening backend tests around the contract rather than introducing a brand-new frontend test stack.
+- Use repo commands such as `make backend-test`, `make frontend-lint`, and `make pre-commit-run` from the repository root.
+
+## Constraints / Anti-Patterns
+
+- Do not add flaky tests that depend on wall-clock timing, external networks, GitHub OAuth, or mutable remote state.
+- Do not introduce Vitest, Playwright, Cypress, or similar tools as part of routine work unless the user asks or the repo adds them.
+- Do not overuse broad integration tests when a targeted parser/API/schema test would cover the behavior more reliably.
+- Do not leave important backend behavior validated only by manual steps if pytest coverage is practical.
+- Do not duplicate fixture logic that already exists in `backend/tests/conftest.py`.
+
+## Example Task
+
+Add regression coverage for a change in token revocation by updating `backend/tests/features/user/api/test_token.py`, reusing existing auth fixtures, and running `make backend-test` to verify the API behavior remains stable.

--- a/.agents/skills/ui-ux-designer/SKILL.md
+++ b/.agents/skills/ui-ux-designer/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: ui-ux-designer
+description: Improve SimBoard interaction design, workflow clarity, information architecture, usability, accessibility, and screen-level UX without taking over implementation responsibilities from frontend engineering.
+---
+
+# UI/UX Designer
+
+## Purpose
+
+Define or improve the user experience of SimBoard screens and workflows. Focus on how researchers browse, compare, upload, and understand simulation metadata. This skill should not own production implementation.
+
+## When To Use
+
+- The user wants UX recommendations before or alongside implementation
+- A screen or workflow feels confusing, dense, or error-prone
+- The team needs better empty/loading/error states, information hierarchy, or accessibility guidance
+- The request is about interaction design, screen structure, copy, or workflow clarity rather than code
+
+## Inputs Expected
+
+- The target workflow or screen
+- Current pain points, user goals, and constraints
+- Any relevant screenshots, routes, or component references
+- Known data/actions available to the UI
+
+## Outputs Required
+
+- A concrete UX recommendation or screen-level proposal
+- Suggested interaction flow, hierarchy, and state handling
+- Accessibility and responsive considerations
+- Component-level guidance tied to the current UI system
+- Tiny illustrative snippets only if they materially clarify the recommendation
+
+## Repo-Specific Conventions
+
+- Design for the actual SimBoard flows surfaced by the current nav: Home, Browse, Compare, All Simulations, Upload, and Docs.
+- Preserve the compare-selection mental model already present in the app, including the current small selection cap in the browse flow.
+- Reuse the existing Tailwind + shadcn/Radix component vocabulary rather than inventing a separate design system.
+- Assume the frontend is route-based and feature-based, so designs should map cleanly to `frontend/src/features/*`.
+- Keep auth entry points and navigation patterns coherent with `frontend/src/components/layout/NavBar.tsx` and related mobile navigation.
+- The current docs page is largely empty; if improving docs UX, propose practical information architecture rather than assuming a mature documentation surface already exists.
+
+## Constraints / Anti-Patterns
+
+- Do not implement the full feature in code; that belongs to `frontend-engineer`.
+- Do not prescribe UI patterns that require a new design system, major rebrand, or new dependency unless the request explicitly asks for that level of change.
+- Do not optimize only for visual polish. Prioritize workflow clarity, discoverability, feedback states, accessibility, and mobile behavior.
+- Do not ignore keyboard access, labels, focus order, or error messaging for data-heavy forms and filters.
+- Do not produce vague advice like "make it cleaner" without tying it to concrete interface changes.
+
+## Example Task
+
+Redesign the browse-to-compare workflow so users understand how many simulations they can select, what will happen when they compare, and how to recover from over-selection, while keeping the output at the level of interaction guidance rather than production code.


### PR DESCRIPTION
## Description

- Add five repo-local Codex skills under `.agents/skills/` for backend, frontend, testing, review, and docs work.
- Align each skill to SimBoard's current FastAPI, SQLAlchemy, React, Vite, Tailwind, and repo workflow conventions.
- Keep the skill set lean by limiting it to the core reusable roles.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [ ] Tests added or updated (if needed)
- [ ] All tests pass (locally and CI/CD)
- [x] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)

- None.