### PR TITLE
Fix browse detail overflow and interaction behavior

### DIFF
--- a/frontend/src/components/ui/multi-select.tsx
+++ b/frontend/src/components/ui/multi-select.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { TableCellText } from "@/components/ui/table-cell-text";
 import {
 	Popover,
 	PopoverContent,
@@ -921,11 +922,12 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
 																})}
 															/>
 														)}
-														<span
-															className="min-w-0 flex-1 truncate"
-															title={option.label}>
-															{option.label}
-														</span>
+														<TableCellText
+															value={option.label}
+															lines={1}
+															fullValueMode="tooltip"
+															className="min-w-0 flex-1"
+														/>
 														<div
 															role="button"
 															tabIndex={0}
@@ -1029,19 +1031,19 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
 							)}
 						</Button>
 					</PopoverTrigger>
-					<PopoverContent
-						id={listboxId}
-						role="listbox"
-						aria-multiselectable={maxSelected === 1 ? "false" : "true"}
-						aria-label="Available options"
-						className={cn(
-							"w-auto p-0",
-							getPopoverAnimationClass(),
-							screenSize === "mobile" && "w-[85vw] max-w-[280px]",
-							screenSize === "tablet" && "w-[70vw] max-w-md",
-							screenSize === "desktop" && "min-w-[300px]",
-							popoverClassName
-						)}
+						<PopoverContent
+							id={listboxId}
+							role="listbox"
+							aria-multiselectable={maxSelected === 1 ? "false" : "true"}
+							aria-label="Available options"
+							className={cn(
+								"w-[var(--radix-popover-trigger-width)] min-w-[var(--radix-popover-trigger-width)] p-0",
+								getPopoverAnimationClass(),
+								screenSize === "mobile" && "w-[85vw] max-w-[280px]",
+								screenSize === "tablet" && "w-[70vw] max-w-md",
+								screenSize === "desktop" && "max-w-full",
+								popoverClassName
+							)}
 						style={{
 							animationDuration: `${animationConfig?.duration || animation}s`,
 							animationDelay: `${animationConfig?.delay || 0}s`,
@@ -1130,7 +1132,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
 															isSelected ? ", selected" : ", not selected"
 														}${option.disabled ? ", disabled" : ""}`}
 														className={cn(
-															"cursor-pointer",
+															"min-w-0 max-w-full cursor-pointer",
 															option.disabled && "opacity-50 cursor-not-allowed"
 														)}
 														disabled={option.disabled}>
@@ -1150,9 +1152,12 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
 																aria-hidden="true"
 															/>
 														)}
-														<span className="min-w-0 flex-1 truncate" title={option.label}>
-															{option.label}
-														</span>
+														<TableCellText
+															value={option.label}
+															lines={1}
+															fullValueMode="tooltip"
+															className="min-w-0 flex-1"
+														/>
 													</CommandItem>
 												);
 											})}
@@ -1173,7 +1178,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
 														isSelected ? ", selected" : ", not selected"
 													}${option.disabled ? ", disabled" : ""}`}
 													className={cn(
-														"cursor-pointer",
+														"min-w-0 max-w-full cursor-pointer",
 														option.disabled && "opacity-50 cursor-not-allowed"
 													)}
 													disabled={option.disabled}>
@@ -1193,9 +1198,12 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
 															aria-hidden="true"
 														/>
 													)}
-													<span className="min-w-0 flex-1 truncate" title={option.label}>
-														{option.label}
-													</span>
+													<TableCellText
+														value={option.label}
+														lines={1}
+														fullValueMode="tooltip"
+														className="min-w-0 flex-1"
+													/>
 												</CommandItem>
 											);
 										})}

--- a/frontend/src/features/browse/BrowsePage.tsx
+++ b/frontend/src/features/browse/BrowsePage.tsx
@@ -18,6 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { TableCellText } from '@/components/ui/table-cell-text';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { BrowseFiltersSidePanel } from '@/features/browse/components/BrowseFiltersSidePanel';
 import { SimulationResultCards } from '@/features/browse/components/SimulationResults/SimulationResultsCards';
@@ -652,15 +653,18 @@ export const BrowsePage = ({
                   </div>
                   <div className="flex min-w-0 flex-wrap gap-2">
                   {selectedCaseName && (
-                    <span className="inline-flex max-w-full items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700">
-                      <span className="mr-2 text-xs font-medium text-slate-500">case:</span>
-                      <span className="mr-2 truncate font-medium text-slate-700">
-                        {selectedCaseName}
-                      </span>
+                    <span className="inline-flex min-w-0 max-w-[min(100%,40rem)] items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700">
+                      <span className="mr-2 shrink-0 text-xs font-medium text-slate-500">case:</span>
+                      <TableCellText
+                        value={selectedCaseName}
+                        lines={1}
+                        fullValueMode="tooltip"
+                        className="mr-2 min-w-0 flex-1 font-medium text-slate-700"
+                      />
                       <button
                         type="button"
                         aria-label="Remove case filter"
-                        className="ml-1 rounded-sm text-slate-400 transition-colors hover:text-slate-700 focus:outline-none"
+                        className="ml-1 shrink-0 rounded-sm text-slate-400 transition-colors hover:text-slate-700 focus:outline-none"
                         onClick={handleClearCaseNameFilter}
                       >
                         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
@@ -688,18 +692,18 @@ export const BrowsePage = ({
                         return (
                           <span
                             key={`${key}-${value}-${idx}`}
-                            className="inline-flex max-w-full items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
+                            className="inline-flex min-w-0 max-w-full items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
                           >
-                            <span className="mr-2 text-xs font-medium text-slate-500">
+                            <span className="mr-2 shrink-0 text-xs font-medium text-slate-500">
                               {String(key).replace(/Id$/, '')}:
                             </span>
-                            <span className="mr-2 truncate font-medium text-slate-700">
+                            <span className="mr-2 min-w-0 flex-1 truncate font-medium text-slate-700">
                               {display}
                             </span>
                             <button
                               type="button"
                               aria-label={`Remove ${String(key)} filter`}
-                              className="ml-1 rounded-sm text-slate-400 transition-colors hover:text-slate-700 focus:outline-none"
+                              className="ml-1 shrink-0 rounded-sm text-slate-400 transition-colors hover:text-slate-700 focus:outline-none"
                               onClick={() => {
                                 setAppliedFilters((prev) => ({
                                   ...prev,
@@ -729,18 +733,18 @@ export const BrowsePage = ({
                       return (
                         <span
                           key={`${String(key)}-${values}`}
-                          className="inline-flex max-w-full items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
+                          className="inline-flex min-w-0 max-w-full items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
                         >
-                          <span className="mr-2 text-xs font-medium text-slate-500">
+                          <span className="mr-2 shrink-0 text-xs font-medium text-slate-500">
                             {String(key).replace(/Id$/, '')}:
                           </span>
-                          <span className="mr-2 truncate font-medium text-slate-700">
+                          <span className="mr-2 min-w-0 flex-1 truncate font-medium text-slate-700">
                             {display}
                           </span>
                           <button
                             type="button"
                             aria-label={`Remove ${String(key)} filter`}
-                            className="ml-1 rounded-sm text-slate-400 transition-colors hover:text-slate-700 focus:outline-none"
+                            className="ml-1 shrink-0 rounded-sm text-slate-400 transition-colors hover:text-slate-700 focus:outline-none"
                             onClick={() => {
                               setAppliedFilters((prev) => ({ ...prev, [key]: '' }));
                             }}

--- a/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
@@ -11,7 +11,6 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import {
-  shouldSuppressBrowseSelection,
   suppressNextBrowseInteraction,
 } from '@/features/browse/components/SimulationResults/selectionGuard';
 import type { SimulationOut } from '@/types/index';
@@ -34,10 +33,6 @@ export const SimulationBrowseDetailsDialog = ({
   const [isOpen, setIsOpen] = useState(false);
   const handleTriggerInteraction = (event: React.SyntheticEvent) => {
     event.stopPropagation();
-
-    if (shouldSuppressBrowseSelection()) {
-      event.preventDefault();
-    }
   };
   const stopDrawerPropagation = (event: React.SyntheticEvent) => {
     event.stopPropagation();

--- a/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
@@ -1,0 +1,412 @@
+import { useState } from 'react';
+
+import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge';
+import { Button, type ButtonProps } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  shouldSuppressBrowseSelection,
+  suppressNextBrowseInteraction,
+} from '@/features/browse/components/SimulationResults/selectionGuard';
+import type { SimulationOut } from '@/types/index';
+
+interface SimulationBrowseDetailsDialogProps {
+  simulation: SimulationOut;
+  triggerLabel?: string;
+  triggerVariant?: ButtonProps['variant'];
+  triggerSize?: ButtonProps['size'];
+  triggerClassName?: string;
+}
+
+export const SimulationBrowseDetailsDialog = ({
+  simulation,
+  triggerLabel = 'More Details',
+  triggerVariant = 'outline',
+  triggerSize = 'default',
+  triggerClassName,
+}: SimulationBrowseDetailsDialogProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleTriggerInteraction = (event: React.SyntheticEvent) => {
+    event.stopPropagation();
+
+    if (shouldSuppressBrowseSelection()) {
+      event.preventDefault();
+    }
+  };
+  const stopDrawerPropagation = (event: React.SyntheticEvent) => {
+    event.stopPropagation();
+  };
+
+  const startStr = simulation.simulationStartDate
+    ? new Date(simulation.simulationStartDate).toISOString().slice(0, 10)
+    : 'N/A';
+  const endStr = simulation.simulationEndDate
+    ? new Date(simulation.simulationEndDate).toISOString().slice(0, 10)
+    : 'N/A';
+  const runStartStr = simulation.runStartDate
+    ? new Date(simulation.runStartDate).toISOString().slice(0, 10)
+    : 'N/A';
+  const runEndStr = simulation.runEndDate
+    ? new Date(simulation.runEndDate).toISOString().slice(0, 10)
+    : 'N/A';
+  const createdAtStr = new Date(simulation.createdAt).toISOString().slice(0, 10);
+  const updatedAtStr = new Date(simulation.updatedAt).toISOString().slice(0, 10);
+  const diagnosticLinks = simulation.groupedLinks.diagnostic ?? [];
+  const performanceLinks = simulation.groupedLinks.performance ?? [];
+  const runScripts = simulation.groupedArtifacts.runScript ?? [];
+  const archivePaths = simulation.groupedArtifacts.archive ?? [];
+  const postprocessingScripts =
+    simulation.groupedArtifacts.postProcessingScript ??
+    simulation.groupedArtifacts.postprocessingScript ??
+    [];
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant={triggerVariant}
+          size={triggerSize}
+          className={triggerClassName}
+          data-prevent-selection="true"
+          onPointerDown={handleTriggerInteraction}
+          onMouseDown={handleTriggerInteraction}
+          onClick={handleTriggerInteraction}
+        >
+          {triggerLabel}
+        </Button>
+      </DialogTrigger>
+      <DialogContent
+        className="left-auto right-0 top-0 h-[100dvh] w-full max-w-[min(92vw,42rem)] translate-x-0 translate-y-0 gap-0 overflow-hidden rounded-none border-l border-slate-200 p-0 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-2xl sm:rounded-none"
+        onPointerDownOutside={() => {
+          suppressNextBrowseInteraction();
+        }}
+        onPointerDownCapture={stopDrawerPropagation}
+        onClickCapture={stopDrawerPropagation}
+      >
+        <div className="flex h-full min-h-0 flex-col">
+          <DialogHeader className="border-b border-slate-200 px-6 py-5 text-left">
+            <DialogTitle className="text-xl text-slate-950">{simulation.executionId}</DialogTitle>
+            <DialogDescription className="mt-2 text-sm leading-6 text-slate-600">
+              Additional browse details for <span className="font-medium">{simulation.caseName}</span>.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-6 py-5">
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
+                Overview
+              </h3>
+              <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:grid-cols-2">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    Case
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">{simulation.caseName}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    Status
+                  </p>
+                  <div className="mt-1">
+                    <SimulationStatusBadge status={simulation.status} />
+                  </div>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    Machine
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">{simulation.machine.name}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    Compiler
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">{simulation.compiler ?? 'N/A'}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    Grid
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">{simulation.gridName}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    Canonical
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">
+                    {simulation.isCanonical ? 'Yes' : 'No'}
+                    {!simulation.isCanonical && simulation.changeCount > 0
+                      ? ` (${simulation.changeCount} changes)`
+                      : ''}
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
+                Runtime And Provenance
+              </h3>
+              <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    Model Run Dates
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">
+                    {startStr} to {endStr}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    Runtime Window
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">
+                    {runStartStr} to {runEndStr}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    Created By
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">
+                    {simulation.createdByUser?.email ?? simulation.createdBy ?? 'N/A'}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    HPC Username
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">{simulation.hpcUsername ?? 'N/A'}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    Catalog Dates
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">
+                    Created {createdAtStr}, updated {updatedAtStr}
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            {(simulation.gitRepositoryUrl ||
+              simulation.gitBranch ||
+              simulation.gitTag ||
+              simulation.gitCommitHash) && (
+              <section className="space-y-3">
+                <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
+                  Version Control
+                </h3>
+                <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4">
+                  {simulation.gitRepositoryUrl && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Repository
+                      </p>
+                      <p className="mt-1 break-all text-sm text-slate-700">
+                        {simulation.gitRepositoryUrl}
+                      </p>
+                    </div>
+                  )}
+                  {simulation.gitBranch && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Branch
+                      </p>
+                      <p className="mt-1 break-all font-mono text-xs text-slate-700">
+                        {simulation.gitBranch}
+                      </p>
+                    </div>
+                  )}
+                  {simulation.gitTag && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Tag
+                      </p>
+                      <p className="mt-1 text-sm text-slate-700">{simulation.gitTag}</p>
+                    </div>
+                  )}
+                  {simulation.gitCommitHash && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Commit
+                      </p>
+                      <p className="mt-1 break-all font-mono text-xs text-slate-700">
+                        {simulation.gitCommitHash}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </section>
+            )}
+
+            {(simulation.description ||
+              simulation.keyFeatures ||
+              simulation.knownIssues ||
+              simulation.notesMarkdown) && (
+              <section className="space-y-3">
+                <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
+                  Notes And Context
+                </h3>
+                <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
+                  {simulation.description && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Description
+                      </p>
+                      <p className="mt-1 text-sm leading-6 text-slate-700">
+                        {simulation.description}
+                      </p>
+                    </div>
+                  )}
+                  {simulation.keyFeatures && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Key Features
+                      </p>
+                      <p className="mt-1 text-sm leading-6 text-slate-700">
+                        {simulation.keyFeatures}
+                      </p>
+                    </div>
+                  )}
+                  {simulation.knownIssues && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Known Issues
+                      </p>
+                      <p className="mt-1 text-sm leading-6 text-slate-700">
+                        {simulation.knownIssues}
+                      </p>
+                    </div>
+                  )}
+                  {simulation.notesMarkdown && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Notes
+                      </p>
+                      <p className="mt-1 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+                        {simulation.notesMarkdown}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </section>
+            )}
+
+            {(diagnosticLinks.length > 0 || performanceLinks.length > 0) && (
+              <section className="space-y-3">
+                <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
+                  External Links
+                </h3>
+                <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
+                  {diagnosticLinks.length > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Diagnostics
+                      </p>
+                      <ul className="mt-2 space-y-2">
+                        {diagnosticLinks.map((link) => (
+                          <li key={link.id}>
+                            <a
+                              href={link.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-sm text-blue-700 underline"
+                            >
+                              {link.label}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {performanceLinks.length > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Performance
+                      </p>
+                      <ul className="mt-2 space-y-2">
+                        {performanceLinks.map((link) => (
+                          <li key={link.id}>
+                            <a
+                              href={link.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-sm text-blue-700 underline"
+                            >
+                              {link.label}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              </section>
+            )}
+
+            {(runScripts.length > 0 ||
+              archivePaths.length > 0 ||
+              postprocessingScripts.length > 0) && (
+              <section className="space-y-3">
+                <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
+                  Artifact Paths
+                </h3>
+                <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
+                  {runScripts.length > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Run Scripts
+                      </p>
+                      <ul className="mt-2 space-y-2 text-sm text-slate-700">
+                        {runScripts.map((item, index) => (
+                          <li key={index} className="break-all">
+                            {typeof item === 'string' ? item : (item.label ?? item.uri)}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {archivePaths.length > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Archive Paths
+                      </p>
+                      <ul className="mt-2 space-y-2 text-sm text-slate-700">
+                        {archivePaths.map((item, index) => (
+                          <li key={index} className="break-all">
+                            {typeof item === 'string' ? item : (item.label ?? item.uri)}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {postprocessingScripts.length > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Postprocessing Scripts
+                      </p>
+                      <ul className="mt-2 space-y-2 text-sm text-slate-700">
+                        {postprocessingScripts.map((item, index) => (
+                          <li key={index} className="break-all">
+                            {typeof item === 'string' ? item : (item.label ?? item.uri)}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              </section>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
@@ -8,7 +8,6 @@ import {
   Server,
   Tag,
 } from 'lucide-react';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge';
@@ -16,14 +15,9 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
+import { TableCellText } from '@/components/ui/table-cell-text';
+import { shouldSuppressBrowseSelection } from '@/features/browse/components/SimulationResults/selectionGuard';
+import { SimulationBrowseDetailsDialog } from '@/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog';
 import type { SimulationOut } from '@/types/index';
 
 interface SimulationResultCard {
@@ -33,6 +27,10 @@ interface SimulationResultCard {
   handleSelect: (sim: SimulationOut) => void;
 }
 
+const shouldIgnoreSelection = (target: EventTarget | null): boolean =>
+  target instanceof Element &&
+  Boolean(target.closest('button, a, input, [role="button"], [data-prevent-selection]'));
+
 export const SimulationResultCard = ({
   simulation,
   selected,
@@ -41,7 +39,6 @@ export const SimulationResultCard = ({
 }: SimulationResultCard) => {
   // -------------------- Router --------------------
   const navigate = useNavigate();
-  const [isDetailsOpen, setIsDetailsOpen] = useState(false);
 
   // -------------------- Derived Data --------------------
   const startStr = simulation.simulationStartDate
@@ -50,22 +47,6 @@ export const SimulationResultCard = ({
   const endStr = simulation.simulationEndDate
     ? new Date(simulation.simulationEndDate).toISOString().slice(0, 10)
     : 'N/A';
-  const runStartStr = simulation.runStartDate
-    ? new Date(simulation.runStartDate).toISOString().slice(0, 10)
-    : 'N/A';
-  const runEndStr = simulation.runEndDate
-    ? new Date(simulation.runEndDate).toISOString().slice(0, 10)
-    : 'N/A';
-  const createdAtStr = new Date(simulation.createdAt).toISOString().slice(0, 10);
-  const updatedAtStr = new Date(simulation.updatedAt).toISOString().slice(0, 10);
-  const diagnosticLinks = simulation.groupedLinks.diagnostic ?? [];
-  const performanceLinks = simulation.groupedLinks.performance ?? [];
-  const runScripts = simulation.groupedArtifacts.runScript ?? [];
-  const archivePaths = simulation.groupedArtifacts.archive ?? [];
-  const postprocessingScripts =
-    simulation.groupedArtifacts.postProcessingScript ??
-    simulation.groupedArtifacts.postprocessingScript ??
-    [];
 
   return (
     <Card
@@ -74,7 +55,11 @@ export const SimulationResultCard = ({
           ? 'border-slate-300 ring-1 ring-slate-200'
           : 'border-slate-200 hover:shadow-md'
       } ${isSelectionDisabled ? 'cursor-default' : 'cursor-pointer'}`}
-      onClick={() => {
+      onClick={(event) => {
+        if (shouldSuppressBrowseSelection() || shouldIgnoreSelection(event.target)) {
+          return;
+        }
+
         if (!isSelectionDisabled || selected) {
           handleSelect(simulation);
         }
@@ -96,8 +81,14 @@ export const SimulationResultCard = ({
               <span className="block break-words text-base font-semibold tracking-tight text-slate-950">
                 {simulation.executionId}
               </span>
-              <div className="mt-1 break-words text-sm leading-6 text-slate-500">
-                <span className="font-medium text-slate-600">Case:</span> {simulation.caseName}
+              <div className="mt-1 min-w-0 text-sm leading-6 text-slate-500">
+                <span className="font-medium text-slate-600">Case:</span>
+                <TableCellText
+                  value={simulation.caseName}
+                  lines={2}
+                  fullValueMode="tooltip"
+                  className="mt-0.5 text-sm leading-6 text-slate-500 [overflow-wrap:anywhere]"
+                />
               </div>
             </div>
             <div className="flex w-full flex-wrap items-center gap-2 text-xs uppercase tracking-[0.12em] text-slate-400">
@@ -117,18 +108,30 @@ export const SimulationResultCard = ({
             {/* One metadata item per line with bold labels */}
             <dl className="mb-2 space-y-2 text-sm">
               <div className="flex items-start gap-2">
-                <dt className="flex items-center gap-2 whitespace-nowrap font-semibold text-slate-700">
+                <dt className="flex shrink-0 items-center gap-2 whitespace-nowrap font-semibold text-slate-700">
                   <Rocket className="w-4 h-4" /> Campaign:
                 </dt>
-                <dd className="break-words font-normal text-slate-600">{simulation.campaign}</dd>
+                <dd className="min-w-0 flex-1 font-normal text-slate-600">
+                  <TableCellText
+                    value={simulation.campaign}
+                    lines={2}
+                    fullValueMode="tooltip"
+                    className="text-sm leading-6 text-slate-600 [overflow-wrap:anywhere]"
+                  />
+                </dd>
               </div>
 
               <div className="flex items-start gap-2">
-                <dt className="flex items-center gap-2 whitespace-nowrap font-semibold text-slate-700">
+                <dt className="flex shrink-0 items-center gap-2 whitespace-nowrap font-semibold text-slate-700">
                   <Lightbulb className="w-4 h-4" /> Experiment:
                 </dt>
-                <dd className="break-words font-normal text-slate-600">
-                  {simulation.experimentType}
+                <dd className="min-w-0 flex-1 font-normal text-slate-600">
+                  <TableCellText
+                    value={simulation.experimentType}
+                    lines={2}
+                    fullValueMode="tooltip"
+                    className="text-sm leading-6 text-slate-600 [overflow-wrap:anywhere]"
+                  />
                 </dd>
               </div>
 
@@ -221,339 +224,10 @@ export const SimulationResultCard = ({
 
             <div style={{ height: '6px' }} />
 
-            <Dialog open={isDetailsOpen} onOpenChange={setIsDetailsOpen}>
-              <DialogTrigger asChild>
-                <Button
-                  variant="outline"
-                  className="mb-4 w-full justify-between rounded-xl border-slate-200 bg-slate-50/70 px-4 py-6 text-left text-base text-slate-900 hover:bg-slate-100"
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  More Details
-                </Button>
-              </DialogTrigger>
-              <DialogContent
-                className="left-auto right-0 top-0 h-[100dvh] w-full max-w-[min(92vw,42rem)] translate-x-0 translate-y-0 gap-0 overflow-hidden rounded-none border-l border-slate-200 p-0 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-2xl sm:rounded-none"
-                onClick={(event) => event.stopPropagation()}
-              >
-                <div className="flex h-full min-h-0 flex-col">
-                  <DialogHeader className="border-b border-slate-200 px-6 py-5 text-left">
-                    <DialogTitle className="text-xl text-slate-950">
-                      {simulation.executionId}
-                    </DialogTitle>
-                    <DialogDescription className="mt-2 text-sm leading-6 text-slate-600">
-                      Additional browse details for <span className="font-medium">{simulation.caseName}</span>.
-                    </DialogDescription>
-                  </DialogHeader>
-
-                  <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-6 py-5">
-                    <section className="space-y-3">
-                      <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
-                        Overview
-                      </h3>
-                      <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:grid-cols-2">
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            Case
-                          </p>
-                          <p className="mt-1 text-sm text-slate-700">{simulation.caseName}</p>
-                        </div>
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            Status
-                          </p>
-                          <div className="mt-1">
-                            <SimulationStatusBadge status={simulation.status} />
-                          </div>
-                        </div>
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            Machine
-                          </p>
-                          <p className="mt-1 text-sm text-slate-700">{simulation.machine.name}</p>
-                        </div>
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            Compiler
-                          </p>
-                          <p className="mt-1 text-sm text-slate-700">{simulation.compiler ?? 'N/A'}</p>
-                        </div>
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            Grid
-                          </p>
-                          <p className="mt-1 text-sm text-slate-700">{simulation.gridName}</p>
-                        </div>
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            Canonical
-                          </p>
-                          <p className="mt-1 text-sm text-slate-700">
-                            {simulation.isCanonical ? 'Yes' : 'No'}
-                            {!simulation.isCanonical && simulation.changeCount > 0
-                              ? ` (${simulation.changeCount} changes)`
-                              : ''}
-                          </p>
-                        </div>
-                      </div>
-                    </section>
-
-                    <section className="space-y-3">
-                      <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
-                        Runtime And Provenance
-                      </h3>
-                      <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4">
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            Model Run Dates
-                          </p>
-                          <p className="mt-1 text-sm text-slate-700">
-                            {startStr} to {endStr}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            Runtime Window
-                          </p>
-                          <p className="mt-1 text-sm text-slate-700">
-                            {runStartStr} to {runEndStr}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            Created By
-                          </p>
-                          <p className="mt-1 text-sm text-slate-700">
-                            {simulation.createdByUser?.email ?? simulation.createdBy ?? 'N/A'}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            HPC Username
-                          </p>
-                          <p className="mt-1 text-sm text-slate-700">{simulation.hpcUsername ?? 'N/A'}</p>
-                        </div>
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                            Catalog Dates
-                          </p>
-                          <p className="mt-1 text-sm text-slate-700">
-                            Created {createdAtStr}, updated {updatedAtStr}
-                          </p>
-                        </div>
-                      </div>
-                    </section>
-
-                    {(simulation.gitRepositoryUrl ||
-                      simulation.gitBranch ||
-                      simulation.gitTag ||
-                      simulation.gitCommitHash) && (
-                      <section className="space-y-3">
-                        <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
-                          Version Control
-                        </h3>
-                        <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4">
-                          {simulation.gitRepositoryUrl && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Repository
-                              </p>
-                              <p className="mt-1 break-all text-sm text-slate-700">
-                                {simulation.gitRepositoryUrl}
-                              </p>
-                            </div>
-                          )}
-                          {simulation.gitBranch && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Branch
-                              </p>
-                              <p className="mt-1 break-all font-mono text-xs text-slate-700">
-                                {simulation.gitBranch}
-                              </p>
-                            </div>
-                          )}
-                          {simulation.gitTag && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Tag
-                              </p>
-                              <p className="mt-1 text-sm text-slate-700">{simulation.gitTag}</p>
-                            </div>
-                          )}
-                          {simulation.gitCommitHash && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Commit
-                              </p>
-                              <p className="mt-1 break-all font-mono text-xs text-slate-700">
-                                {simulation.gitCommitHash}
-                              </p>
-                            </div>
-                          )}
-                        </div>
-                      </section>
-                    )}
-
-                    {(simulation.description ||
-                      simulation.keyFeatures ||
-                      simulation.knownIssues ||
-                      simulation.notesMarkdown) && (
-                      <section className="space-y-3">
-                        <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
-                          Notes And Context
-                        </h3>
-                        <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
-                          {simulation.description && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Description
-                              </p>
-                              <p className="mt-1 text-sm leading-6 text-slate-700">
-                                {simulation.description}
-                              </p>
-                            </div>
-                          )}
-                          {simulation.keyFeatures && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Key Features
-                              </p>
-                              <p className="mt-1 text-sm leading-6 text-slate-700">
-                                {simulation.keyFeatures}
-                              </p>
-                            </div>
-                          )}
-                          {simulation.knownIssues && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Known Issues
-                              </p>
-                              <p className="mt-1 text-sm leading-6 text-slate-700">
-                                {simulation.knownIssues}
-                              </p>
-                            </div>
-                          )}
-                          {simulation.notesMarkdown && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Notes
-                              </p>
-                              <p className="mt-1 whitespace-pre-wrap text-sm leading-6 text-slate-700">
-                                {simulation.notesMarkdown}
-                              </p>
-                            </div>
-                          )}
-                        </div>
-                      </section>
-                    )}
-
-                    {(diagnosticLinks.length > 0 || performanceLinks.length > 0) && (
-                      <section className="space-y-3">
-                        <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
-                          External Links
-                        </h3>
-                        <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
-                          {diagnosticLinks.length > 0 && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Diagnostics
-                              </p>
-                              <ul className="mt-2 space-y-2">
-                                {diagnosticLinks.map((link) => (
-                                  <li key={link.id}>
-                                    <a
-                                      href={link.url}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="text-sm text-blue-700 underline"
-                                    >
-                                      {link.label}
-                                    </a>
-                                  </li>
-                                ))}
-                              </ul>
-                            </div>
-                          )}
-                          {performanceLinks.length > 0 && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Performance
-                              </p>
-                              <ul className="mt-2 space-y-2">
-                                {performanceLinks.map((link) => (
-                                  <li key={link.id}>
-                                    <a
-                                      href={link.url}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="text-sm text-blue-700 underline"
-                                    >
-                                      {link.label}
-                                    </a>
-                                  </li>
-                                ))}
-                              </ul>
-                            </div>
-                          )}
-                        </div>
-                      </section>
-                    )}
-
-                    {(runScripts.length > 0 || archivePaths.length > 0 || postprocessingScripts.length > 0) && (
-                      <section className="space-y-3">
-                        <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
-                          Artifact Paths
-                        </h3>
-                        <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
-                          {runScripts.length > 0 && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Run Scripts
-                              </p>
-                              <ul className="mt-2 space-y-2 text-sm text-slate-700">
-                                {runScripts.map((item, index) => (
-                                  <li key={index} className="break-all">
-                                    {typeof item === 'string' ? item : (item.label ?? item.uri)}
-                                  </li>
-                                ))}
-                              </ul>
-                            </div>
-                          )}
-                          {archivePaths.length > 0 && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Archive Paths
-                              </p>
-                              <ul className="mt-2 space-y-2 text-sm text-slate-700">
-                                {archivePaths.map((item, index) => (
-                                  <li key={index} className="break-all">
-                                    {typeof item === 'string' ? item : (item.label ?? item.uri)}
-                                  </li>
-                                ))}
-                              </ul>
-                            </div>
-                          )}
-                          {postprocessingScripts.length > 0 && (
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                                Postprocessing Scripts
-                              </p>
-                              <ul className="mt-2 space-y-2 text-sm text-slate-700">
-                                {postprocessingScripts.map((item, index) => (
-                                  <li key={index} className="break-all">
-                                    {typeof item === 'string' ? item : (item.label ?? item.uri)}
-                                  </li>
-                                ))}
-                              </ul>
-                            </div>
-                          )}
-                        </div>
-                      </section>
-                    )}
-                  </div>
-                </div>
-              </DialogContent>
-            </Dialog>
+            <SimulationBrowseDetailsDialog
+              simulation={simulation}
+              triggerClassName="mb-4 w-full justify-between rounded-xl border-slate-200 bg-slate-50/70 px-4 py-6 text-left text-base text-slate-900 hover:bg-slate-100"
+            />
 
             <div className="flex flex-col sm:flex-row items-center gap-4 mt-4 justify-end">
               <Button
@@ -565,7 +239,7 @@ export const SimulationResultCard = ({
                   navigate(`/simulations/${simulation.id}`);
                 }}
               >
-                View All Details
+                All Details
               </Button>
             </div>
           </CardContent>

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
@@ -16,7 +16,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { TableCellText } from '@/components/ui/table-cell-text';
-import { shouldSuppressBrowseSelection } from '@/features/browse/components/SimulationResults/selectionGuard';
 import { SimulationBrowseDetailsDialog } from '@/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog';
 import type { SimulationOut } from '@/types/index';
 
@@ -56,7 +55,7 @@ export const SimulationResultCard = ({
           : 'border-slate-200 hover:shadow-md'
       } ${isSelectionDisabled ? 'cursor-default' : 'cursor-pointer'}`}
       onClick={(event) => {
-        if (shouldSuppressBrowseSelection() || shouldIgnoreSelection(event.target)) {
+        if (shouldIgnoreSelection(event.target)) {
           return;
         }
 

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
@@ -15,6 +15,7 @@ import {
 } from '@tanstack/react-table';
 import { ArrowUpDown } from 'lucide-react';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -28,6 +29,8 @@ import {
 } from '@/components/ui/table';
 import { TableCellText } from '@/components/ui/table-cell-text';
 import { BrowseToolbar } from '@/features/browse/components/BrowseToolbar';
+import { shouldSuppressBrowseSelection } from '@/features/browse/components/SimulationResults/selectionGuard';
+import { SimulationBrowseDetailsDialog } from '@/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog';
 import type { SimulationOut } from '@/types/index';
 
 // Max number of rows that can be selected at once.
@@ -74,6 +77,36 @@ interface SimulationResultsTable {
     updater: VisibilityState | ((old: VisibilityState) => VisibilityState),
   ) => void;
 }
+
+const shouldIgnoreRowSelection = (target: EventTarget | null): boolean =>
+  target instanceof Element &&
+  Boolean(target.closest('button, a, input, [role="button"], [data-prevent-selection]'));
+
+const SimulationTableActions = ({ simulation }: { simulation: SimulationOut }) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex items-center justify-end gap-2" data-prevent-selection="true">
+      <SimulationBrowseDetailsDialog
+        simulation={simulation}
+        triggerSize="sm"
+        triggerClassName="h-9 rounded-lg border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+      />
+      <Button
+        variant="outline"
+        size="sm"
+        data-prevent-selection="true"
+        className="h-9 rounded-lg border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+        onClick={(event) => {
+          event.stopPropagation();
+          navigate(`/simulations/${simulation.id}`);
+        }}
+      >
+        All Details
+      </Button>
+    </div>
+  );
+};
 
 const columns: ColumnDef<SimulationOut>[] = [
   {
@@ -208,26 +241,11 @@ const columns: ColumnDef<SimulationOut>[] = [
     meta: { width: 180 },
   },
   {
-    id: 'details',
+    id: 'actions',
     enableHiding: false,
-    cell: ({ row }) => {
-      const simulation = row.original;
-      return (
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-9 rounded-lg border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
-          onClick={(event) => {
-            event.stopPropagation();
-            window.location.href = `/simulations/${simulation.id}`;
-          }}
-        >
-          Details
-        </Button>
-      );
-    },
+    cell: ({ row }) => <SimulationTableActions simulation={row.original} />,
     enableSorting: false,
-    meta: { sticky: true, width: 100, position: 'right' },
+    meta: { sticky: true, width: 220, position: 'right' },
   },
 ];
 
@@ -440,7 +458,11 @@ export const SimulationResultsTable = ({
                 key={row.id}
                 data-state={row.getIsSelected() ? 'selected' : undefined}
                 className="cursor-pointer border-b border-slate-100 hover:bg-slate-50/60 data-[state=selected]:bg-slate-50/80"
-                onClick={() => {
+                onClick={(event) => {
+                  if (shouldSuppressBrowseSelection() || shouldIgnoreRowSelection(event.target)) {
+                    return;
+                  }
+
                   const isSelected = row.getIsSelected();
                   const canSelectMore =
                     isSelected || Object.values(rowSelection).filter(Boolean).length < MAX_SELECTION;

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
@@ -29,7 +29,6 @@ import {
 } from '@/components/ui/table';
 import { TableCellText } from '@/components/ui/table-cell-text';
 import { BrowseToolbar } from '@/features/browse/components/BrowseToolbar';
-import { shouldSuppressBrowseSelection } from '@/features/browse/components/SimulationResults/selectionGuard';
 import { SimulationBrowseDetailsDialog } from '@/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog';
 import type { SimulationOut } from '@/types/index';
 
@@ -459,7 +458,7 @@ export const SimulationResultsTable = ({
                 data-state={row.getIsSelected() ? 'selected' : undefined}
                 className="cursor-pointer border-b border-slate-100 hover:bg-slate-50/60 data-[state=selected]:bg-slate-50/80"
                 onClick={(event) => {
-                  if (shouldSuppressBrowseSelection() || shouldIgnoreRowSelection(event.target)) {
+                  if (shouldIgnoreRowSelection(event.target)) {
                     return;
                   }
 

--- a/frontend/src/features/browse/components/SimulationResults/selectionGuard.ts
+++ b/frontend/src/features/browse/components/SimulationResults/selectionGuard.ts
@@ -1,0 +1,36 @@
+let suppressedUntil = 0;
+let clearPendingInteractionBlock: (() => void) | null = null;
+
+const SUPPRESSION_WINDOW_MS = 250;
+
+export const suppressBrowseSelection = (durationMs = SUPPRESSION_WINDOW_MS) => {
+  suppressedUntil = Date.now() + durationMs;
+};
+
+export const shouldSuppressBrowseSelection = () => Date.now() < suppressedUntil;
+
+export const suppressNextBrowseInteraction = (durationMs = SUPPRESSION_WINDOW_MS) => {
+  suppressBrowseSelection(durationMs);
+
+  if (typeof window === 'undefined' || clearPendingInteractionBlock) {
+    return;
+  }
+
+  const clear = () => {
+    window.removeEventListener('click', blockNextInteraction, true);
+    window.clearTimeout(timeoutId);
+    clearPendingInteractionBlock = null;
+  };
+
+  const blockNextInteraction = (event: Event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+    clear();
+  };
+
+  const timeoutId = window.setTimeout(clear, durationMs);
+  clearPendingInteractionBlock = clear;
+
+  window.addEventListener('click', blockNextInteraction, true);
+};

--- a/frontend/src/features/browse/components/SimulationResults/selectionGuard.ts
+++ b/frontend/src/features/browse/components/SimulationResults/selectionGuard.ts
@@ -1,17 +1,8 @@
-let suppressedUntil = 0;
 let clearPendingInteractionBlock: (() => void) | null = null;
 
 const SUPPRESSION_WINDOW_MS = 250;
 
-export const suppressBrowseSelection = (durationMs = SUPPRESSION_WINDOW_MS) => {
-  suppressedUntil = Date.now() + durationMs;
-};
-
-export const shouldSuppressBrowseSelection = () => Date.now() < suppressedUntil;
-
 export const suppressNextBrowseInteraction = (durationMs = SUPPRESSION_WINDOW_MS) => {
-  suppressBrowseSelection(durationMs);
-
   if (typeof window === 'undefined' || clearPendingInteractionBlock) {
     return;
   }


### PR DESCRIPTION
## Summary
- clamp long browse card metadata and filter labels so case, campaign, and experiment text stay within their containers
- add a shared browse details drawer and expose `More Details` plus `All Details` actions in table view
- fix card/table selection regressions caused by drawer interactions, including outside-click dismissal over underlying rows/cards

## Key Changes
- reuse `TableCellText` for truncated case/filter/multi-select text so tooltips only appear when content is actually truncated
- constrain the browse case filter chip and multi-select popovers so long case names do not stretch layout
- extract the browse details drawer into a shared `SimulationBrowseDetailsDialog` used by both cards and table rows
- add target-aware row/card selection guards plus a one-shot suppression helper to prevent drawer clicks from selecting the underlying row/card
- align the full-page action label to `All Details`

## Validation
- `make frontend-lint`
- `pnpm --dir frontend run type-check`
- `pnpm --dir frontend run build`

## Notes
- Vite build still reports the existing large chunk warning, but the build succeeds.