### PR TITLE
Add case-centric browse and detail pages

### DIFF
--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils';
 const navItems = [
   { label: 'Home', href: '/', description: 'Overview and featured simulations' },
   { label: 'Browse', href: '/browse', description: 'Guided discovery with filters' },
+  { label: 'Cases', href: '/cases', description: 'Experiment-level browse and detail pages' },
   { label: 'Compare', href: '/compare', description: 'Side-by-side view of selected runs' },
   {
     label: 'All Simulations',
@@ -67,7 +68,10 @@ export const NavBar = ({ selectedSimulationIds }: NavBarProps) => {
         <nav className="hidden md:flex gap-3 ml-6">
           {navItems.map((item) => {
             const isCompare = item.label === 'Compare';
-            const isActive = location.pathname === item.href;
+            const isActive =
+              item.href === '/'
+                ? location.pathname === item.href
+                : location.pathname === item.href || location.pathname.startsWith(`${item.href}/`);
 
             return (
               <TooltipProvider delayDuration={150} key={item.href}>

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -17,15 +17,10 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { cn } from '@/lib/utils';
 
 const navItems = [
-  { label: 'Home', href: '/', description: 'Overview and featured simulations' },
-  { label: 'Browse', href: '/browse', description: 'Guided discovery with filters' },
-  { label: 'Cases', href: '/cases', description: 'Experiment-level browse and detail pages' },
+  { label: 'Home', href: '/', description: 'Overview and entry points for catalog discovery' },
+  { label: 'Cases', href: '/cases', description: 'Primary case-centric discovery and detail pages' },
+  { label: 'Runs', href: '/browse', description: 'Advanced execution-level discovery workspace' },
   { label: 'Compare', href: '/compare', description: 'Side-by-side view of selected runs' },
-  {
-    label: 'All Simulations',
-    href: '/simulations',
-    description: 'Complete catalog in a sortable table',
-  },
   { label: 'Upload', href: '/upload', description: 'Add a new simulation to the catalog' },
   { label: 'Docs', href: '/docs', description: 'Guides and references for using the viewer' },
 ];

--- a/frontend/src/features/browse/BrowsePage.tsx
+++ b/frontend/src/features/browse/BrowsePage.tsx
@@ -102,6 +102,18 @@ const createEmptyFilters = (): FilterState => ({
   hpcUsername: [],
 });
 
+const FILTER_KEYS = Object.keys(createEmptyFilters()) as (keyof FilterState)[];
+const MULTI_SELECT_FILTER_KEYS = FILTER_KEYS.filter((key) => key !== 'canonicalStatus');
+
+const areStringArraysEqual = (left: string[], right: string[]): boolean =>
+  left.length === right.length && left.every((value, index) => value === right[index]);
+
+const areFiltersEqual = (left: FilterState, right: FilterState): boolean =>
+  left.canonicalStatus === right.canonicalStatus &&
+  MULTI_SELECT_FILTER_KEYS.every((key) =>
+    areStringArraysEqual(left[key] as string[], right[key] as string[]),
+  );
+
 const parseViewMode = (params: URLSearchParams): 'grid' | 'table' =>
   params.get('view') === 'grid' ? 'grid' : 'table';
 
@@ -144,9 +156,7 @@ export const BrowsePage = ({
     const filters = createEmptyFilters();
 
     // Array-based filter keys that correspond to SimulationOut properties.
-    const arrayKeys = Object.keys(createEmptyFilters()).filter(
-      (k) => k !== 'canonicalStatus',
-    ) as (keyof SimulationOut)[];
+    const arrayKeys = MULTI_SELECT_FILTER_KEYS as (keyof SimulationOut)[];
 
     // Populate filter options based on available simulations.
     for (const sim of simulations) {
@@ -301,7 +311,14 @@ export const BrowsePage = ({
   useEffect(() => {
     let cancelled = false;
 
-    listSimulations(SIMULATIONS_URL)
+    // If exactly one caseName filter is applied, pass it as a query param for server-side narrowing.
+    const caseNames = appliedFilters.caseName;
+    const fetchPromise =
+      Array.isArray(caseNames) && caseNames.length === 1
+        ? listSimulations(`${SIMULATIONS_URL}?case_name=${encodeURIComponent(caseNames[0])}`)
+        : listSimulations(SIMULATIONS_URL);
+
+    fetchPromise
       .then((res) => {
         if (!cancelled) setSimulations(res);
       })
@@ -312,15 +329,13 @@ export const BrowsePage = ({
     return () => {
       cancelled = true;
     };
-  }, []);
+    // Re-run when the caseName filter changes.
+  }, [appliedFilters.caseName]);
 
   useEffect(() => {
     const next = createEmptyFilters();
-    const multiSelectFilterKeys = (
-      Object.keys(createEmptyFilters()) as (keyof FilterState)[]
-    ).filter((key) => key !== 'canonicalStatus');
 
-    multiSelectFilterKeys.forEach((key) => {
+    MULTI_SELECT_FILTER_KEYS.forEach((key) => {
       const value = searchParams.get(key);
       if (value !== null) {
         next[key] = value.split(',').filter(Boolean) as FilterState[typeof key];
@@ -333,7 +348,7 @@ export const BrowsePage = ({
         ? canonicalStatus
         : '';
 
-    setAppliedFilters(next);
+    setAppliedFilters((current) => (areFiltersEqual(current, next) ? current : next));
 
     // Sync view, page, pageSize from URL (handles back/forward navigation).
     setViewMode(parseViewMode(searchParams));
@@ -379,9 +394,8 @@ export const BrowsePage = ({
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
-        const filterKeys = Object.keys(createEmptyFilters()) as (keyof FilterState)[];
 
-        for (const key of filterKeys) {
+        for (const key of FILTER_KEYS) {
           const value = appliedFilters[key];
           if (Array.isArray(value) && value.length) {
             next.set(key, value.join(','));
@@ -422,7 +436,7 @@ export const BrowsePage = ({
       (prev) => {
         const next = new URLSearchParams(prev);
 
-        (Object.keys(createEmptyFilters()) as (keyof FilterState)[]).forEach((key) => {
+        FILTER_KEYS.forEach((key) => {
           next.delete(key);
         });
 
@@ -477,12 +491,11 @@ export const BrowsePage = ({
             <div className="flex min-w-0 flex-col">
               <header className="mb-4 flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm xl:flex-row xl:items-start xl:justify-between">
                 <div className="min-w-0">
-                  <h1 className="mb-2 text-3xl font-bold tracking-tight text-slate-950">
-                    Runs
-                  </h1>
+                  <h1 className="mb-2 text-3xl font-bold tracking-tight text-slate-950">Runs</h1>
                   <p className="max-w-4xl text-[15px] leading-7 text-slate-600 sm:text-base">
                     Explore and filter individual runs using the panel on the left. This is the
-                    advanced execution-level workspace for drilling into details and setting up compare.
+                    advanced execution-level workspace for drilling into details and setting up
+                    compare.
                   </p>
                 </div>
                 <div className="xl:min-w-[360px]">
@@ -491,7 +504,9 @@ export const BrowsePage = ({
                       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-slate-600">
                         <div>
                           <span className="font-medium text-slate-500">Results</span>{' '}
-                          <span className="font-semibold text-slate-950">{filteredData.length}</span>
+                          <span className="font-semibold text-slate-950">
+                            {filteredData.length}
+                          </span>
                         </div>
                         <div>
                           <span className="font-medium text-slate-500">View</span>{' '}
@@ -573,7 +588,9 @@ export const BrowsePage = ({
                 </div>
               </header>
 
-              {Object.values(appliedFilters).some((v) => (Array.isArray(v) ? v.length > 0 : !!v)) && (
+              {Object.values(appliedFilters).some((v) =>
+                Array.isArray(v) ? v.length > 0 : !!v,
+              ) && (
                 <div className="mb-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
                   <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <div>
@@ -600,20 +617,63 @@ export const BrowsePage = ({
                     </button>
                   </div>
                   <div className="flex min-w-0 flex-wrap gap-2">
-                  {(
-                    Object.entries(appliedFilters) as [keyof FilterState, string[] | string][]
-                  ).flatMap(([key, values]) => {
-                    if (Array.isArray(values)) {
-                      return values.map((value, idx) => {
+                    {(
+                      Object.entries(appliedFilters) as [keyof FilterState, string[] | string][]
+                    ).flatMap(([key, values]) => {
+                      if (Array.isArray(values)) {
+                        return values.map((value, idx) => {
+                          const display =
+                            key === 'machineId'
+                              ? (machineOptions.find((opt) => opt.value === value)?.label ?? value)
+                              : key === 'createdBy'
+                                ? (creatorOptions.find((opt) => opt.value === value)?.label ??
+                                  value)
+                                : value;
+                          return (
+                            <span
+                              key={`${key}-${value}-${idx}`}
+                              className="inline-flex min-w-0 max-w-full items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
+                            >
+                              <span className="mr-2 shrink-0 text-xs font-medium text-slate-500">
+                                {String(key).replace(/Id$/, '')}:
+                              </span>
+                              <span className="mr-2 min-w-0 flex-1 truncate font-medium text-slate-700">
+                                {display}
+                              </span>
+                              <button
+                                type="button"
+                                aria-label={`Remove ${String(key)} filter`}
+                                className="ml-1 shrink-0 rounded-sm text-slate-400 transition-colors hover:text-slate-700 focus:outline-none"
+                                onClick={() => {
+                                  setAppliedFilters((prev) => ({
+                                    ...prev,
+                                    [key]: (prev[key] as string[]).filter((v) => v !== value),
+                                  }));
+                                }}
+                              >
+                                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                                  <path
+                                    d="M4 4L12 12M12 4L4 12"
+                                    stroke="currentColor"
+                                    strokeWidth="2"
+                                    strokeLinecap="round"
+                                  />
+                                </svg>
+                              </button>
+                            </span>
+                          );
+                        });
+                      } else if (values) {
                         const display =
                           key === 'machineId'
-                            ? (machineOptions.find((opt) => opt.value === value)?.label ?? value)
+                            ? (machineOptions.find((opt) => opt.value === values)?.label ?? values)
                             : key === 'createdBy'
-                              ? (creatorOptions.find((opt) => opt.value === value)?.label ?? value)
-                            : value;
+                              ? (creatorOptions.find((opt) => opt.value === values)?.label ??
+                                values)
+                              : values;
                         return (
                           <span
-                            key={`${key}-${value}-${idx}`}
+                            key={`${String(key)}-${values}`}
                             className="inline-flex min-w-0 max-w-full items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
                           >
                             <span className="mr-2 shrink-0 text-xs font-medium text-slate-500">
@@ -627,10 +687,7 @@ export const BrowsePage = ({
                               aria-label={`Remove ${String(key)} filter`}
                               className="ml-1 shrink-0 rounded-sm text-slate-400 transition-colors hover:text-slate-700 focus:outline-none"
                               onClick={() => {
-                                setAppliedFilters((prev) => ({
-                                  ...prev,
-                                  [key]: (prev[key] as string[]).filter((v) => v !== value),
-                                }));
+                                setAppliedFilters((prev) => ({ ...prev, [key]: '' }));
                               }}
                             >
                               <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
@@ -644,47 +701,9 @@ export const BrowsePage = ({
                             </button>
                           </span>
                         );
-                      });
-                    } else if (values) {
-                      const display =
-                        key === 'machineId'
-                          ? (machineOptions.find((opt) => opt.value === values)?.label ?? values)
-                          : key === 'createdBy'
-                            ? (creatorOptions.find((opt) => opt.value === values)?.label ?? values)
-                          : values;
-                      return (
-                        <span
-                          key={`${String(key)}-${values}`}
-                          className="inline-flex min-w-0 max-w-full items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
-                        >
-                          <span className="mr-2 shrink-0 text-xs font-medium text-slate-500">
-                            {String(key).replace(/Id$/, '')}:
-                          </span>
-                          <span className="mr-2 min-w-0 flex-1 truncate font-medium text-slate-700">
-                            {display}
-                          </span>
-                          <button
-                            type="button"
-                            aria-label={`Remove ${String(key)} filter`}
-                            className="ml-1 shrink-0 rounded-sm text-slate-400 transition-colors hover:text-slate-700 focus:outline-none"
-                            onClick={() => {
-                              setAppliedFilters((prev) => ({ ...prev, [key]: '' }));
-                            }}
-                          >
-                            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                              <path
-                                d="M4 4L12 12M12 4L4 12"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                              />
-                            </svg>
-                          </button>
-                        </span>
-                      );
-                    }
-                    return [];
-                  })}
+                      }
+                      return [];
+                    })}
                   </div>
                 </div>
               )}

--- a/frontend/src/features/browse/BrowsePage.tsx
+++ b/frontend/src/features/browse/BrowsePage.tsx
@@ -18,7 +18,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { TableCellText } from '@/components/ui/table-cell-text';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { BrowseFiltersSidePanel } from '@/features/browse/components/BrowseFiltersSidePanel';
 import { SimulationResultCards } from '@/features/browse/components/SimulationResults/SimulationResultsCards';
@@ -42,6 +41,8 @@ const TOGGLEABLE_BROWSE_COLUMNS = [
 
 // -------------------- Types & Interfaces --------------------
 export interface FilterState {
+  caseName: string[];
+
   // Scientific Goal
   campaign: string[];
   experimentType: string[];
@@ -74,6 +75,8 @@ interface BrowsePageProps {
 
 // -------------------- Pure Helpers --------------------
 const createEmptyFilters = (): FilterState => ({
+  caseName: [],
+
   // Scientific Goal
   campaign: [],
   experimentType: [],
@@ -123,7 +126,6 @@ export const BrowsePage = ({
   // -------------------- Router --------------------
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const selectedCaseName = searchParams.get('caseName') ?? '';
 
   // -------------------- Local State --------------------
   const [simulations, setSimulations] = useState<SimulationOut[]>([]);
@@ -235,6 +237,7 @@ export const BrowsePage = ({
         (rec: SimulationOut) => string | string[] | [string | null, string | null] | undefined
       >
     > = {
+      caseName: (rec) => rec.caseName ?? [],
       machineId: (rec) => simMachineId(rec) ?? '',
       campaign: (rec) => rec.campaign ?? [],
       experimentType: (rec) => rec.experimentType ?? [],
@@ -297,17 +300,8 @@ export const BrowsePage = ({
 
   useEffect(() => {
     let cancelled = false;
-    const params = new URLSearchParams();
 
-    if (selectedCaseName) {
-      params.set('case_name', selectedCaseName);
-    }
-
-    const simulationsUrl = params.toString()
-      ? `${SIMULATIONS_URL}?${params.toString()}`
-      : SIMULATIONS_URL;
-
-    listSimulations(simulationsUrl)
+    listSimulations(SIMULATIONS_URL)
       .then((res) => {
         if (!cancelled) setSimulations(res);
       })
@@ -318,7 +312,7 @@ export const BrowsePage = ({
     return () => {
       cancelled = true;
     };
-  }, [selectedCaseName]);
+  }, []);
 
   useEffect(() => {
     const next = createEmptyFilters();
@@ -351,7 +345,6 @@ export const BrowsePage = ({
   const prevPageResetSignature = useRef<string | null>(null);
   useEffect(() => {
     const currentSignature = JSON.stringify({
-      selectedCaseName,
       appliedFilters,
     });
 
@@ -365,7 +358,7 @@ export const BrowsePage = ({
       prevPageResetSignature.current = currentSignature;
       setPage(1);
     }
-  }, [appliedFilters, selectedCaseName]);
+  }, [appliedFilters]);
 
   // Sync applied filters to URL via setSearchParams (single writer).
   // Use a ref to avoid re-running this effect on every searchParams change.
@@ -386,8 +379,6 @@ export const BrowsePage = ({
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
-
-        // Preserve caseName (managed by handleCaseNameChange).
         const filterKeys = Object.keys(createEmptyFilters()) as (keyof FilterState)[];
 
         for (const key of filterKeys) {
@@ -424,45 +415,6 @@ export const BrowsePage = ({
   }, [appliedFilters, viewMode, page, pageSize, setSearchParams]);
 
   // -------------------- Handlers --------------------
-  const handleCaseNameChange = (caseName: string) => {
-    skipNextFilterUrlSync.current = true;
-    setAppliedFilters(createEmptyFilters());
-    setPage(1);
-
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-
-        (Object.keys(createEmptyFilters()) as (keyof FilterState)[]).forEach((key) => {
-          next.delete(key);
-        });
-
-        if (caseName) {
-          next.set('caseName', caseName);
-        } else {
-          next.delete('caseName');
-        }
-
-        next.delete('page');
-
-        return next;
-      },
-      { replace: true },
-    );
-  };
-
-  const handleClearCaseNameFilter = () => {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        next.delete('caseName');
-        next.delete('page');
-        return next;
-      },
-      { replace: true },
-    );
-  };
-
   const handleResetFilters = () => {
     skipNextFilterUrlSync.current = true;
     setAppliedFilters(createEmptyFilters());
@@ -474,7 +426,6 @@ export const BrowsePage = ({
           next.delete(key);
         });
 
-        next.delete('caseName');
         next.delete('page');
         return next;
       },
@@ -519,8 +470,6 @@ export const BrowsePage = ({
                 machineOptions={machineOptions}
                 creatorOptions={creatorOptions}
                 caseOptions={caseOptions}
-                selectedCaseName={selectedCaseName}
-                onCaseNameChange={handleCaseNameChange}
               />
             </div>
           </div>
@@ -624,8 +573,7 @@ export const BrowsePage = ({
                 </div>
               </header>
 
-              {(selectedCaseName ||
-                Object.values(appliedFilters).some((v) => (Array.isArray(v) ? v.length > 0 : !!v))) && (
+              {Object.values(appliedFilters).some((v) => (Array.isArray(v) ? v.length > 0 : !!v)) && (
                 <div className="mb-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
                   <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <div>
@@ -652,32 +600,6 @@ export const BrowsePage = ({
                     </button>
                   </div>
                   <div className="flex min-w-0 flex-wrap gap-2">
-                  {selectedCaseName && (
-                    <span className="inline-flex min-w-0 max-w-[min(100%,40rem)] items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700">
-                      <span className="mr-2 shrink-0 text-xs font-medium text-slate-500">case:</span>
-                      <TableCellText
-                        value={selectedCaseName}
-                        lines={1}
-                        fullValueMode="tooltip"
-                        className="mr-2 min-w-0 flex-1 font-medium text-slate-700"
-                      />
-                      <button
-                        type="button"
-                        aria-label="Remove case filter"
-                        className="ml-1 shrink-0 rounded-sm text-slate-400 transition-colors hover:text-slate-700 focus:outline-none"
-                        onClick={handleClearCaseNameFilter}
-                      >
-                        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                          <path
-                            d="M4 4L12 12M12 4L4 12"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                          />
-                        </svg>
-                      </button>
-                    </span>
-                  )}
                   {(
                     Object.entries(appliedFilters) as [keyof FilterState, string[] | string][]
                   ).flatMap(([key, values]) => {

--- a/frontend/src/features/browse/BrowsePage.tsx
+++ b/frontend/src/features/browse/BrowsePage.tsx
@@ -529,11 +529,11 @@ export const BrowsePage = ({
               <header className="mb-4 flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm xl:flex-row xl:items-start xl:justify-between">
                 <div className="min-w-0">
                   <h1 className="mb-2 text-3xl font-bold tracking-tight text-slate-950">
-                    Browse Simulations
+                    Runs
                   </h1>
                   <p className="max-w-4xl text-[15px] leading-7 text-slate-600 sm:text-base">
-                    Explore and filter available simulations using the panel on the left. Select
-                    simulations to view more details or take further actions.
+                    Explore and filter individual runs using the panel on the left. This is the
+                    advanced execution-level workspace for drilling into details and setting up compare.
                   </p>
                 </div>
                 <div className="xl:min-w-[360px]">

--- a/frontend/src/features/browse/components/BrowseFiltersSidePanel.tsx
+++ b/frontend/src/features/browse/components/BrowseFiltersSidePanel.tsx
@@ -12,8 +12,6 @@ interface FilterPanelProps {
   machineOptions: { value: string; label: string }[];
   creatorOptions: { value: string; label: string }[];
   caseOptions: { value: string; label: string }[];
-  selectedCaseName: string;
-  onCaseNameChange: (caseName: string) => void;
 }
 
 export const BrowseFiltersSidePanel = ({
@@ -23,8 +21,6 @@ export const BrowseFiltersSidePanel = ({
   machineOptions,
   creatorOptions,
   caseOptions,
-  selectedCaseName,
-  onCaseNameChange,
 }: FilterPanelProps) => {
   const filterLabelClassName =
     'mb-1.5 block text-xs font-semibold tracking-[0.08em] text-slate-500';
@@ -51,22 +47,15 @@ export const BrowseFiltersSidePanel = ({
       <div>
         <label className={filterLabelClassName}>Case</label>
         <p className="mb-2 text-xs leading-5 text-slate-500">
-          Only one case can be selected at a time. Choosing a new case resets the other filters.
+          Select one or more cases to narrow the run workspace without leaving cross-case browsing.
         </p>
       </div>
       <MultiSelect
-        options={
-          selectedCaseName && !caseOptions.some((o) => o.value === selectedCaseName)
-            ? [...caseOptions, { value: selectedCaseName, label: selectedCaseName }]
-            : caseOptions
-        }
-        maxSelected={1}
-        maxCount={1}
-        defaultValue={selectedCaseName ? [selectedCaseName] : []}
-        onValueChange={(next) => onCaseNameChange(next[0] ?? '')}
-        placeholder="Select one case"
+        options={caseOptions}
+        defaultValue={appliedFilters.caseName || []}
+        onValueChange={(next) => handleChange('caseName', next as string[])}
+        placeholder="Select cases"
         hideSelectAll={true}
-        closeOnSelect={true}
         resetOnDefaultValueChange={true}
       />
 

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
@@ -8,7 +8,7 @@ import {
   Server,
   Tag,
 } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge';
 import { Badge } from '@/components/ui/badge';
@@ -38,6 +38,8 @@ export const SimulationResultCard = ({
 }: SimulationResultCard) => {
   // -------------------- Router --------------------
   const navigate = useNavigate();
+  const location = useLocation();
+  const currentPath = `${location.pathname}${location.search}`;
 
   // -------------------- Derived Data --------------------
   const startStr = simulation.simulationStartDate
@@ -235,7 +237,7 @@ export const SimulationResultCard = ({
                 className="w-full sm:w-40"
                 onClick={(event) => {
                   event.stopPropagation();
-                  navigate(`/simulations/${simulation.id}`);
+                  navigate(`/simulations/${simulation.id}`, { state: { from: currentPath } });
                 }}
               >
                 All Details

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
@@ -15,7 +15,7 @@ import {
 } from '@tanstack/react-table';
 import { ArrowUpDown } from 'lucide-react';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -83,6 +83,8 @@ const shouldIgnoreRowSelection = (target: EventTarget | null): boolean =>
 
 const SimulationTableActions = ({ simulation }: { simulation: SimulationOut }) => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const currentPath = `${location.pathname}${location.search}`;
 
   return (
     <div className="flex items-center justify-end gap-2" data-prevent-selection="true">
@@ -98,7 +100,7 @@ const SimulationTableActions = ({ simulation }: { simulation: SimulationOut }) =
         className="h-9 rounded-lg border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
         onClick={(event) => {
           event.stopPropagation();
-          navigate(`/simulations/${simulation.id}`);
+          navigate(`/simulations/${simulation.id}`, { state: { from: currentPath } });
         }}
       >
         All Details

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -20,9 +20,10 @@ interface HomePageProps {
 }
 
 export const HomePage = ({ simulations, machines }: HomePageProps) => {
-  const totalCases = useMemo(() => new Set(simulations.map((simulation) => simulation.caseId)).size, [
-    simulations,
-  ]);
+  const totalCases = useMemo(
+    () => new Set(simulations.map((simulation) => simulation.caseId)).size,
+    [simulations],
+  );
   const latestSubmission = useMemo(
     () =>
       [...simulations]
@@ -96,7 +97,10 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
     };
 
     return [...casesById.values()]
-      .sort((left, right) => new Date(right.lastUpdated).getTime() - new Date(left.lastUpdated).getTime())
+      .sort(
+        (left, right) =>
+          new Date(right.lastUpdated).getTime() - new Date(left.lastUpdated).getTime(),
+      )
       .slice(0, 6)
       .map((caseRecord) => ({
         ...caseRecord,
@@ -121,14 +125,16 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
   const workflows = [
     {
       title: 'Browse Cases',
-      description: 'Browse grouped simulation work, scan related runs, and open deeper case details.',
+      description:
+        'Browse grouped simulation work, scan related runs, and open deeper case details.',
       to: '/cases',
       action: 'Open Cases',
       icon: FolderOpen,
     },
     {
       title: 'Explore Runs',
-      description: 'Use the advanced run browser when you need detailed filters, selection, and compare setup.',
+      description:
+        'Use the advanced run browser when you need detailed filters, selection, and compare setup.',
       to: '/browse',
       action: 'Open Runs',
       icon: Search,
@@ -166,12 +172,17 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
 
           <ul className="space-y-2 text-sm leading-6 text-muted-foreground md:text-base">
             <li>
-              Browse simulation collections, open case pages, and inspect the runs connected to them.
+              Browse simulation collections, open case pages, and inspect the runs connected to
+              them.
             </li>
             <li>
-              Jump into run-level views when you need machine, version, user, or date-specific context.
+              Jump into run-level views when you need machine, version, user, or date-specific
+              context.
             </li>
-            <li>Compare simulations side by side and share specific case or run pages with collaborators.</li>
+            <li>
+              Compare simulations side by side and share specific case or run pages with
+              collaborators.
+            </li>
           </ul>
 
           <div className="flex flex-wrap gap-3">
@@ -273,7 +284,8 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
           <div className="space-y-1">
             <h2 className="text-2xl font-bold">Recent Cases</h2>
             <p className="text-muted-foreground">
-              Open recently active case pages and move from grouped simulation context into run details.
+              Open recently active case pages and move from grouped simulation context into run
+              details.
             </p>
           </div>
           <Button asChild variant="secondary">

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -35,6 +35,7 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
         name: string;
         caseGroup: string | null;
         machineNames: Set<string>;
+        hpcUsernames: Set<string>;
         simulationCount: number;
         lastUpdated: string;
       }
@@ -49,6 +50,9 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
         if (simulation.machine?.name) {
           existing.machineNames.add(simulation.machine.name);
         }
+        if (simulation.hpcUsername) {
+          existing.hpcUsernames.add(simulation.hpcUsername);
+        }
         if (new Date(simulationUpdatedAt).getTime() > new Date(existing.lastUpdated).getTime()) {
           existing.lastUpdated = simulationUpdatedAt;
         }
@@ -60,6 +64,7 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
         name: simulation.caseName,
         caseGroup: simulation.caseGroup ?? null,
         machineNames: simulation.machine?.name ? new Set([simulation.machine.name]) : new Set(),
+        hpcUsernames: simulation.hpcUsername ? new Set([simulation.hpcUsername]) : new Set(),
         simulationCount: 1,
         lastUpdated: simulationUpdatedAt,
       });
@@ -76,12 +81,24 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
       return `${names[0]} +${names.length - 1}`;
     };
 
+    const summarizeUsers = (hpcUsernames: Set<string>) => {
+      const names = [...hpcUsernames].sort((left, right) =>
+        left.localeCompare(right, undefined, { sensitivity: 'base' }),
+      );
+
+      if (names.length === 0) return '—';
+      if (names.length === 1) return names[0];
+
+      return `${names[0]} +${names.length - 1}`;
+    };
+
     return [...casesById.values()]
       .sort((left, right) => new Date(right.lastUpdated).getTime() - new Date(left.lastUpdated).getTime())
       .slice(0, 6)
       .map((caseRecord) => ({
         ...caseRecord,
         machineSummary: summarizeMachines(caseRecord.machineNames),
+        hpcUsernameSummary: summarizeUsers(caseRecord.hpcUsernames),
       }));
   }, [simulations]);
   const machineSimulationCounts = new Map<Machine['id'], number>();
@@ -256,10 +273,11 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
           <Table className="table-fixed">
             <TableHeader>
               <TableRow>
-                <TableHead>Case Name</TableHead>
-                <TableHead>Case Group</TableHead>
+                <TableHead className="w-[32%] min-w-[320px]">Case Name</TableHead>
+                <TableHead>HPC Username</TableHead>
                 <TableHead>Machines</TableHead>
                 <TableHead>Runs</TableHead>
+                <TableHead>Case Group</TableHead>
                 <TableHead>Last Updated</TableHead>
                 <TableHead>Details</TableHead>
               </TableRow>
@@ -270,11 +288,14 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
                   <TableCell className="align-top">
                     <TableCellText value={caseRecord.name} lines={1} />
                   </TableCell>
-                  <TableCell>{caseRecord.caseGroup ?? '—'}</TableCell>
+                  <TableCell className="align-top">
+                    <TableCellText value={caseRecord.hpcUsernameSummary} lines={1} />
+                  </TableCell>
                   <TableCell className="align-top">
                     <TableCellText value={caseRecord.machineSummary} lines={1} />
                   </TableCell>
                   <TableCell>{caseRecord.simulationCount}</TableCell>
+                  <TableCell>{caseRecord.caseGroup ?? '—'}</TableCell>
                   <TableCell>{new Date(caseRecord.lastUpdated).toLocaleDateString()}</TableCell>
                   <TableCell>
                     <Button asChild variant="outline" size="sm" className="h-8 gap-1 px-2">

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -46,14 +46,14 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
   const workflows = [
     {
       title: 'Browse Cases',
-      description: 'Find cases by run metadata, inspect canonical baselines, and open nested runs.',
+      description: 'Browse grouped simulation work, scan related runs, and open deeper case details.',
       to: '/cases',
       action: 'Open Cases',
       icon: FolderOpen,
     },
     {
       title: 'Explore Runs',
-      description: 'Use the advanced execution browser when you need run-level filters and selection.',
+      description: 'Use the advanced run browser when you need detailed filters, selection, and compare setup.',
       to: '/browse',
       action: 'Open Runs',
       icon: Search,
@@ -80,22 +80,23 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
         <div className="max-w-3xl space-y-5">
           <div className="space-y-3">
             <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
-              Find Cases Through Your Runs
+              Explore E3SM Simulations
             </h1>
             <p className="max-w-2xl text-lg leading-8 text-muted-foreground">
-              SimBoard is a web interface for finding E3SM cases and reviewing the runs that belong
-              to them. Start from run metadata like HPC username, then move into case-level context.
+              SimBoard is a public-facing interface for browsing, comparing, and sharing cataloged
+              E3SM simulations. Start with a broad view of the catalog, then drill into cases and
+              runs when you want more detail.
             </p>
           </div>
 
           <ul className="space-y-2 text-sm leading-6 text-muted-foreground md:text-base">
             <li>
-              Filter cases using run metadata such as HPC username, machine, status, and execution context.
+              Browse simulation collections, open case pages, and inspect the runs connected to them.
             </li>
             <li>
-              Open case detail pages to inspect canonical baselines and nested run summaries.
+              Jump into run-level views when you need machine, version, user, or date-specific context.
             </li>
-            <li>Use the runs workspace when you need execution-level browsing, selection, and compare setup.</li>
+            <li>Compare simulations side by side and share specific case or run pages with collaborators.</li>
           </ul>
 
           <div className="flex flex-wrap gap-3">

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -1,4 +1,4 @@
-import { GitCompareArrows, Search, Upload } from 'lucide-react';
+import { FolderOpen, GitCompareArrows, Search, Upload } from 'lucide-react';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -59,6 +59,13 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
       icon: GitCompareArrows,
     },
     {
+      title: 'Browse Cases',
+      description: 'Discover experiment-level case records and inspect their canonical baselines.',
+      to: '/cases',
+      action: 'Open Cases',
+      icon: FolderOpen,
+    },
+    {
       title: 'Upload a Simulation',
       description: 'Submit new simulation metadata to share results and preserve provenance.',
       to: '/upload',
@@ -100,6 +107,9 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
             </Button>
             <Button asChild variant="secondary">
               <Link to="/compare">Compare</Link>
+            </Button>
+            <Button asChild variant="secondary">
+              <Link to="/cases">Browse Cases</Link>
             </Button>
             <Button asChild variant="secondary">
               <Link to="/simulations">All Simulations</Link>
@@ -155,7 +165,7 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
             Jump from the catalog overview into the primary SimBoard tasks.
           </p>
         </div>
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
           {workflows.map((workflow) => {
             const Icon = workflow.icon;
             return (

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -45,10 +45,17 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
 
   const workflows = [
     {
-      title: 'Browse Curated Simulations',
-      description: 'Filter simulations by case, campaign, context, and execution metadata.',
+      title: 'Browse Cases',
+      description: 'Find cases by run metadata, inspect canonical baselines, and open nested runs.',
+      to: '/cases',
+      action: 'Open Cases',
+      icon: FolderOpen,
+    },
+    {
+      title: 'Explore Runs',
+      description: 'Use the advanced execution browser when you need run-level filters and selection.',
       to: '/browse',
-      action: 'Open Browse',
+      action: 'Open Runs',
       icon: Search,
     },
     {
@@ -57,13 +64,6 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
       to: '/compare',
       action: 'Open Compare',
       icon: GitCompareArrows,
-    },
-    {
-      title: 'Browse Cases',
-      description: 'Discover experiment-level case records and inspect their canonical baselines.',
-      to: '/cases',
-      action: 'Open Cases',
-      icon: FolderOpen,
     },
     {
       title: 'Upload a Simulation',
@@ -80,39 +80,36 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
         <div className="max-w-3xl space-y-5">
           <div className="space-y-3">
             <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
-              Explore E3SM Simulations
+              Find Cases Through Your Runs
             </h1>
             <p className="max-w-2xl text-lg leading-8 text-muted-foreground">
-              SimBoard is a web interface for exploring, comparing, and sharing curated simulations
-              from the Department of Energy&apos;s Energy Exascale Earth System Model.
+              SimBoard is a web interface for finding E3SM cases and reviewing the runs that belong
+              to them. Start from run metadata like HPC username, then move into case-level context.
             </p>
           </div>
 
           <ul className="space-y-2 text-sm leading-6 text-muted-foreground md:text-base">
             <li>
-              Browse cataloged runs across cases, campaigns, configurations, and execution metadata.
+              Filter cases using run metadata such as HPC username, machine, status, and execution context.
             </li>
             <li>
-              Compare simulations side by side to inspect canonical status, versioning, and context.
+              Open case detail pages to inspect canonical baselines and nested run summaries.
             </li>
-            <li>Review recent submissions and the machines used to run cataloged E3SM datasets.</li>
+            <li>Use the runs workspace when you need execution-level browsing, selection, and compare setup.</li>
           </ul>
 
           <div className="flex flex-wrap gap-3">
             <Button asChild>
-              <Link to="/browse">Browse Simulations</Link>
+              <Link to="/cases">Browse Cases</Link>
             </Button>
-            <Button asChild>
-              <Link to="/upload">Upload Simulation</Link>
+            <Button asChild variant="secondary">
+              <Link to="/browse">Open Runs</Link>
             </Button>
             <Button asChild variant="secondary">
               <Link to="/compare">Compare</Link>
             </Button>
             <Button asChild variant="secondary">
-              <Link to="/cases">Browse Cases</Link>
-            </Button>
-            <Button asChild variant="secondary">
-              <Link to="/simulations">All Simulations</Link>
+              <Link to="/upload">Upload Simulation</Link>
             </Button>
           </div>
 
@@ -192,11 +189,11 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
           <div className="space-y-1">
             <h2 className="text-2xl font-bold">Recently Added Simulations</h2>
             <p className="text-muted-foreground">
-              Preview recent catalog activity and jump directly into the full simulation index.
+              Preview recent catalog activity and jump into the run-level workspace when needed.
             </p>
           </div>
           <Button asChild variant="secondary">
-            <Link to="/simulations">View All Simulations</Link>
+            <Link to="/browse">Open Runs</Link>
           </Button>
         </div>
         <div className="rounded-xl border border-muted bg-white p-4 shadow-sm md:p-6">

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -1,4 +1,4 @@
-import { FolderOpen, GitCompareArrows, Search, Upload } from 'lucide-react';
+import { ArrowRight, FolderOpen, GitCompareArrows, Search, Upload } from 'lucide-react';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -12,7 +12,6 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { TableCellText } from '@/components/ui/table-cell-text';
-import LatestSimulationsTable from '@/features/home/components/LatestSimulationsTable';
 import type { Machine, SimulationOut } from '@/types/index';
 
 interface HomePageProps {
@@ -21,14 +20,70 @@ interface HomePageProps {
 }
 
 export const HomePage = ({ simulations, machines }: HomePageProps) => {
-  const latestSimulations = useMemo(
+  const latestSubmission = useMemo(
     () =>
       [...simulations]
-        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-        .slice(0, 6),
+        .map((simulation) => simulation.createdAt)
+        .sort((left, right) => new Date(right).getTime() - new Date(left).getTime())[0],
     [simulations],
   );
-  const latestSubmission = latestSimulations[0]?.createdAt;
+  const recentCases = useMemo(() => {
+    const casesById = new Map<
+      string,
+      {
+        id: string;
+        name: string;
+        caseGroup: string | null;
+        machineNames: Set<string>;
+        simulationCount: number;
+        lastUpdated: string;
+      }
+    >();
+
+    for (const simulation of simulations) {
+      const existing = casesById.get(simulation.caseId);
+      const simulationUpdatedAt = simulation.updatedAt ?? simulation.createdAt;
+
+      if (existing) {
+        existing.simulationCount += 1;
+        if (simulation.machine?.name) {
+          existing.machineNames.add(simulation.machine.name);
+        }
+        if (new Date(simulationUpdatedAt).getTime() > new Date(existing.lastUpdated).getTime()) {
+          existing.lastUpdated = simulationUpdatedAt;
+        }
+        continue;
+      }
+
+      casesById.set(simulation.caseId, {
+        id: simulation.caseId,
+        name: simulation.caseName,
+        caseGroup: simulation.caseGroup ?? null,
+        machineNames: simulation.machine?.name ? new Set([simulation.machine.name]) : new Set(),
+        simulationCount: 1,
+        lastUpdated: simulationUpdatedAt,
+      });
+    }
+
+    const summarizeMachines = (machineNames: Set<string>) => {
+      const names = [...machineNames].sort((left, right) =>
+        left.localeCompare(right, undefined, { sensitivity: 'base' }),
+      );
+
+      if (names.length === 0) return '—';
+      if (names.length === 1) return names[0];
+
+      return `${names[0]} +${names.length - 1}`;
+    };
+
+    return [...casesById.values()]
+      .sort((left, right) => new Date(right.lastUpdated).getTime() - new Date(left.lastUpdated).getTime())
+      .slice(0, 6)
+      .map((caseRecord) => ({
+        ...caseRecord,
+        machineSummary: summarizeMachines(caseRecord.machineNames),
+      }));
+  }, [simulations]);
   const machineSimulationCounts = new Map<Machine['id'], number>();
   for (const simulation of simulations) {
     machineSimulationCounts.set(
@@ -188,17 +243,51 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
       <section className="mx-auto mt-10 w-full max-w-7xl">
         <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
           <div className="space-y-1">
-            <h2 className="text-2xl font-bold">Recently Added Simulations</h2>
+            <h2 className="text-2xl font-bold">Recent Cases</h2>
             <p className="text-muted-foreground">
-              Preview recent catalog activity and jump into the run-level workspace when needed.
+              Open recently active case pages and move from grouped simulation context into run details.
             </p>
           </div>
           <Button asChild variant="secondary">
-            <Link to="/browse">Open Runs</Link>
+            <Link to="/cases">Browse Cases</Link>
           </Button>
         </div>
         <div className="rounded-xl border border-muted bg-white p-4 shadow-sm md:p-6">
-          <LatestSimulationsTable latestSimulations={latestSimulations} />
+          <Table className="table-fixed">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Case Name</TableHead>
+                <TableHead>Case Group</TableHead>
+                <TableHead>Machines</TableHead>
+                <TableHead>Runs</TableHead>
+                <TableHead>Last Updated</TableHead>
+                <TableHead>Details</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {recentCases.map((caseRecord) => (
+                <TableRow key={caseRecord.id}>
+                  <TableCell className="align-top">
+                    <TableCellText value={caseRecord.name} lines={1} />
+                  </TableCell>
+                  <TableCell>{caseRecord.caseGroup ?? '—'}</TableCell>
+                  <TableCell className="align-top">
+                    <TableCellText value={caseRecord.machineSummary} lines={1} />
+                  </TableCell>
+                  <TableCell>{caseRecord.simulationCount}</TableCell>
+                  <TableCell>{new Date(caseRecord.lastUpdated).toLocaleDateString()}</TableCell>
+                  <TableCell>
+                    <Button asChild variant="outline" size="sm" className="h-8 gap-1 px-2">
+                      <Link to={`/cases/${caseRecord.id}`}>
+                        Open
+                        <ArrowRight className="h-4 w-4" />
+                      </Link>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         </div>
       </section>
 

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -20,6 +20,9 @@ interface HomePageProps {
 }
 
 export const HomePage = ({ simulations, machines }: HomePageProps) => {
+  const totalCases = useMemo(() => new Set(simulations.map((simulation) => simulation.caseId)).size, [
+    simulations,
+  ]);
   const latestSubmission = useMemo(
     () =>
       [...simulations]
@@ -138,8 +141,8 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
       icon: GitCompareArrows,
     },
     {
-      title: 'Upload a Simulation',
-      description: 'Submit new simulation metadata to share results and preserve provenance.',
+      title: 'Upload a Case',
+      description: 'Submit new case metadata to share results and preserve provenance.',
       to: '/upload',
       action: 'Open Upload',
       icon: Upload,
@@ -189,13 +192,21 @@ export const HomePage = ({ simulations, machines }: HomePageProps) => {
           <div className="grid overflow-hidden rounded-xl border border-muted sm:grid-cols-2 xl:grid-cols-4">
             <div className="flex min-h-28 flex-col gap-4 border-b border-muted px-4 py-4 sm:border-r xl:border-b-0">
               <p className="min-h-[2.75rem] text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                Total Cases
+              </p>
+              <p className="mt-auto text-xl font-semibold leading-none text-foreground sm:text-2xl">
+                {totalCases}
+              </p>
+            </div>
+            <div className="flex min-h-28 flex-col gap-4 border-b border-muted px-4 py-4 sm:border-r xl:border-b-0">
+              <p className="min-h-[2.75rem] text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                 Total Simulations
               </p>
               <p className="mt-auto text-xl font-semibold leading-none text-foreground sm:text-2xl">
                 {simulations.length}
               </p>
             </div>
-            <div className="flex min-h-28 flex-col gap-4 border-b border-muted px-4 py-4 xl:border-b-0 xl:border-r">
+            <div className="flex min-h-28 flex-col gap-4 border-b border-muted px-4 py-4 sm:border-r xl:border-b-0 xl:border-r">
               <p className="min-h-[2.75rem] text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                 Machines
               </p>

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -1,11 +1,12 @@
 import { ArrowLeft, Share2 } from 'lucide-react';
 import { useMemo } from 'react';
-import { Link, useLocation, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Table,
   TableBody,
@@ -34,11 +35,20 @@ const MetadataRow = ({ label, value }: { label: string; value: React.ReactNode }
 
 interface CaseDetailsPageProps {
   simulations: SimulationOut[];
+  selectedSimulationIds: string[];
+  setSelectedSimulationIds: (ids: string[]) => void;
 }
 
-export const CaseDetailsPage = ({ simulations: allSimulations }: CaseDetailsPageProps) => {
+const MAX_SELECTION = 5;
+
+export const CaseDetailsPage = ({
+  simulations: allSimulations,
+  selectedSimulationIds,
+  setSelectedSimulationIds,
+}: CaseDetailsPageProps) => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
+  const navigate = useNavigate();
   const { data: caseRecord, loading, error } = useCase(id ?? '');
   const currentPath = `${location.pathname}${location.search}`;
   const state = location.state as { from?: string } | null;
@@ -119,6 +129,20 @@ export const CaseDetailsPage = ({ simulations: allSimulations }: CaseDetailsPage
     summary: simulation,
     details: simulationDetailsById.get(simulation.id),
   }));
+  const isCompareButtonDisabled = selectedSimulationIds.length < 2;
+
+  const toggleSimulationSelection = (simulationId: string) => {
+    if (selectedSimulationIds.includes(simulationId)) {
+      setSelectedSimulationIds(selectedSimulationIds.filter((id) => id !== simulationId));
+      return;
+    }
+
+    if (selectedSimulationIds.length >= MAX_SELECTION) {
+      return;
+    }
+
+    setSelectedSimulationIds([...selectedSimulationIds, simulationId]);
+  };
 
   return (
     <div className="mx-auto w-full max-w-[1200px] space-y-6 px-6 py-8">
@@ -159,7 +183,7 @@ export const CaseDetailsPage = ({ simulations: allSimulations }: CaseDetailsPage
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-base">Canonical Simulation</CardTitle>
+            <CardTitle className="text-base">Baseline Simulation</CardTitle>
           </CardHeader>
           <CardContent>
             {canonicalSimulation ? (
@@ -203,11 +227,40 @@ export const CaseDetailsPage = ({ simulations: allSimulations }: CaseDetailsPage
           </p>
         </div>
 
+        <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-slate-50/70 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Button
+              type="button"
+              onClick={() => navigate('/compare')}
+              disabled={isCompareButtonDisabled}
+            >
+              Compare Selected
+            </Button>
+            <div className="text-sm text-slate-600">
+              Selected <span className="font-semibold text-slate-950">{selectedSimulationIds.length}</span>{' '}
+              / {MAX_SELECTION}
+            </div>
+          </div>
+
+          {selectedSimulationIds.length > 0 && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="text-slate-600 hover:text-slate-900"
+              onClick={() => setSelectedSimulationIds([])}
+            >
+              Deselect all
+            </Button>
+          )}
+        </div>
+
         <div className="overflow-hidden rounded-md border bg-background">
-          <div className="overflow-x-auto">
+          <div className="max-h-[32rem] overflow-auto">
             <Table>
               <TableHeader>
                 <TableRow>
+                  <TableHead className="w-12">Select</TableHead>
                   <TableHead>Execution ID</TableHead>
                   <TableHead>Change Count</TableHead>
                   <TableHead>Simulation Type</TableHead>
@@ -221,6 +274,17 @@ export const CaseDetailsPage = ({ simulations: allSimulations }: CaseDetailsPage
               <TableBody>
                 {simulations.map(({ summary, details }) => (
                   <TableRow key={summary.id}>
+                    <TableCell className="align-top">
+                      <Checkbox
+                        checked={selectedSimulationIds.includes(summary.id)}
+                        disabled={
+                          !selectedSimulationIds.includes(summary.id) &&
+                          selectedSimulationIds.length >= MAX_SELECTION
+                        }
+                        onCheckedChange={() => toggleSimulationSelection(summary.id)}
+                        aria-label={`Select ${summary.executionId} for compare`}
+                      />
+                    </TableCell>
                     <TableCell className="align-top">
                       <Link
                         to={`/simulations/${summary.id}`}

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -1,7 +1,9 @@
+import { Share2 } from 'lucide-react';
 import { Link, useParams } from 'react-router-dom';
 
 import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Table,
@@ -18,6 +20,7 @@ import {
   sortSimulationSummaries,
 } from '@/features/simulations/caseUtils';
 import { useCase } from '@/features/simulations/hooks/useCase';
+import { toast } from '@/hooks/use-toast';
 
 const MetadataRow = ({ label, value }: { label: string; value: React.ReactNode }) => (
   <div className="flex items-start justify-between gap-4 border-b border-border/60 py-3 last:border-b-0">
@@ -29,6 +32,40 @@ const MetadataRow = ({ label, value }: { label: string; value: React.ReactNode }
 export const CaseDetailsPage = () => {
   const { id } = useParams<{ id: string }>();
   const { data: caseRecord, loading, error } = useCase(id ?? '');
+
+  const handleShareCase = async () => {
+    if (!id) return;
+
+    const shareUrl = new URL(`/cases/${id}`, window.location.origin).toString();
+    const canUseWebShare = typeof navigator.share === 'function';
+
+    try {
+      if (canUseWebShare) {
+        await navigator.share({
+          title: caseRecord?.name ?? 'SimBoard Case',
+          text: caseRecord?.name ?? 'SimBoard Case',
+          url: shareUrl,
+        });
+      } else {
+        await navigator.clipboard.writeText(shareUrl);
+      }
+
+      toast({
+        title: 'Case link ready',
+        description: canUseWebShare ? 'Share dialog opened.' : 'Case URL copied to clipboard.',
+      });
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return;
+      }
+
+      toast({
+        title: 'Unable to share case',
+        description: 'Try copying the page URL directly from your browser.',
+        variant: 'destructive',
+      });
+    }
+  };
 
   if (!id) {
     return (
@@ -78,7 +115,13 @@ export const CaseDetailsPage = () => {
             </Link>
           </div>
         </div>
-        {caseRecord.caseGroup && <Badge variant="outline">{caseRecord.caseGroup}</Badge>}
+        <div className="flex items-center gap-2 self-start">
+          {caseRecord.caseGroup && <Badge variant="outline">{caseRecord.caseGroup}</Badge>}
+          <Button variant="outline" size="sm" type="button" onClick={handleShareCase}>
+            <Share2 className="h-4 w-4" />
+            Share Case
+          </Button>
+        </div>
       </div>
 
       <div className="grid gap-6 lg:grid-cols-2">

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -129,6 +129,34 @@ export const CaseDetailsPage = ({
     summary: simulation,
     details: simulationDetailsById.get(simulation.id),
   }));
+  const machineSummary = (() => {
+    const names = [
+      ...new Set(
+        simulations
+          .map(({ details }) => details?.machine?.name)
+          .filter((name): name is string => Boolean(name)),
+      ),
+    ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' }));
+
+    if (names.length === 0) return '—';
+    if (names.length === 1) return names[0];
+
+    return `${names[0]} +${names.length - 1}`;
+  })();
+  const hpcUsernameSummary = (() => {
+    const usernames = [
+      ...new Set(
+        simulations
+          .map(({ details }) => details?.hpcUsername)
+          .filter((username): username is string => Boolean(username)),
+      ),
+    ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' }));
+
+    if (usernames.length === 0) return '—';
+    if (usernames.length === 1) return usernames[0];
+
+    return `${usernames[0]} +${usernames.length - 1}`;
+  })();
   const isCompareButtonDisabled = selectedSimulationIds.length < 2;
 
   const toggleSimulationSelection = (simulationId: string) => {
@@ -176,6 +204,8 @@ export const CaseDetailsPage = ({
           <CardContent>
             <MetadataRow label="Case Group" value={caseRecord.caseGroup ?? '—'} />
             <MetadataRow label="Total Simulations" value={caseRecord.simulations.length} />
+            <MetadataRow label="Machines" value={machineSummary} />
+            <MetadataRow label="HPC Usernames" value={hpcUsernameSummary} />
             <MetadataRow label="Created" value={formatCaseDate(caseRecord.createdAt)} />
             <MetadataRow label="Last Updated" value={formatCaseDate(caseRecord.updatedAt)} />
           </CardContent>
@@ -264,8 +294,6 @@ export const CaseDetailsPage = ({
                   <TableHead>Execution ID</TableHead>
                   <TableHead>Changes</TableHead>
                   <TableHead>Initialization</TableHead>
-                  <TableHead>Machine</TableHead>
-                  <TableHead>HPC Username</TableHead>
                   <TableHead>Git Tag</TableHead>
                   <TableHead>Simulation Dates</TableHead>
                   <TableHead>Run Dates</TableHead>
@@ -312,12 +340,6 @@ export const CaseDetailsPage = ({
                     </TableCell>
                     <TableCell className="align-top">
                       <TableCellText value={details?.initializationType ?? '—'} lines={1} />
-                    </TableCell>
-                    <TableCell className="align-top">
-                      <TableCellText value={details?.machine?.name ?? '—'} lines={1} />
-                    </TableCell>
-                    <TableCell className="align-top">
-                      <TableCellText value={details?.hpcUsername ?? '—'} lines={1} />
                     </TableCell>
                     <TableCell className="align-top">
                       <TableCellText value={details?.gitTag ?? '—'} lines={1} />

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -202,10 +202,10 @@ export const CaseDetailsPage = ({
             <CardTitle className="text-base">Case Metadata</CardTitle>
           </CardHeader>
           <CardContent>
-            <MetadataRow label="Case Group" value={caseRecord.caseGroup ?? '—'} />
             <MetadataRow label="Total Simulations" value={caseRecord.simulations.length} />
             <MetadataRow label="Machines" value={machineSummary} />
             <MetadataRow label="HPC Usernames" value={hpcUsernameSummary} />
+            <MetadataRow label="Case Group" value={caseRecord.caseGroup ?? '—'} />
             <MetadataRow label="Created" value={formatCaseDate(caseRecord.createdAt)} />
             <MetadataRow label="Last Updated" value={formatCaseDate(caseRecord.updatedAt)} />
           </CardContent>
@@ -218,15 +218,26 @@ export const CaseDetailsPage = ({
           <CardContent>
             {canonicalSimulation ? (
               <>
+                <p className="mb-4 text-sm leading-6 text-muted-foreground">
+                  This is the first successful run for the case and serves as the baseline used to
+                  compare configuration changes across the other simulations.
+                </p>
                 <MetadataRow
                   label="Execution ID"
                   value={
                     <Link
                       to={`/simulations/${canonicalSimulation.id}`}
                       state={{ from: currentPath }}
-                      className="font-mono text-xs text-blue-600 hover:underline"
+                      className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                     >
                       {canonicalSimulation.executionId}
+                      <span
+                        className="inline-flex items-center"
+                        title="Baseline simulation"
+                        aria-label="Baseline simulation"
+                      >
+                        <Pin className="h-3.5 w-3.5 text-amber-600" />
+                      </span>
                     </Link>
                   }
                 />
@@ -234,7 +245,6 @@ export const CaseDetailsPage = ({
                   label="Status"
                   value={<SimulationStatusBadge status={canonicalSimulation.status} />}
                 />
-                <MetadataRow label="Change Count" value={canonicalSimulation.changeCount} />
                 <MetadataRow
                   label="Simulation Dates"
                   value={formatSimulationDateRange(canonicalSimulation)}

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -1,5 +1,6 @@
-import { Share2 } from 'lucide-react';
-import { Link, useParams } from 'react-router-dom';
+import { ArrowLeft, Share2 } from 'lucide-react';
+import { useMemo } from 'react';
+import { Link, useLocation, useParams } from 'react-router-dom';
 
 import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge';
 import { Badge } from '@/components/ui/badge';
@@ -13,6 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { TableCellText } from '@/components/ui/table-cell-text';
 import {
   formatCaseDate,
   formatSimulationDateRange,
@@ -21,6 +23,7 @@ import {
 } from '@/features/simulations/caseUtils';
 import { useCase } from '@/features/simulations/hooks/useCase';
 import { toast } from '@/hooks/use-toast';
+import type { SimulationOut } from '@/types';
 
 const MetadataRow = ({ label, value }: { label: string; value: React.ReactNode }) => (
   <div className="flex items-start justify-between gap-4 border-b border-border/60 py-3 last:border-b-0">
@@ -29,9 +32,21 @@ const MetadataRow = ({ label, value }: { label: string; value: React.ReactNode }
   </div>
 );
 
-export const CaseDetailsPage = () => {
+interface CaseDetailsPageProps {
+  simulations: SimulationOut[];
+}
+
+export const CaseDetailsPage = ({ simulations: allSimulations }: CaseDetailsPageProps) => {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
   const { data: caseRecord, loading, error } = useCase(id ?? '');
+  const currentPath = `${location.pathname}${location.search}`;
+  const state = location.state as { from?: string } | null;
+  const backHref = typeof state?.from === 'string' ? state.from : '/cases';
+  const simulationDetailsById = useMemo(
+    () => new Map(allSimulations.map((simulation) => [simulation.id, simulation])),
+    [allSimulations],
+  );
 
   const handleShareCase = async () => {
     if (!id) return;
@@ -100,19 +115,24 @@ export const CaseDetailsPage = () => {
   }
 
   const canonicalSimulation = getCanonicalSimulation(caseRecord);
-  const simulations = sortSimulationSummaries(caseRecord.simulations);
+  const simulations = sortSimulationSummaries(caseRecord.simulations).map((simulation) => ({
+    summary: simulation,
+    details: simulationDetailsById.get(simulation.id),
+  }));
 
   return (
     <div className="mx-auto w-full max-w-[1200px] space-y-6 px-6 py-8">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
+          <Button variant="outline" size="sm" asChild className="mb-3">
+            <Link to={backHref}>
+              <ArrowLeft className="h-4 w-4" />
+              Back
+            </Link>
+          </Button>
           <h1 className="text-2xl font-bold">{caseRecord.name}</h1>
           <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
             <span>Case detail</span>
-            <span>•</span>
-            <Link to="/cases" className="text-blue-600 hover:underline">
-              Back to cases
-            </Link>
           </div>
         </div>
         <div className="flex items-center gap-2 self-start">
@@ -149,6 +169,7 @@ export const CaseDetailsPage = () => {
                   value={
                     <Link
                       to={`/simulations/${canonicalSimulation.id}`}
+                      state={{ from: currentPath }}
                       className="font-mono text-xs text-blue-600 hover:underline"
                     >
                       {canonicalSimulation.executionId}
@@ -178,7 +199,7 @@ export const CaseDetailsPage = () => {
         <div>
           <h2 className="text-xl font-semibold">Simulations</h2>
           <p className="text-sm text-muted-foreground">
-            Execution-level summaries for this case. Canonical runs are pinned first.
+            Execution-level summaries for this case. Reference runs are pinned first.
           </p>
         </div>
 
@@ -188,50 +209,45 @@ export const CaseDetailsPage = () => {
               <TableHeader>
                 <TableRow>
                   <TableHead>Execution ID</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Canonical</TableHead>
                   <TableHead>Change Count</TableHead>
+                  <TableHead>Simulation Type</TableHead>
+                  <TableHead>Initialization</TableHead>
+                  <TableHead>Machine</TableHead>
+                  <TableHead>HPC Username</TableHead>
+                  <TableHead>Git Tag</TableHead>
                   <TableHead>Simulation Dates</TableHead>
-                  <TableHead>View Details</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {simulations.map((simulation) => (
-                  <TableRow key={simulation.id}>
+                {simulations.map(({ summary, details }) => (
+                  <TableRow key={summary.id}>
                     <TableCell className="align-top">
                       <Link
-                        to={`/simulations/${simulation.id}`}
+                        to={`/simulations/${summary.id}`}
+                        state={{ from: currentPath }}
                         className="font-mono text-xs text-blue-600 hover:underline"
                       >
-                        {simulation.executionId}
+                        {summary.executionId}
                       </Link>
                     </TableCell>
+                    <TableCell className="align-top">{summary.changeCount}</TableCell>
                     <TableCell className="align-top">
-                      <SimulationStatusBadge status={simulation.status} />
+                      <TableCellText value={details?.simulationType ?? '—'} lines={1} />
                     </TableCell>
                     <TableCell className="align-top">
-                      {simulation.isCanonical ? (
-                        <Badge
-                          variant="outline"
-                          className="border-green-200 bg-green-50 text-green-700"
-                        >
-                          Canonical
-                        </Badge>
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="align-top">{simulation.changeCount}</TableCell>
-                    <TableCell className="align-top">
-                      {formatSimulationDateRange(simulation)}
+                      <TableCellText value={details?.initializationType ?? '—'} lines={1} />
                     </TableCell>
                     <TableCell className="align-top">
-                      <Link
-                        to={`/simulations/${simulation.id}`}
-                        className="text-blue-600 hover:underline"
-                      >
-                        View simulation
-                      </Link>
+                      <TableCellText value={details?.machine?.name ?? '—'} lines={1} />
+                    </TableCell>
+                    <TableCell className="align-top">
+                      <TableCellText value={details?.hpcUsername ?? '—'} lines={1} />
+                    </TableCell>
+                    <TableCell className="align-top">
+                      <TableCellText value={details?.gitTag ?? '—'} lines={1} />
+                    </TableCell>
+                    <TableCell className="align-top">
+                      {formatSimulationDateRange(summary)}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Share2 } from 'lucide-react';
+import { ArrowLeft, Pin, Share2 } from 'lucide-react';
 import { useMemo } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 
@@ -262,13 +262,13 @@ export const CaseDetailsPage = ({
                 <TableRow>
                   <TableHead className="w-12">Select</TableHead>
                   <TableHead>Execution ID</TableHead>
-                  <TableHead>Change Count</TableHead>
-                  <TableHead>Simulation Type</TableHead>
+                  <TableHead>Changes</TableHead>
                   <TableHead>Initialization</TableHead>
                   <TableHead>Machine</TableHead>
                   <TableHead>HPC Username</TableHead>
                   <TableHead>Git Tag</TableHead>
                   <TableHead>Simulation Dates</TableHead>
+                  <TableHead>Run Dates</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -289,14 +289,26 @@ export const CaseDetailsPage = ({
                       <Link
                         to={`/simulations/${summary.id}`}
                         state={{ from: currentPath }}
-                        className="font-mono text-xs text-blue-600 hover:underline"
+                        className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                       >
                         {summary.executionId}
+                        {summary.isCanonical && (
+                          <span
+                            className="inline-flex items-center"
+                            title="Baseline simulation"
+                            aria-label="Baseline simulation"
+                          >
+                            <Pin className="h-3.5 w-3.5 text-amber-600" />
+                          </span>
+                        )}
                       </Link>
                     </TableCell>
-                    <TableCell className="align-top">{summary.changeCount}</TableCell>
                     <TableCell className="align-top">
-                      <TableCellText value={details?.simulationType ?? '—'} lines={1} />
+                      {summary.isCanonical ? (
+                        <span className="text-sm font-medium text-slate-700">Baseline</span>
+                      ) : (
+                        summary.changeCount
+                      )}
                     </TableCell>
                     <TableCell className="align-top">
                       <TableCellText value={details?.initializationType ?? '—'} lines={1} />
@@ -312,6 +324,17 @@ export const CaseDetailsPage = ({
                     </TableCell>
                     <TableCell className="align-top">
                       {formatSimulationDateRange(summary)}
+                    </TableCell>
+                    <TableCell className="align-top">
+                      {details?.runStartDate || details?.runEndDate ? (
+                        <span
+                          title={`${details?.runStartDate ?? '—'} → ${details?.runEndDate ?? '—'}`}
+                        >
+                          {`${details?.runStartDate?.slice(0, 10) ?? '—'} → ${details?.runEndDate?.slice(0, 10) ?? '—'}`}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -1,0 +1,202 @@
+import { Link, useParams } from 'react-router-dom';
+
+import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  formatCaseDate,
+  formatSimulationDateRange,
+  getCanonicalSimulation,
+  sortSimulationSummaries,
+} from '@/features/simulations/caseUtils';
+import { useCase } from '@/features/simulations/hooks/useCase';
+
+const MetadataRow = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <div className="flex items-start justify-between gap-4 border-b border-border/60 py-3 last:border-b-0">
+    <span className="text-sm text-muted-foreground">{label}</span>
+    <div className="text-right text-sm font-medium">{value}</div>
+  </div>
+);
+
+export const CaseDetailsPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const { data: caseRecord, loading, error } = useCase(id ?? '');
+
+  if (!id) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center text-gray-500">Invalid case ID</div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center text-gray-500">Loading case details…</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center text-red-600">Error: {error}</div>
+      </div>
+    );
+  }
+
+  if (!caseRecord) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center text-gray-500">Case not found</div>
+      </div>
+    );
+  }
+
+  const canonicalSimulation = getCanonicalSimulation(caseRecord);
+  const simulations = sortSimulationSummaries(caseRecord.simulations);
+
+  return (
+    <div className="mx-auto w-full max-w-[1200px] space-y-6 px-6 py-8">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">{caseRecord.name}</h1>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <span>Case detail</span>
+            <span>•</span>
+            <Link to="/cases" className="text-blue-600 hover:underline">
+              Back to cases
+            </Link>
+          </div>
+        </div>
+        {caseRecord.caseGroup && <Badge variant="outline">{caseRecord.caseGroup}</Badge>}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Case Metadata</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <MetadataRow label="Case Group" value={caseRecord.caseGroup ?? '—'} />
+            <MetadataRow label="Total Simulations" value={caseRecord.simulations.length} />
+            <MetadataRow label="Created" value={formatCaseDate(caseRecord.createdAt)} />
+            <MetadataRow label="Last Updated" value={formatCaseDate(caseRecord.updatedAt)} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Canonical Simulation</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {canonicalSimulation ? (
+              <>
+                <MetadataRow
+                  label="Execution ID"
+                  value={
+                    <Link
+                      to={`/simulations/${canonicalSimulation.id}`}
+                      className="font-mono text-xs text-blue-600 hover:underline"
+                    >
+                      {canonicalSimulation.executionId}
+                    </Link>
+                  }
+                />
+                <MetadataRow
+                  label="Status"
+                  value={<SimulationStatusBadge status={canonicalSimulation.status} />}
+                />
+                <MetadataRow label="Change Count" value={canonicalSimulation.changeCount} />
+                <MetadataRow
+                  label="Simulation Dates"
+                  value={formatSimulationDateRange(canonicalSimulation)}
+                />
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No canonical simulation is set for this case.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-xl font-semibold">Simulations</h2>
+          <p className="text-sm text-muted-foreground">
+            Execution-level summaries for this case. Canonical runs are pinned first.
+          </p>
+        </div>
+
+        <div className="overflow-hidden rounded-md border bg-background">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Execution ID</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Canonical</TableHead>
+                  <TableHead>Change Count</TableHead>
+                  <TableHead>Simulation Dates</TableHead>
+                  <TableHead>View Details</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {simulations.map((simulation) => (
+                  <TableRow key={simulation.id}>
+                    <TableCell className="align-top">
+                      <Link
+                        to={`/simulations/${simulation.id}`}
+                        className="font-mono text-xs text-blue-600 hover:underline"
+                      >
+                        {simulation.executionId}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="align-top">
+                      <SimulationStatusBadge status={simulation.status} />
+                    </TableCell>
+                    <TableCell className="align-top">
+                      {simulation.isCanonical ? (
+                        <Badge
+                          variant="outline"
+                          className="border-green-200 bg-green-50 text-green-700"
+                        >
+                          Canonical
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="align-top">{simulation.changeCount}</TableCell>
+                    <TableCell className="align-top">
+                      {formatSimulationDateRange(simulation)}
+                    </TableCell>
+                    <TableCell className="align-top">
+                      <Link
+                        to={`/simulations/${simulation.id}`}
+                        className="text-blue-600 hover:underline"
+                      >
+                        View simulation
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -6,9 +6,11 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { Fragment, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
+import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -28,18 +30,64 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { TableCellText } from '@/components/ui/table-cell-text';
-import { formatCaseDate, getCanonicalSimulation } from '@/features/simulations/caseUtils';
+import {
+  formatCaseDate,
+  getCanonicalSimulation,
+} from '@/features/simulations/caseUtils';
 import { useCases } from '@/features/simulations/hooks/useCases';
-import type { CaseOut } from '@/types';
+import type { CaseOut, SimulationOut } from '@/types';
 
 type CanonicalFilter = 'all' | 'with-canonical' | 'without-canonical';
 
-export const CasesPage = () => {
+interface CasesPageProps {
+  simulations: SimulationOut[];
+}
+
+interface CaseSimulationFilters {
+  hpcUsername: string;
+  machineId: string;
+  status: string;
+  campaign: string;
+  simulationType: string;
+  initializationType: string;
+  compiler: string;
+  gitTag: string;
+  createdBy: string;
+}
+
+const createEmptySimulationFilters = (): CaseSimulationFilters => ({
+  hpcUsername: '',
+  machineId: '',
+  status: '',
+  campaign: '',
+  simulationType: '',
+  initializationType: '',
+  compiler: '',
+  gitTag: '',
+  createdBy: '',
+});
+
+const sortStringValues = (values: string[]) =>
+  values.sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' }));
+
+const sortCaseSimulations = (caseSimulations: SimulationOut[]) =>
+  [...caseSimulations].sort((left, right) => {
+    if (left.isCanonical !== right.isCanonical) {
+      return left.isCanonical ? -1 : 1;
+    }
+
+    return new Date(right.simulationStartDate).getTime() - new Date(left.simulationStartDate).getTime();
+  });
+
+export const CasesPage = ({ simulations }: CasesPageProps) => {
   const navigate = useNavigate();
   const { data: cases, loading, error } = useCases();
   const [caseNameFilter, setCaseNameFilter] = useState('');
   const [caseGroupFilter, setCaseGroupFilter] = useState('');
+  const [simulationFilters, setSimulationFilters] =
+    useState<CaseSimulationFilters>(createEmptySimulationFilters);
   const [canonicalFilter, setCanonicalFilter] = useState<CanonicalFilter>('all');
+  const [expandedCaseId, setExpandedCaseId] = useState<string | null>(null);
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'updatedAt', desc: true },
     { id: 'name', desc: false },
@@ -56,6 +104,221 @@ export const CasesPage = () => {
       ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' })),
     [cases],
   );
+  const simulationsByCaseId = useMemo(() => {
+    const caseMap = new Map<string, SimulationOut[]>();
+    for (const simulation of simulations) {
+      const caseSimulations = caseMap.get(simulation.caseId) ?? [];
+      caseSimulations.push(simulation);
+      caseMap.set(simulation.caseId, caseSimulations);
+    }
+
+    return caseMap;
+  }, [simulations]);
+  const hpcUsernames = useMemo(
+    () =>
+      [
+        ...new Set(
+          simulations
+            .map((simulation) => simulation.hpcUsername)
+            .filter((username): username is string => Boolean(username)),
+        ),
+      ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' })),
+    [simulations],
+  );
+  const machineOptions = useMemo(() => {
+    const machineMap = new Map<string, string>();
+
+    for (const simulation of simulations) {
+      if (!simulation.machine?.id) continue;
+      machineMap.set(simulation.machine.id, simulation.machine.name);
+    }
+
+    return Array.from(machineMap, ([value, label]) => ({ value, label })).sort((left, right) =>
+      left.label.localeCompare(right.label, undefined, { sensitivity: 'base' }),
+    );
+  }, [simulations]);
+  const creatorOptions = useMemo(() => {
+    const creatorMap = new Map<string, string>();
+
+    for (const simulation of simulations) {
+      if (!simulation.createdBy) continue;
+      creatorMap.set(simulation.createdBy, simulation.createdByUser?.email ?? simulation.createdBy);
+    }
+
+    return Array.from(creatorMap, ([value, label]) => ({ value, label })).sort((left, right) =>
+      left.label.localeCompare(right.label, undefined, { sensitivity: 'base' }),
+    );
+  }, [simulations]);
+  const statuses = useMemo(
+    () =>
+      sortStringValues(
+        [...new Set(simulations.map((simulation) => simulation.status).filter(Boolean))] as string[],
+      ),
+    [simulations],
+  );
+  const campaigns = useMemo(
+    () =>
+      sortStringValues(
+        [...new Set(simulations.map((simulation) => simulation.campaign).filter(Boolean))] as string[],
+      ),
+    [simulations],
+  );
+  const simulationTypes = useMemo(
+    () =>
+      sortStringValues(
+        [...new Set(simulations.map((simulation) => simulation.simulationType).filter(Boolean))] as string[],
+      ),
+    [simulations],
+  );
+  const initializationTypes = useMemo(
+    () =>
+      sortStringValues(
+        [
+          ...new Set(
+            simulations.map((simulation) => simulation.initializationType).filter(Boolean),
+          ),
+        ] as string[],
+      ),
+    [simulations],
+  );
+  const compilers = useMemo(
+    () =>
+      sortStringValues(
+        [...new Set(simulations.map((simulation) => simulation.compiler).filter(Boolean))] as string[],
+      ),
+    [simulations],
+  );
+  const gitTags = useMemo(
+    () =>
+      sortStringValues(
+        [...new Set(simulations.map((simulation) => simulation.gitTag).filter(Boolean))] as string[],
+      ),
+    [simulations],
+  );
+  const hasActiveSimulationFilters = useMemo(
+    () => Object.values(simulationFilters).some(Boolean),
+    [simulationFilters],
+  );
+  const hasActiveFilters =
+    caseNameFilter.trim().length > 0 ||
+    caseGroupFilter.length > 0 ||
+    canonicalFilter !== 'all' ||
+    hasActiveSimulationFilters;
+  const matchingSimulationsByCaseId = useMemo(() => {
+    const matchingMap = new Map<string, SimulationOut[]>();
+
+    const matchesSimulationFilters = (simulation: SimulationOut) => {
+      if (
+        simulationFilters.hpcUsername &&
+        simulation.hpcUsername !== simulationFilters.hpcUsername
+      ) {
+        return false;
+      }
+      if (simulationFilters.machineId && simulation.machine?.id !== simulationFilters.machineId) {
+        return false;
+      }
+      if (simulationFilters.status && simulation.status !== simulationFilters.status) {
+        return false;
+      }
+      if (simulationFilters.campaign && simulation.campaign !== simulationFilters.campaign) {
+        return false;
+      }
+      if (
+        simulationFilters.simulationType &&
+        simulation.simulationType !== simulationFilters.simulationType
+      ) {
+        return false;
+      }
+      if (
+        simulationFilters.initializationType &&
+        simulation.initializationType !== simulationFilters.initializationType
+      ) {
+        return false;
+      }
+      if (simulationFilters.compiler && simulation.compiler !== simulationFilters.compiler) {
+        return false;
+      }
+      if (simulationFilters.gitTag && simulation.gitTag !== simulationFilters.gitTag) {
+        return false;
+      }
+      if (simulationFilters.createdBy && simulation.createdBy !== simulationFilters.createdBy) {
+        return false;
+      }
+
+      return true;
+    };
+
+    for (const simulation of simulations) {
+      if (!matchesSimulationFilters(simulation)) continue;
+
+      const caseSimulations = matchingMap.get(simulation.caseId) ?? [];
+      caseSimulations.push(simulation);
+      matchingMap.set(simulation.caseId, caseSimulations);
+    }
+
+    return matchingMap;
+  }, [simulationFilters, simulations]);
+  const activeFilterPills = useMemo(() => {
+    const filters: { key: string; label: string; value: string }[] = [];
+    if (caseNameFilter.trim()) filters.push({ key: 'caseName', label: 'Case', value: caseNameFilter.trim() });
+    if (simulationFilters.hpcUsername) {
+      filters.push({ key: 'hpcUsername', label: 'HPC', value: simulationFilters.hpcUsername });
+    }
+    if (simulationFilters.machineId) {
+      filters.push({
+        key: 'machineId',
+        label: 'Machine',
+        value:
+          machineOptions.find((option) => option.value === simulationFilters.machineId)?.label ??
+          simulationFilters.machineId,
+      });
+    }
+    if (simulationFilters.status) {
+      filters.push({ key: 'status', label: 'Status', value: simulationFilters.status });
+    }
+    if (simulationFilters.campaign) {
+      filters.push({ key: 'campaign', label: 'Campaign', value: simulationFilters.campaign });
+    }
+    if (simulationFilters.simulationType) {
+      filters.push({
+        key: 'simulationType',
+        label: 'Type',
+        value: simulationFilters.simulationType,
+      });
+    }
+    if (simulationFilters.initializationType) {
+      filters.push({
+        key: 'initializationType',
+        label: 'Init',
+        value: simulationFilters.initializationType,
+      });
+    }
+    if (simulationFilters.compiler) {
+      filters.push({ key: 'compiler', label: 'Compiler', value: simulationFilters.compiler });
+    }
+    if (simulationFilters.gitTag) {
+      filters.push({ key: 'gitTag', label: 'Tag', value: simulationFilters.gitTag });
+    }
+    if (simulationFilters.createdBy) {
+      filters.push({
+        key: 'createdBy',
+        label: 'Creator',
+        value:
+          creatorOptions.find((option) => option.value === simulationFilters.createdBy)?.label ??
+          simulationFilters.createdBy,
+      });
+    }
+    if (caseGroupFilter) filters.push({ key: 'caseGroup', label: 'Group', value: caseGroupFilter });
+    if (canonicalFilter !== 'all') {
+      filters.push({
+        key: 'canonical',
+        label: 'Canonical',
+        value: canonicalFilter === 'with-canonical' ? 'Present' : 'Missing',
+      });
+    }
+
+    return filters;
+  }, [canonicalFilter, caseGroupFilter, caseNameFilter, creatorOptions, machineOptions, simulationFilters]);
 
   const filteredCases = useMemo(() => {
     const normalizedNameFilter = caseNameFilter.trim().toLowerCase();
@@ -70,20 +333,54 @@ export const CasesPage = () => {
         canonicalFilter === 'all' ||
         (canonicalFilter === 'with-canonical' && hasCanonicalSimulation) ||
         (canonicalFilter === 'without-canonical' && !hasCanonicalSimulation);
+      const matchesSimulationFilters =
+        !hasActiveSimulationFilters ||
+        (matchingSimulationsByCaseId.get(caseRecord.id)?.length ?? 0) > 0;
 
-      return matchesName && matchesGroup && matchesCanonical;
+      return matchesName && matchesGroup && matchesCanonical && matchesSimulationFilters;
     });
-  }, [cases, caseGroupFilter, canonicalFilter, caseNameFilter]);
+  }, [
+    caseGroupFilter,
+    cases,
+    canonicalFilter,
+    caseNameFilter,
+    hasActiveSimulationFilters,
+    matchingSimulationsByCaseId,
+  ]);
 
   const columns = useMemo<ColumnDef<CaseOut>[]>(
     () => [
+      {
+        id: 'expand',
+        header: '',
+        enableSorting: false,
+        cell: ({ row }) => {
+          const isExpanded = expandedCaseId === row.original.id;
+
+          return (
+            <Button
+              variant="ghost"
+              size="icon"
+              type="button"
+              className="h-8 w-8"
+              aria-label={isExpanded ? 'Collapse simulations' : 'Expand simulations'}
+              onClick={(event) => {
+                event.stopPropagation();
+                setExpandedCaseId((current) => (current === row.original.id ? null : row.original.id));
+              }}
+            >
+              {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+            </Button>
+          );
+        },
+      },
       {
         accessorKey: 'name',
         header: 'Case Name',
         cell: ({ row }) => (
           <Link
             to={`/cases/${row.original.id}`}
-            className="block max-w-full truncate font-medium text-blue-600 hover:underline"
+            className="block max-w-[28rem] truncate font-medium text-blue-600 hover:underline"
             title={row.original.name}
             onClick={(event) => event.stopPropagation()}
           >
@@ -123,7 +420,20 @@ export const CasesPage = () => {
         id: 'simulationCount',
         header: 'Total Simulations',
         accessorFn: (caseRecord) => caseRecord.simulations.length,
-        cell: ({ row }) => <Badge variant="secondary">{row.original.simulations.length}</Badge>,
+        cell: ({ row }) => {
+          const totalSimulations =
+            simulationsByCaseId.get(row.original.id)?.length ?? row.original.simulations.length;
+          const matchingSimulations = matchingSimulationsByCaseId.get(row.original.id)?.length ?? 0;
+
+          return hasActiveSimulationFilters ? (
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary">{matchingSimulations}</Badge>
+              <span className="text-xs text-muted-foreground">of {totalSimulations}</span>
+            </div>
+          ) : (
+            <Badge variant="secondary">{totalSimulations}</Badge>
+          );
+        },
       },
       {
         accessorKey: 'updatedAt',
@@ -141,7 +451,7 @@ export const CasesPage = () => {
         ),
       },
     ],
-    [],
+    [expandedCaseId, hasActiveSimulationFilters, matchingSimulationsByCaseId, simulationsByCaseId],
   );
 
   const table = useReactTable({
@@ -159,6 +469,93 @@ export const CasesPage = () => {
       },
     },
   });
+
+  const renderExpandedContent = (caseRecord: CaseOut) => {
+    const allCaseSimulations = sortCaseSimulations(simulationsByCaseId.get(caseRecord.id) ?? []);
+    const matchingCaseSimulations = sortCaseSimulations(
+      matchingSimulationsByCaseId.get(caseRecord.id) ?? [],
+    );
+    const simulations =
+      hasActiveSimulationFilters ? matchingCaseSimulations : allCaseSimulations;
+
+    return (
+      <div className="space-y-3 bg-muted/20 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium">Simulation Summaries</p>
+            <p className="text-xs text-muted-foreground">
+              {hasActiveSimulationFilters
+                ? `${matchingCaseSimulations.length} of ${allCaseSimulations.length} runs match the current filters.`
+                : 'Canonical simulations are pinned first. Open the case page for full context.'}
+            </p>
+          </div>
+          <Button variant="outline" size="sm" asChild>
+            <Link to={`/cases/${caseRecord.id}`}>Open case page</Link>
+          </Button>
+        </div>
+
+        <div className="overflow-hidden rounded-md border bg-background">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Execution ID</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Canonical</TableHead>
+                  <TableHead>Change Count</TableHead>
+                  <TableHead>Simulation Dates</TableHead>
+                  <TableHead>View Details</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {simulations.map((simulation) => (
+                  <TableRow key={simulation.id}>
+                    <TableCell className="align-top">
+                      <Link
+                        to={`/simulations/${simulation.id}`}
+                        className="font-mono text-xs text-blue-600 hover:underline"
+                      >
+                        {simulation.executionId}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="align-top">
+                      <SimulationStatusBadge status={simulation.status} />
+                    </TableCell>
+                    <TableCell className="align-top">
+                      {simulation.isCanonical ? (
+                        <Badge
+                          variant="outline"
+                          className="border-green-200 bg-green-50 text-green-700"
+                        >
+                          Canonical
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="align-top">{simulation.changeCount}</TableCell>
+                    <TableCell className="align-top">
+                      {`${formatCaseDate(simulation.simulationStartDate)} → ${formatCaseDate(
+                        simulation.simulationEndDate ?? null,
+                      )}`}
+                    </TableCell>
+                    <TableCell className="align-top">
+                      <Link
+                        to={`/simulations/${simulation.id}`}
+                        className="text-blue-600 hover:underline"
+                      >
+                        View simulation
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      </div>
+    );
+  };
 
   if (loading) {
     return (
@@ -182,7 +579,7 @@ export const CasesPage = () => {
         <div>
           <h1 className="text-2xl font-bold">Cases</h1>
           <p className="text-sm text-muted-foreground">
-            Browse experiment-level records, inspect canonical baselines, and drill into each case.
+            Discover cases through run metadata like HPC username, machine, status, and version context.
           </p>
         </div>
         <div className="text-sm text-muted-foreground">
@@ -200,6 +597,213 @@ export const CasesPage = () => {
           }}
           className="w-full md:w-[320px]"
         />
+
+        <Select
+          value={simulationFilters.hpcUsername || '__all__'}
+          onValueChange={(value) => {
+            setSimulationFilters((current) => ({
+              ...current,
+              hpcUsername: value === '__all__' ? '' : value,
+            }));
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue placeholder="All HPC usernames" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All HPC usernames</SelectItem>
+            {hpcUsernames.map((username) => (
+              <SelectItem key={username} value={username}>
+                {username}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={simulationFilters.machineId || '__all__'}
+          onValueChange={(value) => {
+            setSimulationFilters((current) => ({
+              ...current,
+              machineId: value === '__all__' ? '' : value,
+            }));
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue placeholder="All machines" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All machines</SelectItem>
+            {machineOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={simulationFilters.status || '__all__'}
+          onValueChange={(value) => {
+            setSimulationFilters((current) => ({
+              ...current,
+              status: value === '__all__' ? '' : value,
+            }));
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All statuses</SelectItem>
+            {statuses.map((status) => (
+              <SelectItem key={status} value={status}>
+                {status}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={simulationFilters.campaign || '__all__'}
+          onValueChange={(value) => {
+            setSimulationFilters((current) => ({
+              ...current,
+              campaign: value === '__all__' ? '' : value,
+            }));
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue placeholder="All campaigns" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All campaigns</SelectItem>
+            {campaigns.map((campaign) => (
+              <SelectItem key={campaign} value={campaign}>
+                {campaign}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={simulationFilters.simulationType || '__all__'}
+          onValueChange={(value) => {
+            setSimulationFilters((current) => ({
+              ...current,
+              simulationType: value === '__all__' ? '' : value,
+            }));
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All types</SelectItem>
+            {simulationTypes.map((simulationType) => (
+              <SelectItem key={simulationType} value={simulationType}>
+                {simulationType}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={simulationFilters.initializationType || '__all__'}
+          onValueChange={(value) => {
+            setSimulationFilters((current) => ({
+              ...current,
+              initializationType: value === '__all__' ? '' : value,
+            }));
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue placeholder="All init types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All init types</SelectItem>
+            {initializationTypes.map((initializationType) => (
+              <SelectItem key={initializationType} value={initializationType}>
+                {initializationType}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={simulationFilters.compiler || '__all__'}
+          onValueChange={(value) => {
+            setSimulationFilters((current) => ({
+              ...current,
+              compiler: value === '__all__' ? '' : value,
+            }));
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue placeholder="All compilers" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All compilers</SelectItem>
+            {compilers.map((compiler) => (
+              <SelectItem key={compiler} value={compiler}>
+                {compiler}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={simulationFilters.gitTag || '__all__'}
+          onValueChange={(value) => {
+            setSimulationFilters((current) => ({
+              ...current,
+              gitTag: value === '__all__' ? '' : value,
+            }));
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue placeholder="All tags" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All tags</SelectItem>
+            {gitTags.map((gitTag) => (
+              <SelectItem key={gitTag} value={gitTag}>
+                {gitTag}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={simulationFilters.createdBy || '__all__'}
+          onValueChange={(value) => {
+            setSimulationFilters((current) => ({
+              ...current,
+              createdBy: value === '__all__' ? '' : value,
+            }));
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue placeholder="All creators" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All creators</SelectItem>
+            {creatorOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
         <Select
           value={caseGroupFilter || '__all__'}
@@ -237,7 +841,37 @@ export const CasesPage = () => {
             <SelectItem value="without-canonical">Canonical missing</SelectItem>
           </SelectContent>
         </Select>
+
+        <Button
+          variant="outline"
+          size="sm"
+          type="button"
+          onClick={() => {
+            setCaseNameFilter('');
+            setCaseGroupFilter('');
+            setSimulationFilters(createEmptySimulationFilters());
+            setCanonicalFilter('all');
+            table.setPageIndex(0);
+          }}
+          disabled={!hasActiveFilters}
+        >
+          Clear filters
+        </Button>
       </div>
+
+      {hasActiveFilters && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border bg-background p-3">
+          {activeFilterPills.map((filter) => (
+            <span
+              key={`${filter.key}-${filter.value}`}
+              className="inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
+            >
+              <span className="mr-2 text-xs font-medium text-slate-500">{filter.label}:</span>
+              <span className="font-medium">{filter.value}</span>
+            </span>
+          ))}
+        </div>
+      )}
 
       <div className="overflow-hidden rounded-md border bg-background">
         <div className="overflow-x-auto">
@@ -267,19 +901,31 @@ export const CasesPage = () => {
             </TableHeader>
             <TableBody>
               {table.getRowModel().rows.length > 0 ? (
-                table.getRowModel().rows.map((row) => (
-                  <TableRow
-                    key={row.id}
-                    className="cursor-pointer hover:bg-muted/40"
-                    onClick={() => navigate(`/cases/${row.original.id}`)}
-                  >
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id} className="align-top">
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))
+                table.getRowModel().rows.map((row) => {
+                  const isExpanded = expandedCaseId === row.original.id;
+
+                  return (
+                    <Fragment key={row.id}>
+                      <TableRow
+                        className="cursor-pointer hover:bg-muted/40"
+                        onClick={() => navigate(`/cases/${row.original.id}`)}
+                      >
+                        {row.getVisibleCells().map((cell) => (
+                          <TableCell key={cell.id} className="align-top">
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                      {isExpanded && (
+                        <TableRow className="hover:bg-transparent">
+                          <TableCell colSpan={columns.length} className="p-0">
+                            {renderExpandedContent(row.original)}
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </Fragment>
+                  );
+                })
               ) : (
                 <TableRow>
                   <TableCell

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -6,7 +6,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { ChevronDown, ChevronRight, Search, SlidersHorizontal, X } from 'lucide-react';
+import { ChevronDown, ChevronRight, Pin, Search, SlidersHorizontal, X } from 'lucide-react';
 import { Fragment, useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
@@ -537,16 +537,8 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         cell: ({ row }) => {
           const totalSimulations =
             simulationsByCaseId.get(row.original.id)?.length ?? row.original.simulations.length;
-          const matchingSimulations = matchingSimulationsByCaseId.get(row.original.id)?.length ?? 0;
 
-          return hasActiveSimulationFilters ? (
-            <div className="flex items-center gap-2">
-              <Badge variant="secondary">{matchingSimulations}</Badge>
-              <span className="text-xs text-muted-foreground">of {totalSimulations}</span>
-            </div>
-          ) : (
-            <Badge variant="secondary">{totalSimulations}</Badge>
-          );
+          return <Badge variant="secondary">{totalSimulations}</Badge>;
         },
       },
       {
@@ -577,8 +569,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
       caseMachineSummaries,
       currentPath,
       expandedCaseId,
-      hasActiveSimulationFilters,
-      matchingSimulationsByCaseId,
       simulationsByCaseId,
     ],
   );
@@ -676,9 +666,18 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                       <Link
                         to={`/simulations/${simulation.id}`}
                         state={{ from: currentPath }}
-                        className="font-mono text-xs text-blue-600 hover:underline"
+                        className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                       >
                         {simulation.executionId}
+                        {simulation.isCanonical && (
+                          <span
+                            className="inline-flex items-center"
+                            title="Baseline simulation"
+                            aria-label="Baseline simulation"
+                          >
+                            <Pin className="h-3.5 w-3.5 text-amber-600" />
+                          </span>
+                        )}
                       </Link>
                     </TableCell>
                     <TableCell className="align-top">

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -659,7 +659,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         </div>
 
         <div className="overflow-hidden rounded-md border bg-background">
-          <div className="overflow-x-auto">
+          <div className="max-h-[26rem] overflow-auto">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -1,0 +1,326 @@
+import type { ColumnDef, SortingState } from '@tanstack/react-table';
+import {
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { TableCellText } from '@/components/ui/table-cell-text';
+import { formatCaseDate, getCanonicalSimulation } from '@/features/simulations/caseUtils';
+import { useCases } from '@/features/simulations/hooks/useCases';
+import type { CaseOut } from '@/types';
+
+type CanonicalFilter = 'all' | 'with-canonical' | 'without-canonical';
+
+export const CasesPage = () => {
+  const navigate = useNavigate();
+  const { data: cases, loading, error } = useCases();
+  const [caseNameFilter, setCaseNameFilter] = useState('');
+  const [caseGroupFilter, setCaseGroupFilter] = useState('');
+  const [canonicalFilter, setCanonicalFilter] = useState<CanonicalFilter>('all');
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'updatedAt', desc: true },
+    { id: 'name', desc: false },
+  ]);
+
+  const caseGroups = useMemo(
+    () =>
+      [
+        ...new Set(
+          cases
+            .map((caseRecord) => caseRecord.caseGroup)
+            .filter((group): group is string => Boolean(group)),
+        ),
+      ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' })),
+    [cases],
+  );
+
+  const filteredCases = useMemo(() => {
+    const normalizedNameFilter = caseNameFilter.trim().toLowerCase();
+
+    return cases.filter((caseRecord) => {
+      const matchesName =
+        normalizedNameFilter.length === 0 ||
+        caseRecord.name.toLowerCase().includes(normalizedNameFilter);
+      const matchesGroup = !caseGroupFilter || caseRecord.caseGroup === caseGroupFilter;
+      const hasCanonicalSimulation = caseRecord.canonicalSimulationId != null;
+      const matchesCanonical =
+        canonicalFilter === 'all' ||
+        (canonicalFilter === 'with-canonical' && hasCanonicalSimulation) ||
+        (canonicalFilter === 'without-canonical' && !hasCanonicalSimulation);
+
+      return matchesName && matchesGroup && matchesCanonical;
+    });
+  }, [cases, caseGroupFilter, canonicalFilter, caseNameFilter]);
+
+  const columns = useMemo<ColumnDef<CaseOut>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        header: 'Case Name',
+        cell: ({ row }) => (
+          <Link
+            to={`/cases/${row.original.id}`}
+            className="block max-w-full truncate font-medium text-blue-600 hover:underline"
+            title={row.original.name}
+            onClick={(event) => event.stopPropagation()}
+          >
+            {row.original.name}
+          </Link>
+        ),
+      },
+      {
+        accessorKey: 'caseGroup',
+        header: 'Case Group',
+        cell: ({ row }) => <TableCellText value={row.original.caseGroup ?? '—'} />,
+      },
+      {
+        id: 'canonicalSimulation',
+        header: 'Canonical Simulation',
+        accessorFn: (caseRecord) => getCanonicalSimulation(caseRecord)?.executionId ?? '—',
+        cell: ({ row }) => {
+          const canonicalSimulation = getCanonicalSimulation(row.original);
+
+          if (!canonicalSimulation) {
+            return <span className="text-muted-foreground">—</span>;
+          }
+
+          return (
+            <Link
+              to={`/simulations/${canonicalSimulation.id}`}
+              className="font-mono text-xs text-blue-600 hover:underline"
+              title={canonicalSimulation.executionId}
+              onClick={(event) => event.stopPropagation()}
+            >
+              {canonicalSimulation.executionId}
+            </Link>
+          );
+        },
+      },
+      {
+        id: 'simulationCount',
+        header: 'Total Simulations',
+        accessorFn: (caseRecord) => caseRecord.simulations.length,
+        cell: ({ row }) => <Badge variant="secondary">{row.original.simulations.length}</Badge>,
+      },
+      {
+        accessorKey: 'updatedAt',
+        header: 'Last Updated',
+        cell: ({ row }) => formatCaseDate(row.original.updatedAt),
+      },
+      {
+        id: 'details',
+        header: 'Details',
+        enableSorting: false,
+        cell: ({ row }) => (
+          <Button variant="outline" size="sm" asChild onClick={(event) => event.stopPropagation()}>
+            <Link to={`/cases/${row.original.id}`}>View case</Link>
+          </Button>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const table = useReactTable({
+    data: filteredCases,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: {
+      pagination: {
+        pageIndex: 0,
+        pageSize: 25,
+      },
+    },
+  });
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center text-gray-500">Loading cases…</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center text-red-600">Error: {error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-[1400px] space-y-6 px-8 py-8">
+      <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Cases</h1>
+          <p className="text-sm text-muted-foreground">
+            Browse experiment-level records, inspect canonical baselines, and drill into each case.
+          </p>
+        </div>
+        <div className="text-sm text-muted-foreground">
+          {filteredCases.length} of {cases.length} cases
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 rounded-md bg-muted p-4">
+        <Input
+          placeholder="Search case name…"
+          value={caseNameFilter}
+          onChange={(event) => {
+            setCaseNameFilter(event.target.value);
+            table.setPageIndex(0);
+          }}
+          className="w-full md:w-[320px]"
+        />
+
+        <Select
+          value={caseGroupFilter || '__all__'}
+          onValueChange={(value) => {
+            setCaseGroupFilter(value === '__all__' ? '' : value);
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue placeholder="All case groups" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All case groups</SelectItem>
+            {caseGroups.map((group) => (
+              <SelectItem key={group} value={group}>
+                {group}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={canonicalFilter}
+          onValueChange={(value: CanonicalFilter) => {
+            setCanonicalFilter(value);
+            table.setPageIndex(0);
+          }}
+        >
+          <SelectTrigger className="w-full md:w-[220px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All canonical states</SelectItem>
+            <SelectItem value="with-canonical">Canonical present</SelectItem>
+            <SelectItem value="without-canonical">Canonical missing</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="overflow-hidden rounded-md border bg-background">
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder ? null : (
+                        <button
+                          type="button"
+                          className={
+                            header.column.getCanSort() ? 'select-none text-left' : 'text-left'
+                          }
+                          onClick={header.column.getToggleSortingHandler()}
+                        >
+                          {flexRender(header.column.columnDef.header, header.getContext())}
+                          {header.column.getIsSorted() === 'asc' && ' ▲'}
+                          {header.column.getIsSorted() === 'desc' && ' ▼'}
+                        </button>
+                      )}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows.length > 0 ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className="cursor-pointer hover:bg-muted/40"
+                    onClick={() => navigate(`/cases/${row.original.id}`)}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id} className="align-top">
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={columns.length}
+                    className="py-10 text-center text-muted-foreground"
+                  >
+                    No cases match the current filters.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
+        <div>
+          Showing {table.getRowModel().rows.length} of {filteredCases.length} filtered cases
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <span>
+            Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount() || 1}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -6,13 +6,13 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight, Search, SlidersHorizontal, X } from 'lucide-react';
 import { Fragment, useMemo, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
-import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -35,9 +35,22 @@ import {
   getCanonicalSimulation,
 } from '@/features/simulations/caseUtils';
 import { useCases } from '@/features/simulations/hooks/useCases';
+import { cn } from '@/lib/utils';
 import type { CaseOut, SimulationOut } from '@/types';
 
 type CanonicalFilter = 'all' | 'with-canonical' | 'without-canonical';
+type ActiveFilterKey =
+  | 'caseName'
+  | 'hpcUsername'
+  | 'machineId'
+  | 'campaign'
+  | 'simulationType'
+  | 'initializationType'
+  | 'compiler'
+  | 'gitTag'
+  | 'createdBy'
+  | 'caseGroup'
+  | 'canonical';
 
 interface CasesPageProps {
   simulations: SimulationOut[];
@@ -46,7 +59,6 @@ interface CasesPageProps {
 interface CaseSimulationFilters {
   hpcUsername: string;
   machineId: string;
-  status: string;
   campaign: string;
   simulationType: string;
   initializationType: string;
@@ -55,10 +67,20 @@ interface CaseSimulationFilters {
   createdBy: string;
 }
 
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface ActiveFilterPill {
+  key: ActiveFilterKey;
+  label: string;
+  value: string;
+}
+
 const createEmptySimulationFilters = (): CaseSimulationFilters => ({
   hpcUsername: '',
   machineId: '',
-  status: '',
   campaign: '',
   simulationType: '',
   initializationType: '',
@@ -80,13 +102,13 @@ const sortCaseSimulations = (caseSimulations: SimulationOut[]) =>
   });
 
 export const CasesPage = ({ simulations }: CasesPageProps) => {
-  const navigate = useNavigate();
   const { data: cases, loading, error } = useCases();
   const [caseNameFilter, setCaseNameFilter] = useState('');
   const [caseGroupFilter, setCaseGroupFilter] = useState('');
   const [simulationFilters, setSimulationFilters] =
     useState<CaseSimulationFilters>(createEmptySimulationFilters);
   const [canonicalFilter, setCanonicalFilter] = useState<CanonicalFilter>('all');
+  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const [expandedCaseId, setExpandedCaseId] = useState<string | null>(null);
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'updatedAt', desc: true },
@@ -114,6 +136,54 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
 
     return caseMap;
   }, [simulations]);
+  const caseMachineSummaries = useMemo(() => {
+    const summaries = new Map<string, string>();
+
+    for (const [caseId, caseSimulations] of simulationsByCaseId.entries()) {
+      const machineNames = [
+        ...new Set(
+          caseSimulations
+            .map((simulation) => simulation.machine?.name)
+            .filter((machineName): machineName is string => Boolean(machineName)),
+        ),
+      ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' }));
+
+      if (machineNames.length === 0) {
+        summaries.set(caseId, '—');
+      } else if (machineNames.length === 1) {
+        summaries.set(caseId, machineNames[0]);
+      } else {
+        summaries.set(caseId, `${machineNames[0]} +${machineNames.length - 1}`);
+      }
+    }
+
+    return summaries;
+  }, [simulationsByCaseId]);
+  const caseHpcUserSummaries = useMemo(() => {
+    const summaries = new Map<string, string>();
+
+    for (const [caseId, caseSimulations] of simulationsByCaseId.entries()) {
+      const usernames = [
+        ...new Set(
+          caseSimulations
+            .map((simulation) => simulation.hpcUsername)
+            .filter((username): username is string => Boolean(username)),
+        ),
+      ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' }));
+
+      if (simulationFilters.hpcUsername) {
+        summaries.set(caseId, simulationFilters.hpcUsername);
+      } else if (usernames.length === 0) {
+        summaries.set(caseId, '—');
+      } else if (usernames.length === 1) {
+        summaries.set(caseId, usernames[0]);
+      } else {
+        summaries.set(caseId, `${usernames.length} users`);
+      }
+    }
+
+    return summaries;
+  }, [simulationFilters.hpcUsername, simulationsByCaseId]);
   const hpcUsernames = useMemo(
     () =>
       [
@@ -149,13 +219,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
       left.label.localeCompare(right.label, undefined, { sensitivity: 'base' }),
     );
   }, [simulations]);
-  const statuses = useMemo(
-    () =>
-      sortStringValues(
-        [...new Set(simulations.map((simulation) => simulation.status).filter(Boolean))] as string[],
-      ),
-    [simulations],
-  );
   const campaigns = useMemo(
     () =>
       sortStringValues(
@@ -204,6 +267,21 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     caseGroupFilter.length > 0 ||
     canonicalFilter !== 'all' ||
     hasActiveSimulationFilters;
+  const advancedFilterCount = useMemo(
+    () =>
+      [
+        simulationFilters.machineId,
+        simulationFilters.campaign,
+        simulationFilters.simulationType,
+        simulationFilters.initializationType,
+        simulationFilters.compiler,
+        simulationFilters.gitTag,
+        simulationFilters.createdBy,
+        caseGroupFilter,
+        canonicalFilter !== 'all' ? canonicalFilter : '',
+      ].filter(Boolean).length,
+    [canonicalFilter, caseGroupFilter, simulationFilters],
+  );
   const matchingSimulationsByCaseId = useMemo(() => {
     const matchingMap = new Map<string, SimulationOut[]>();
 
@@ -215,9 +293,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         return false;
       }
       if (simulationFilters.machineId && simulation.machine?.id !== simulationFilters.machineId) {
-        return false;
-      }
-      if (simulationFilters.status && simulation.status !== simulationFilters.status) {
         return false;
       }
       if (simulationFilters.campaign && simulation.campaign !== simulationFilters.campaign) {
@@ -259,8 +334,10 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     return matchingMap;
   }, [simulationFilters, simulations]);
   const activeFilterPills = useMemo(() => {
-    const filters: { key: string; label: string; value: string }[] = [];
-    if (caseNameFilter.trim()) filters.push({ key: 'caseName', label: 'Case', value: caseNameFilter.trim() });
+    const filters: ActiveFilterPill[] = [];
+    if (caseNameFilter.trim()) {
+      filters.push({ key: 'caseName', label: 'Case', value: caseNameFilter.trim() });
+    }
     if (simulationFilters.hpcUsername) {
       filters.push({ key: 'hpcUsername', label: 'HPC', value: simulationFilters.hpcUsername });
     }
@@ -272,9 +349,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
           machineOptions.find((option) => option.value === simulationFilters.machineId)?.label ??
           simulationFilters.machineId,
       });
-    }
-    if (simulationFilters.status) {
-      filters.push({ key: 'status', label: 'Status', value: simulationFilters.status });
     }
     if (simulationFilters.campaign) {
       filters.push({ key: 'campaign', label: 'Campaign', value: simulationFilters.campaign });
@@ -320,6 +394,45 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     return filters;
   }, [canonicalFilter, caseGroupFilter, caseNameFilter, creatorOptions, machineOptions, simulationFilters]);
 
+  const setSimulationFilter = (key: keyof CaseSimulationFilters, value: string) => {
+    setSimulationFilters((current) => ({
+      ...current,
+      [key]: value,
+    }));
+    table.setPageIndex(0);
+  };
+
+  const clearAllFilters = () => {
+    setCaseNameFilter('');
+    setCaseGroupFilter('');
+    setSimulationFilters(createEmptySimulationFilters());
+    setCanonicalFilter('all');
+    setShowAdvancedFilters(false);
+    table.setPageIndex(0);
+  };
+
+  const removeFilter = (filterKey: ActiveFilterKey) => {
+    switch (filterKey) {
+      case 'caseName':
+        setCaseNameFilter('');
+        break;
+      case 'caseGroup':
+        setCaseGroupFilter('');
+        break;
+      case 'canonical':
+        setCanonicalFilter('all');
+        break;
+      default:
+        setSimulationFilters((current) => ({
+          ...current,
+          [filterKey]: '',
+        }));
+        break;
+    }
+
+    table.setPageIndex(0);
+  };
+
   const filteredCases = useMemo(() => {
     const normalizedNameFilter = caseNameFilter.trim().toLowerCase();
 
@@ -347,6 +460,17 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     hasActiveSimulationFilters,
     matchingSimulationsByCaseId,
   ]);
+  const visibleRunCount = useMemo(
+    () =>
+      filteredCases.reduce((count, caseRecord) => {
+        if (hasActiveSimulationFilters) {
+          return count + (matchingSimulationsByCaseId.get(caseRecord.id)?.length ?? 0);
+        }
+
+        return count + (simulationsByCaseId.get(caseRecord.id)?.length ?? caseRecord.simulations.length);
+      }, 0),
+    [filteredCases, hasActiveSimulationFilters, matchingSimulationsByCaseId, simulationsByCaseId],
+  );
 
   const columns = useMemo<ColumnDef<CaseOut>[]>(
     () => [
@@ -392,6 +516,22 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         accessorKey: 'caseGroup',
         header: 'Case Group',
         cell: ({ row }) => <TableCellText value={row.original.caseGroup ?? '—'} />,
+      },
+      {
+        id: 'machines',
+        header: 'Machines',
+        accessorFn: (caseRecord) => caseMachineSummaries.get(caseRecord.id) ?? '—',
+        cell: ({ row }) => (
+          <TableCellText value={caseMachineSummaries.get(row.original.id) ?? '—'} lines={1} />
+        ),
+      },
+      {
+        id: 'hpcUsers',
+        header: 'HPC Users',
+        accessorFn: (caseRecord) => caseHpcUserSummaries.get(caseRecord.id) ?? '—',
+        cell: ({ row }) => (
+          <TableCellText value={caseHpcUserSummaries.get(row.original.id) ?? '—'} lines={1} />
+        ),
       },
       {
         id: 'canonicalSimulation',
@@ -451,7 +591,14 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         ),
       },
     ],
-    [expandedCaseId, hasActiveSimulationFilters, matchingSimulationsByCaseId, simulationsByCaseId],
+    [
+      caseHpcUserSummaries,
+      caseMachineSummaries,
+      expandedCaseId,
+      hasActiveSimulationFilters,
+      matchingSimulationsByCaseId,
+      simulationsByCaseId,
+    ],
   );
 
   const table = useReactTable({
@@ -469,6 +616,39 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
       },
     },
   });
+
+  const renderSelectField = ({
+    label,
+    value,
+    placeholder,
+    options,
+    onValueChange,
+  }: {
+    label: string;
+    value: string;
+    placeholder: string;
+    options: SelectOption[];
+    onValueChange: (value: string) => void;
+  }) => (
+    <div className="space-y-2">
+      <label className="text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
+        {label}
+      </label>
+      <Select value={value || '__all__'} onValueChange={onValueChange}>
+        <SelectTrigger className="h-10 rounded-xl border-slate-200 bg-white shadow-none">
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="__all__">{placeholder}</SelectItem>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
 
   const renderExpandedContent = (caseRecord: CaseOut) => {
     const allCaseSimulations = sortCaseSimulations(simulationsByCaseId.get(caseRecord.id) ?? []);
@@ -500,11 +680,10 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
               <TableHeader>
                 <TableRow>
                   <TableHead>Execution ID</TableHead>
-                  <TableHead>Status</TableHead>
                   <TableHead>Canonical</TableHead>
-                  <TableHead>Change Count</TableHead>
+                  <TableHead>Machine</TableHead>
+                  <TableHead>HPC Username</TableHead>
                   <TableHead>Simulation Dates</TableHead>
-                  <TableHead>View Details</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -519,9 +698,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                       </Link>
                     </TableCell>
                     <TableCell className="align-top">
-                      <SimulationStatusBadge status={simulation.status} />
-                    </TableCell>
-                    <TableCell className="align-top">
                       {simulation.isCanonical ? (
                         <Badge
                           variant="outline"
@@ -533,19 +709,16 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                         <span className="text-muted-foreground">—</span>
                       )}
                     </TableCell>
-                    <TableCell className="align-top">{simulation.changeCount}</TableCell>
+                    <TableCell className="align-top">
+                      <TableCellText value={simulation.machine?.name ?? '—'} lines={1} />
+                    </TableCell>
+                    <TableCell className="align-top">
+                      <TableCellText value={simulation.hpcUsername ?? '—'} lines={1} />
+                    </TableCell>
                     <TableCell className="align-top">
                       {`${formatCaseDate(simulation.simulationStartDate)} → ${formatCaseDate(
                         simulation.simulationEndDate ?? null,
                       )}`}
-                    </TableCell>
-                    <TableCell className="align-top">
-                      <Link
-                        to={`/simulations/${simulation.id}`}
-                        className="text-blue-600 hover:underline"
-                      >
-                        View simulation
-                      </Link>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -574,306 +747,283 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   }
 
   return (
-    <div className="mx-auto w-full max-w-[1400px] space-y-6 px-8 py-8">
-      <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">Cases</h1>
-          <p className="text-sm text-muted-foreground">
-            Discover cases through run metadata like HPC username, machine, status, and version context.
-          </p>
-        </div>
-        <div className="text-sm text-muted-foreground">
-          {filteredCases.length} of {cases.length} cases
+    <div className="mx-auto w-full max-w-[1480px] space-y-6 px-6 py-8">
+      <div className="overflow-hidden rounded-3xl border border-slate-200/80 bg-gradient-to-br from-white via-slate-50/70 to-slate-100/80 shadow-sm">
+        <div className="space-y-5 p-5 sm:p-6">
+          <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+            <div className="space-y-3">
+              <div className="inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Primary Discovery
+              </div>
+              <div className="space-y-2">
+                <h1 className="text-3xl font-semibold tracking-tight text-slate-950">Cases</h1>
+                <p className="max-w-3xl text-sm leading-6 text-slate-600 sm:text-[15px]">
+                  Find the cases behind your runs. Start with HPC username or machine, then
+                  refine by campaign, version context, and canonical state.
+                </p>
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3 xl:min-w-[440px]">
+              <div className="rounded-2xl border border-slate-200 bg-white/85 p-4 shadow-sm shadow-slate-200/30">
+                <p className="text-xs font-medium uppercase tracking-[0.14em] text-slate-500">
+                  Cases shown
+                </p>
+                <p className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+                  {filteredCases.length}
+                </p>
+                <p className="mt-1 text-xs text-slate-500">of {cases.length} total cases</p>
+              </div>
+              <div className="rounded-2xl border border-slate-200 bg-white/85 p-4 shadow-sm shadow-slate-200/30">
+                <p className="text-xs font-medium uppercase tracking-[0.14em] text-slate-500">
+                  Runs shown
+                </p>
+                <p className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+                  {visibleRunCount}
+                </p>
+                <p className="mt-1 text-xs text-slate-500">
+                  {hasActiveSimulationFilters ? 'matching runs in visible cases' : 'runs across visible cases'}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-slate-200 bg-white/85 p-4 shadow-sm shadow-slate-200/30">
+                <p className="text-xs font-medium uppercase tracking-[0.14em] text-slate-500">
+                  Active filters
+                </p>
+                <p className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+                  {activeFilterPills.length}
+                </p>
+                <p className="mt-1 text-xs text-slate-500">
+                  {advancedFilterCount > 0
+                    ? `${advancedFilterCount} advanced refinements applied`
+                    : 'Quick case discovery'}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <Collapsible open={showAdvancedFilters} onOpenChange={setShowAdvancedFilters}>
+            <div className="rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-sm shadow-slate-200/30">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                <div className="grid flex-1 gap-3 md:grid-cols-[minmax(0,1.35fr)_220px_220px]">
+                  <div className="space-y-2">
+                    <label className="text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
+                      Search
+                    </label>
+                    <div className="relative">
+                      <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                      <Input
+                        placeholder="Search case name…"
+                        value={caseNameFilter}
+                        onChange={(event) => {
+                          setCaseNameFilter(event.target.value);
+                          table.setPageIndex(0);
+                        }}
+                        className="h-10 rounded-xl border-slate-200 bg-white pl-10 shadow-none"
+                      />
+                    </div>
+                  </div>
+
+                  {renderSelectField({
+                      label: 'HPC Username',
+                      value: simulationFilters.hpcUsername,
+                      placeholder: 'All HPC usernames',
+                    options: hpcUsernames.map((username) => ({
+                      value: username,
+                      label: username,
+                    })),
+                    onValueChange: (value) =>
+                      setSimulationFilter('hpcUsername', value === '__all__' ? '' : value),
+                  })}
+
+                  {renderSelectField({
+                    label: 'Machine',
+                    value: simulationFilters.machineId,
+                    placeholder: 'All machines',
+                    options: machineOptions,
+                    onValueChange: (value) =>
+                      setSimulationFilter('machineId', value === '__all__' ? '' : value),
+                  })}
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+                  <CollapsibleTrigger asChild>
+                    <Button
+                      variant="outline"
+                      type="button"
+                      className="h-10 rounded-xl border-slate-200 bg-white px-4 text-slate-700 shadow-none hover:bg-slate-50"
+                    >
+                      <SlidersHorizontal className="mr-2 h-4 w-4" />
+                      {advancedFilterCount > 0
+                        ? `More filters (${advancedFilterCount})`
+                        : 'More filters'}
+                      <ChevronDown
+                        className={cn(
+                          'ml-2 h-4 w-4 transition-transform duration-200',
+                          showAdvancedFilters && 'rotate-180',
+                        )}
+                      />
+                    </Button>
+                  </CollapsibleTrigger>
+                  <Button
+                    variant="ghost"
+                    type="button"
+                    onClick={clearAllFilters}
+                    disabled={!hasActiveFilters}
+                    className="h-10 rounded-xl px-4 text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                  >
+                    Clear all
+                  </Button>
+                </div>
+              </div>
+
+              <CollapsibleContent>
+                <div className="mt-4 border-t border-slate-200 pt-4">
+                  <div className="grid gap-6 xl:grid-cols-[minmax(0,2fr)_minmax(260px,1fr)]">
+                    <div className="space-y-4">
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium text-slate-900">Run context</p>
+                        <p className="text-xs text-slate-500">
+                          Filter cases by the metadata attached to the runs inside them.
+                        </p>
+                      </div>
+                      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                        {renderSelectField({
+                          label: 'Campaign',
+                          value: simulationFilters.campaign,
+                          placeholder: 'All campaigns',
+                          options: campaigns.map((campaign) => ({ value: campaign, label: campaign })),
+                          onValueChange: (value) =>
+                            setSimulationFilter('campaign', value === '__all__' ? '' : value),
+                        })}
+                        {renderSelectField({
+                          label: 'Type',
+                          value: simulationFilters.simulationType,
+                          placeholder: 'All types',
+                          options: simulationTypes.map((simulationType) => ({
+                            value: simulationType,
+                            label: simulationType,
+                          })),
+                          onValueChange: (value) =>
+                            setSimulationFilter('simulationType', value === '__all__' ? '' : value),
+                        })}
+                        {renderSelectField({
+                          label: 'Initialization',
+                          value: simulationFilters.initializationType,
+                          placeholder: 'All init types',
+                          options: initializationTypes.map((initializationType) => ({
+                            value: initializationType,
+                            label: initializationType,
+                          })),
+                          onValueChange: (value) =>
+                            setSimulationFilter(
+                              'initializationType',
+                              value === '__all__' ? '' : value,
+                            ),
+                        })}
+                        {renderSelectField({
+                          label: 'Compiler',
+                          value: simulationFilters.compiler,
+                          placeholder: 'All compilers',
+                          options: compilers.map((compiler) => ({
+                            value: compiler,
+                            label: compiler,
+                          })),
+                          onValueChange: (value) =>
+                            setSimulationFilter('compiler', value === '__all__' ? '' : value),
+                        })}
+                        {renderSelectField({
+                          label: 'Tag',
+                          value: simulationFilters.gitTag,
+                          placeholder: 'All tags',
+                          options: gitTags.map((gitTag) => ({ value: gitTag, label: gitTag })),
+                          onValueChange: (value) =>
+                            setSimulationFilter('gitTag', value === '__all__' ? '' : value),
+                        })}
+                        {renderSelectField({
+                          label: 'Creator',
+                          value: simulationFilters.createdBy,
+                          placeholder: 'All creators',
+                          options: creatorOptions,
+                          onValueChange: (value) =>
+                            setSimulationFilter('createdBy', value === '__all__' ? '' : value),
+                        })}
+                      </div>
+                    </div>
+
+                    <div className="space-y-4 rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium text-slate-900">Case settings</p>
+                        <p className="text-xs text-slate-500">
+                          Narrow the result set using case-level metadata and baseline state.
+                        </p>
+                      </div>
+                      <div className="grid gap-3">
+                        {renderSelectField({
+                          label: 'Case group',
+                          value: caseGroupFilter,
+                          placeholder: 'All case groups',
+                          options: caseGroups.map((group) => ({ value: group, label: group })),
+                          onValueChange: (value) => {
+                            setCaseGroupFilter(value === '__all__' ? '' : value);
+                            table.setPageIndex(0);
+                          },
+                        })}
+                        <div className="space-y-2">
+                          <label className="text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
+                            Canonical state
+                          </label>
+                          <Select
+                            value={canonicalFilter}
+                            onValueChange={(value: CanonicalFilter) => {
+                              setCanonicalFilter(value);
+                              table.setPageIndex(0);
+                            }}
+                          >
+                            <SelectTrigger className="h-10 rounded-xl border-slate-200 bg-white shadow-none">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="all">All canonical states</SelectItem>
+                              <SelectItem value="with-canonical">Canonical present</SelectItem>
+                              <SelectItem value="without-canonical">Canonical missing</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </CollapsibleContent>
+            </div>
+          </Collapsible>
+
+          {hasActiveFilters && (
+            <div className="flex flex-wrap items-center gap-2">
+              {activeFilterPills.map((filter) => (
+                <span
+                  key={`${filter.key}-${filter.value}`}
+                  className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-sm shadow-slate-200/30"
+                >
+                  <span className="mr-2 text-xs font-medium uppercase tracking-[0.08em] text-slate-500">
+                    {filter.label}
+                  </span>
+                  <span className="font-medium">{filter.value}</span>
+                  <button
+                    type="button"
+                    aria-label={`Remove ${filter.label} filter`}
+                    className="ml-2 inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                    onClick={() => removeFilter(filter.key)}
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3 rounded-md bg-muted p-4">
-        <Input
-          placeholder="Search case name…"
-          value={caseNameFilter}
-          onChange={(event) => {
-            setCaseNameFilter(event.target.value);
-            table.setPageIndex(0);
-          }}
-          className="w-full md:w-[320px]"
-        />
-
-        <Select
-          value={simulationFilters.hpcUsername || '__all__'}
-          onValueChange={(value) => {
-            setSimulationFilters((current) => ({
-              ...current,
-              hpcUsername: value === '__all__' ? '' : value,
-            }));
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue placeholder="All HPC usernames" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All HPC usernames</SelectItem>
-            {hpcUsernames.map((username) => (
-              <SelectItem key={username} value={username}>
-                {username}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={simulationFilters.machineId || '__all__'}
-          onValueChange={(value) => {
-            setSimulationFilters((current) => ({
-              ...current,
-              machineId: value === '__all__' ? '' : value,
-            }));
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue placeholder="All machines" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All machines</SelectItem>
-            {machineOptions.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={simulationFilters.status || '__all__'}
-          onValueChange={(value) => {
-            setSimulationFilters((current) => ({
-              ...current,
-              status: value === '__all__' ? '' : value,
-            }));
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue placeholder="All statuses" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All statuses</SelectItem>
-            {statuses.map((status) => (
-              <SelectItem key={status} value={status}>
-                {status}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={simulationFilters.campaign || '__all__'}
-          onValueChange={(value) => {
-            setSimulationFilters((current) => ({
-              ...current,
-              campaign: value === '__all__' ? '' : value,
-            }));
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue placeholder="All campaigns" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All campaigns</SelectItem>
-            {campaigns.map((campaign) => (
-              <SelectItem key={campaign} value={campaign}>
-                {campaign}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={simulationFilters.simulationType || '__all__'}
-          onValueChange={(value) => {
-            setSimulationFilters((current) => ({
-              ...current,
-              simulationType: value === '__all__' ? '' : value,
-            }));
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue placeholder="All types" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All types</SelectItem>
-            {simulationTypes.map((simulationType) => (
-              <SelectItem key={simulationType} value={simulationType}>
-                {simulationType}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={simulationFilters.initializationType || '__all__'}
-          onValueChange={(value) => {
-            setSimulationFilters((current) => ({
-              ...current,
-              initializationType: value === '__all__' ? '' : value,
-            }));
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue placeholder="All init types" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All init types</SelectItem>
-            {initializationTypes.map((initializationType) => (
-              <SelectItem key={initializationType} value={initializationType}>
-                {initializationType}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={simulationFilters.compiler || '__all__'}
-          onValueChange={(value) => {
-            setSimulationFilters((current) => ({
-              ...current,
-              compiler: value === '__all__' ? '' : value,
-            }));
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue placeholder="All compilers" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All compilers</SelectItem>
-            {compilers.map((compiler) => (
-              <SelectItem key={compiler} value={compiler}>
-                {compiler}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={simulationFilters.gitTag || '__all__'}
-          onValueChange={(value) => {
-            setSimulationFilters((current) => ({
-              ...current,
-              gitTag: value === '__all__' ? '' : value,
-            }));
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue placeholder="All tags" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All tags</SelectItem>
-            {gitTags.map((gitTag) => (
-              <SelectItem key={gitTag} value={gitTag}>
-                {gitTag}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={simulationFilters.createdBy || '__all__'}
-          onValueChange={(value) => {
-            setSimulationFilters((current) => ({
-              ...current,
-              createdBy: value === '__all__' ? '' : value,
-            }));
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue placeholder="All creators" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All creators</SelectItem>
-            {creatorOptions.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={caseGroupFilter || '__all__'}
-          onValueChange={(value) => {
-            setCaseGroupFilter(value === '__all__' ? '' : value);
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue placeholder="All case groups" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All case groups</SelectItem>
-            {caseGroups.map((group) => (
-              <SelectItem key={group} value={group}>
-                {group}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={canonicalFilter}
-          onValueChange={(value: CanonicalFilter) => {
-            setCanonicalFilter(value);
-            table.setPageIndex(0);
-          }}
-        >
-          <SelectTrigger className="w-full md:w-[220px]">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All canonical states</SelectItem>
-            <SelectItem value="with-canonical">Canonical present</SelectItem>
-            <SelectItem value="without-canonical">Canonical missing</SelectItem>
-          </SelectContent>
-        </Select>
-
-        <Button
-          variant="outline"
-          size="sm"
-          type="button"
-          onClick={() => {
-            setCaseNameFilter('');
-            setCaseGroupFilter('');
-            setSimulationFilters(createEmptySimulationFilters());
-            setCanonicalFilter('all');
-            table.setPageIndex(0);
-          }}
-          disabled={!hasActiveFilters}
-        >
-          Clear filters
-        </Button>
-      </div>
-
-      {hasActiveFilters && (
-        <div className="flex flex-wrap items-center gap-2 rounded-md border bg-background p-3">
-          {activeFilterPills.map((filter) => (
-            <span
-              key={`${filter.key}-${filter.value}`}
-              className="inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
-            >
-              <span className="mr-2 text-xs font-medium text-slate-500">{filter.label}:</span>
-              <span className="font-medium">{filter.value}</span>
-            </span>
-          ))}
-        </div>
-      )}
-
-      <div className="overflow-hidden rounded-md border bg-background">
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         <div className="overflow-x-auto">
           <Table>
             <TableHeader>
@@ -908,7 +1058,11 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                     <Fragment key={row.id}>
                       <TableRow
                         className="cursor-pointer hover:bg-muted/40"
-                        onClick={() => navigate(`/cases/${row.original.id}`)}
+                        onClick={() =>
+                          setExpandedCaseId((current) =>
+                            current === row.original.id ? null : row.original.id,
+                          )
+                        }
                       >
                         {row.getVisibleCells().map((cell) => (
                           <TableCell key={cell.id} className="align-top">

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -30,9 +30,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { TableCellText } from '@/components/ui/table-cell-text';
-import {
-  formatCaseDate,
-} from '@/features/simulations/caseUtils';
+import { formatCaseDate } from '@/features/simulations/caseUtils';
 import { useCases } from '@/features/simulations/hooks/useCases';
 import { cn } from '@/lib/utils';
 import type { CaseOut, SimulationOut } from '@/types';
@@ -97,7 +95,9 @@ const sortCaseSimulations = (caseSimulations: SimulationOut[]) =>
       return left.isCanonical ? -1 : 1;
     }
 
-    return new Date(right.simulationStartDate).getTime() - new Date(left.simulationStartDate).getTime();
+    return (
+      new Date(right.simulationStartDate).getTime() - new Date(left.simulationStartDate).getTime()
+    );
   });
 
 export const CasesPage = ({ simulations }: CasesPageProps) => {
@@ -106,8 +106,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   const currentPath = `${location.pathname}${location.search}`;
   const [caseNameFilter, setCaseNameFilter] = useState('');
   const [caseGroupFilter, setCaseGroupFilter] = useState('');
-  const [simulationFilters, setSimulationFilters] =
-    useState<CaseSimulationFilters>(createEmptySimulationFilters);
+  const [simulationFilters, setSimulationFilters] = useState<CaseSimulationFilters>(
+    createEmptySimulationFilters,
+  );
   const [canonicalFilter, setCanonicalFilter] = useState<CanonicalFilter>('all');
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const [expandedCaseId, setExpandedCaseId] = useState<string | null>(null);
@@ -222,41 +223,37 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   }, [simulations]);
   const campaigns = useMemo(
     () =>
-      sortStringValues(
-        [...new Set(simulations.map((simulation) => simulation.campaign).filter(Boolean))] as string[],
-      ),
+      sortStringValues([
+        ...new Set(simulations.map((simulation) => simulation.campaign).filter(Boolean)),
+      ] as string[]),
     [simulations],
   );
   const simulationTypes = useMemo(
     () =>
-      sortStringValues(
-        [...new Set(simulations.map((simulation) => simulation.simulationType).filter(Boolean))] as string[],
-      ),
+      sortStringValues([
+        ...new Set(simulations.map((simulation) => simulation.simulationType).filter(Boolean)),
+      ] as string[]),
     [simulations],
   );
   const initializationTypes = useMemo(
     () =>
-      sortStringValues(
-        [
-          ...new Set(
-            simulations.map((simulation) => simulation.initializationType).filter(Boolean),
-          ),
-        ] as string[],
-      ),
+      sortStringValues([
+        ...new Set(simulations.map((simulation) => simulation.initializationType).filter(Boolean)),
+      ] as string[]),
     [simulations],
   );
   const compilers = useMemo(
     () =>
-      sortStringValues(
-        [...new Set(simulations.map((simulation) => simulation.compiler).filter(Boolean))] as string[],
-      ),
+      sortStringValues([
+        ...new Set(simulations.map((simulation) => simulation.compiler).filter(Boolean)),
+      ] as string[]),
     [simulations],
   );
   const gitTags = useMemo(
     () =>
-      sortStringValues(
-        [...new Set(simulations.map((simulation) => simulation.gitTag).filter(Boolean))] as string[],
-      ),
+      sortStringValues([
+        ...new Set(simulations.map((simulation) => simulation.gitTag).filter(Boolean)),
+      ] as string[]),
     [simulations],
   );
   const hasActiveSimulationFilters = useMemo(
@@ -393,7 +390,14 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     }
 
     return filters;
-  }, [canonicalFilter, caseGroupFilter, caseNameFilter, creatorOptions, machineOptions, simulationFilters]);
+  }, [
+    canonicalFilter,
+    caseGroupFilter,
+    caseNameFilter,
+    creatorOptions,
+    machineOptions,
+    simulationFilters,
+  ]);
 
   const setSimulationFilter = (key: keyof CaseSimulationFilters, value: string) => {
     setSimulationFilters((current) => ({
@@ -468,7 +472,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
           return count + (matchingSimulationsByCaseId.get(caseRecord.id)?.length ?? 0);
         }
 
-        return count + (simulationsByCaseId.get(caseRecord.id)?.length ?? caseRecord.simulations.length);
+        return (
+          count + (simulationsByCaseId.get(caseRecord.id)?.length ?? caseRecord.simulations.length)
+        );
       }, 0),
     [filteredCases, hasActiveSimulationFilters, matchingSimulationsByCaseId, simulationsByCaseId],
   );
@@ -491,10 +497,16 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
               aria-label={isExpanded ? 'Collapse simulations' : 'Expand simulations'}
               onClick={(event) => {
                 event.stopPropagation();
-                setExpandedCaseId((current) => (current === row.original.id ? null : row.original.id));
+                setExpandedCaseId((current) =>
+                  current === row.original.id ? null : row.original.id,
+                );
               }}
             >
-              {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+              {isExpanded ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
             </Button>
           );
         },
@@ -564,13 +576,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         ),
       },
     ],
-    [
-      caseHpcUserSummaries,
-      caseMachineSummaries,
-      currentPath,
-      expandedCaseId,
-      simulationsByCaseId,
-    ],
+    [caseHpcUserSummaries, caseMachineSummaries, currentPath, expandedCaseId, simulationsByCaseId],
   );
 
   const table = useReactTable({
@@ -627,8 +633,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     const matchingCaseSimulations = sortCaseSimulations(
       matchingSimulationsByCaseId.get(caseRecord.id) ?? [],
     );
-    const simulations =
-      hasActiveSimulationFilters ? matchingCaseSimulations : allCaseSimulations;
+    const visibleCaseSimulations = hasActiveSimulationFilters
+      ? matchingCaseSimulations
+      : allCaseSimulations;
 
     return (
       <div className="space-y-3 bg-muted/20 p-4">
@@ -659,7 +666,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {simulations.map((simulation) => (
+                {visibleCaseSimulations.map((simulation) => (
                   <TableRow key={simulation.id}>
                     <TableCell className="align-top">
                       <Link
@@ -741,8 +748,8 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
               <div className="space-y-2">
                 <h1 className="text-3xl font-semibold tracking-tight text-slate-950">Cases</h1>
                 <p className="max-w-3xl text-sm leading-6 text-slate-600 sm:text-[15px]">
-                  Find the cases behind your runs. Start with HPC username or machine, then
-                  refine by campaign, version context, and canonical state.
+                  Find the cases behind your runs. Start with HPC username or machine, then refine
+                  by campaign, version context, and canonical state.
                 </p>
               </div>
             </div>
@@ -765,7 +772,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                   {visibleRunCount}
                 </p>
                 <p className="mt-1 text-xs text-slate-500">
-                  {hasActiveSimulationFilters ? 'matching runs in visible cases' : 'runs across visible cases'}
+                  {hasActiveSimulationFilters
+                    ? 'matching runs in visible cases'
+                    : 'runs across visible cases'}
                 </p>
               </div>
               <div className="rounded-2xl border border-slate-200 bg-white/85 p-4 shadow-sm shadow-slate-200/30">
@@ -807,9 +816,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                   </div>
 
                   {renderSelectField({
-                      label: 'HPC Username',
-                      value: simulationFilters.hpcUsername,
-                      placeholder: 'All HPC usernames',
+                    label: 'HPC Username',
+                    value: simulationFilters.hpcUsername,
+                    placeholder: 'All HPC usernames',
                     options: hpcUsernames.map((username) => ({
                       value: username,
                       label: username,
@@ -874,7 +883,10 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                           label: 'Campaign',
                           value: simulationFilters.campaign,
                           placeholder: 'All campaigns',
-                          options: campaigns.map((campaign) => ({ value: campaign, label: campaign })),
+                          options: campaigns.map((campaign) => ({
+                            value: campaign,
+                            label: campaign,
+                          })),
                           onValueChange: (value) =>
                             setSimulationFilter('campaign', value === '__all__' ? '' : value),
                         })}

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -104,6 +104,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   const location = useLocation();
   const { data: cases, loading, error } = useCases();
   const currentPath = `${location.pathname}${location.search}`;
+
   const [caseNameFilter, setCaseNameFilter] = useState('');
   const [caseGroupFilter, setCaseGroupFilter] = useState('');
   const [simulationFilters, setSimulationFilters] = useState<CaseSimulationFilters>(
@@ -128,6 +129,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
       ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' })),
     [cases],
   );
+
   const simulationsByCaseId = useMemo(() => {
     const caseMap = new Map<string, SimulationOut[]>();
     for (const simulation of simulations) {
@@ -138,6 +140,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
 
     return caseMap;
   }, [simulations]);
+
   const caseMachineSummaries = useMemo(() => {
     const summaries = new Map<string, string>();
 
@@ -161,6 +164,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
 
     return summaries;
   }, [simulationsByCaseId]);
+
   const caseHpcUserSummaries = useMemo(() => {
     const summaries = new Map<string, string>();
 
@@ -197,6 +201,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
       ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' })),
     [simulations],
   );
+
   const machineOptions = useMemo(() => {
     const machineMap = new Map<string, string>();
 
@@ -209,6 +214,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
       left.label.localeCompare(right.label, undefined, { sensitivity: 'base' }),
     );
   }, [simulations]);
+
   const creatorOptions = useMemo(() => {
     const creatorMap = new Map<string, string>();
 
@@ -221,41 +227,33 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
       left.label.localeCompare(right.label, undefined, { sensitivity: 'base' }),
     );
   }, [simulations]);
-  const campaigns = useMemo(
-    () =>
-      sortStringValues([
-        ...new Set(simulations.map((simulation) => simulation.campaign).filter(Boolean)),
-      ] as string[]),
-    [simulations],
-  );
-  const simulationTypes = useMemo(
-    () =>
-      sortStringValues([
-        ...new Set(simulations.map((simulation) => simulation.simulationType).filter(Boolean)),
-      ] as string[]),
-    [simulations],
-  );
-  const initializationTypes = useMemo(
-    () =>
-      sortStringValues([
-        ...new Set(simulations.map((simulation) => simulation.initializationType).filter(Boolean)),
-      ] as string[]),
-    [simulations],
-  );
-  const compilers = useMemo(
-    () =>
-      sortStringValues([
-        ...new Set(simulations.map((simulation) => simulation.compiler).filter(Boolean)),
-      ] as string[]),
-    [simulations],
-  );
-  const gitTags = useMemo(
-    () =>
-      sortStringValues([
-        ...new Set(simulations.map((simulation) => simulation.gitTag).filter(Boolean)),
-      ] as string[]),
-    [simulations],
-  );
+
+  const { campaigns, simulationTypes, initializationTypes, compilers, gitTags } = useMemo(() => {
+    const campaigns = new Set<string>();
+    const simulationTypes = new Set<string>();
+    const initializationTypes = new Set<string>();
+    const compilers = new Set<string>();
+    const gitTags = new Set<string>();
+
+    for (const simulation of simulations) {
+      if (simulation.campaign) campaigns.add(simulation.campaign);
+      if (simulation.simulationType) simulationTypes.add(simulation.simulationType);
+      if (simulation.initializationType) {
+        initializationTypes.add(simulation.initializationType);
+      }
+      if (simulation.compiler) compilers.add(simulation.compiler);
+      if (simulation.gitTag) gitTags.add(simulation.gitTag);
+    }
+
+    return {
+      campaigns: sortStringValues([...campaigns]),
+      simulationTypes: sortStringValues([...simulationTypes]),
+      initializationTypes: sortStringValues([...initializationTypes]),
+      compilers: sortStringValues([...compilers]),
+      gitTags: sortStringValues([...gitTags]),
+    };
+  }, [simulations]);
+
   const hasActiveSimulationFilters = useMemo(
     () => Object.values(simulationFilters).some(Boolean),
     [simulationFilters],
@@ -331,14 +329,18 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
 
     return matchingMap;
   }, [simulationFilters, simulations]);
+
   const activeFilterPills = useMemo(() => {
     const filters: ActiveFilterPill[] = [];
+
     if (caseNameFilter.trim()) {
       filters.push({ key: 'caseName', label: 'Case', value: caseNameFilter.trim() });
     }
+
     if (simulationFilters.hpcUsername) {
       filters.push({ key: 'hpcUsername', label: 'HPC', value: simulationFilters.hpcUsername });
     }
+
     if (simulationFilters.machineId) {
       filters.push({
         key: 'machineId',
@@ -348,6 +350,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
           simulationFilters.machineId,
       });
     }
+
     if (simulationFilters.campaign) {
       filters.push({ key: 'campaign', label: 'Campaign', value: simulationFilters.campaign });
     }
@@ -358,6 +361,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         value: simulationFilters.simulationType,
       });
     }
+
     if (simulationFilters.initializationType) {
       filters.push({
         key: 'initializationType',
@@ -365,12 +369,15 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         value: simulationFilters.initializationType,
       });
     }
+
     if (simulationFilters.compiler) {
       filters.push({ key: 'compiler', label: 'Compiler', value: simulationFilters.compiler });
     }
+
     if (simulationFilters.gitTag) {
       filters.push({ key: 'gitTag', label: 'Tag', value: simulationFilters.gitTag });
     }
+
     if (simulationFilters.createdBy) {
       filters.push({
         key: 'createdBy',
@@ -380,7 +387,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
           simulationFilters.createdBy,
       });
     }
+
     if (caseGroupFilter) filters.push({ key: 'caseGroup', label: 'Group', value: caseGroupFilter });
+
     if (canonicalFilter !== 'all') {
       filters.push({
         key: 'canonical',
@@ -465,6 +474,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     hasActiveSimulationFilters,
     matchingSimulationsByCaseId,
   ]);
+
   const visibleRunCount = useMemo(
     () =>
       filteredCases.reduce((count, caseRecord) => {

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@tanstack/react-table';
 import { ChevronDown, ChevronRight, Search, SlidersHorizontal, X } from 'lucide-react';
 import { Fragment, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -32,7 +32,6 @@ import {
 import { TableCellText } from '@/components/ui/table-cell-text';
 import {
   formatCaseDate,
-  getCanonicalSimulation,
 } from '@/features/simulations/caseUtils';
 import { useCases } from '@/features/simulations/hooks/useCases';
 import { cn } from '@/lib/utils';
@@ -102,7 +101,9 @@ const sortCaseSimulations = (caseSimulations: SimulationOut[]) =>
   });
 
 export const CasesPage = ({ simulations }: CasesPageProps) => {
+  const location = useLocation();
   const { data: cases, loading, error } = useCases();
+  const currentPath = `${location.pathname}${location.search}`;
   const [caseNameFilter, setCaseNameFilter] = useState('');
   const [caseGroupFilter, setCaseGroupFilter] = useState('');
   const [simulationFilters, setSimulationFilters] =
@@ -504,6 +505,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         cell: ({ row }) => (
           <Link
             to={`/cases/${row.original.id}`}
+            state={{ from: currentPath }}
             className="block max-w-[28rem] truncate font-medium text-blue-600 hover:underline"
             title={row.original.name}
             onClick={(event) => event.stopPropagation()}
@@ -532,29 +534,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         cell: ({ row }) => (
           <TableCellText value={caseHpcUserSummaries.get(row.original.id) ?? '—'} lines={1} />
         ),
-      },
-      {
-        id: 'canonicalSimulation',
-        header: 'Canonical Simulation',
-        accessorFn: (caseRecord) => getCanonicalSimulation(caseRecord)?.executionId ?? '—',
-        cell: ({ row }) => {
-          const canonicalSimulation = getCanonicalSimulation(row.original);
-
-          if (!canonicalSimulation) {
-            return <span className="text-muted-foreground">—</span>;
-          }
-
-          return (
-            <Link
-              to={`/simulations/${canonicalSimulation.id}`}
-              className="font-mono text-xs text-blue-600 hover:underline"
-              title={canonicalSimulation.executionId}
-              onClick={(event) => event.stopPropagation()}
-            >
-              {canonicalSimulation.executionId}
-            </Link>
-          );
-        },
       },
       {
         id: 'simulationCount',
@@ -586,7 +565,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         enableSorting: false,
         cell: ({ row }) => (
           <Button variant="outline" size="sm" asChild onClick={(event) => event.stopPropagation()}>
-            <Link to={`/cases/${row.original.id}`}>View case</Link>
+            <Link to={`/cases/${row.original.id}`} state={{ from: currentPath }}>
+              View case
+            </Link>
           </Button>
         ),
       },
@@ -594,6 +575,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     [
       caseHpcUserSummaries,
       caseMachineSummaries,
+      currentPath,
       expandedCaseId,
       hasActiveSimulationFilters,
       matchingSimulationsByCaseId,
@@ -666,11 +648,13 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
             <p className="text-xs text-muted-foreground">
               {hasActiveSimulationFilters
                 ? `${matchingCaseSimulations.length} of ${allCaseSimulations.length} runs match the current filters.`
-                : 'Canonical simulations are pinned first. Open the case page for full context.'}
+                : 'Reference runs are pinned first. Open the case page for full context.'}
             </p>
           </div>
           <Button variant="outline" size="sm" asChild>
-            <Link to={`/cases/${caseRecord.id}`}>Open case page</Link>
+            <Link to={`/cases/${caseRecord.id}`} state={{ from: currentPath }}>
+              Open case page
+            </Link>
           </Button>
         </div>
 
@@ -680,7 +664,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
               <TableHeader>
                 <TableRow>
                   <TableHead>Execution ID</TableHead>
-                  <TableHead>Canonical</TableHead>
                   <TableHead>Machine</TableHead>
                   <TableHead>HPC Username</TableHead>
                   <TableHead>Simulation Dates</TableHead>
@@ -692,22 +675,11 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                     <TableCell className="align-top">
                       <Link
                         to={`/simulations/${simulation.id}`}
+                        state={{ from: currentPath }}
                         className="font-mono text-xs text-blue-600 hover:underline"
                       >
                         {simulation.executionId}
                       </Link>
-                    </TableCell>
-                    <TableCell className="align-top">
-                      {simulation.isCanonical ? (
-                        <Badge
-                          variant="outline"
-                          className="border-green-200 bg-green-50 text-green-700"
-                        >
-                          Canonical
-                        </Badge>
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
                     </TableCell>
                     <TableCell className="align-top">
                       <TableCellText value={simulation.machine?.name ?? '—'} lines={1} />
@@ -752,9 +724,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         <div className="space-y-5 p-5 sm:p-6">
           <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
             <div className="space-y-3">
-              <div className="inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
-                Primary Discovery
-              </div>
               <div className="space-y-2">
                 <h1 className="text-3xl font-semibold tracking-tight text-slate-950">Cases</h1>
                 <p className="max-w-3xl text-sm leading-6 text-slate-600 sm:text-[15px]">

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -33,7 +33,7 @@ import { TableCellText } from '@/components/ui/table-cell-text';
 import { formatCaseDate } from '@/features/simulations/caseUtils';
 import { useCases } from '@/features/simulations/hooks/useCases';
 import { cn } from '@/lib/utils';
-import type { CaseOut, SimulationOut } from '@/types';
+import type { CaseOut, SimulationOut, SimulationSummaryOut } from '@/types';
 
 type CanonicalFilter = 'all' | 'with-canonical' | 'without-canonical';
 type ActiveFilterKey =
@@ -75,6 +75,8 @@ interface ActiveFilterPill {
   value: string;
 }
 
+type CaseSimulationListItem = SimulationOut | SimulationSummaryOut;
+
 const createEmptySimulationFilters = (): CaseSimulationFilters => ({
   hpcUsername: '',
   machineId: '',
@@ -89,7 +91,7 @@ const createEmptySimulationFilters = (): CaseSimulationFilters => ({
 const sortStringValues = (values: string[]) =>
   values.sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' }));
 
-const sortCaseSimulations = (caseSimulations: SimulationOut[]) =>
+const sortCaseSimulations = (caseSimulations: CaseSimulationListItem[]) =>
   [...caseSimulations].sort((left, right) => {
     if (left.isCanonical !== right.isCanonical) {
       return left.isCanonical ? -1 : 1;
@@ -99,6 +101,18 @@ const sortCaseSimulations = (caseSimulations: SimulationOut[]) =>
       new Date(right.simulationStartDate).getTime() - new Date(left.simulationStartDate).getTime()
     );
   });
+
+const getSimulationChangeTitle = (simulation: CaseSimulationListItem) => {
+  if ('runConfigDeltas' in simulation && simulation.runConfigDeltas) {
+    const changedFields = Object.keys(simulation.runConfigDeltas);
+
+    if (changedFields.length > 0) {
+      return `Changed fields: ${changedFields.join(', ')}`;
+    }
+  }
+
+  return `${simulation.changeCount} changes from baseline`;
+};
 
 export const CasesPage = ({ simulations }: CasesPageProps) => {
   const location = useLocation();
@@ -639,9 +653,18 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   );
 
   const renderExpandedContent = (caseRecord: CaseOut) => {
-    const allCaseSimulations = sortCaseSimulations(simulationsByCaseId.get(caseRecord.id) ?? []);
+    const detailedCaseSimulations = simulationsByCaseId.get(caseRecord.id);
+    const summaryCaseSimulations = caseRecord.simulations;
+    const isUsingSummaryFallback =
+      (detailedCaseSimulations == null || detailedCaseSimulations.length === 0) &&
+      summaryCaseSimulations.length > 0;
+    const allCaseSimulations = sortCaseSimulations(
+      detailedCaseSimulations?.length ? detailedCaseSimulations : summaryCaseSimulations,
+    );
     const matchingCaseSimulations = sortCaseSimulations(
-      matchingSimulationsByCaseId.get(caseRecord.id) ?? [],
+      isUsingSummaryFallback
+        ? summaryCaseSimulations
+        : (matchingSimulationsByCaseId.get(caseRecord.id) ?? []),
     );
     const visibleCaseSimulations = hasActiveSimulationFilters
       ? matchingCaseSimulations
@@ -653,9 +676,11 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
           <div>
             <p className="text-sm font-medium">Simulation Summaries</p>
             <p className="text-xs text-muted-foreground">
-              {hasActiveSimulationFilters
-                ? `${matchingCaseSimulations.length} of ${allCaseSimulations.length} runs match the current filters.`
-                : 'Reference runs are pinned first. Open the case page for full context.'}
+              {isUsingSummaryFallback
+                ? 'Showing case-level run summaries because full simulation details are unavailable.'
+                : hasActiveSimulationFilters
+                  ? `${matchingCaseSimulations.length} of ${allCaseSimulations.length} runs match the current filters.`
+                  : 'Reference runs are pinned first. Open the case page for full context.'}
             </p>
           </div>
           <Button variant="outline" size="sm" asChild>
@@ -705,15 +730,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                           Baseline
                         </span>
                       ) : (
-                        <Badge
-                          variant="secondary"
-                          title={
-                            simulation.runConfigDeltas &&
-                            Object.keys(simulation.runConfigDeltas).length > 0
-                              ? `Changed fields: ${Object.keys(simulation.runConfigDeltas).join(', ')}`
-                              : `${simulation.changeCount} changes from baseline`
-                          }
-                        >
+                        <Badge variant="secondary" title={getSimulationChangeTitle(simulation)}>
                           {simulation.changeCount}
                         </Badge>
                       )}

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -648,14 +648,13 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
           </Button>
         </div>
 
-        <div className="overflow-hidden rounded-md border bg-background">
+        <div className="max-w-4xl overflow-hidden rounded-md border bg-background">
           <div className="max-h-[26rem] overflow-auto">
             <Table>
               <TableHeader>
                 <TableRow>
                   <TableHead>Execution ID</TableHead>
-                  <TableHead>Machine</TableHead>
-                  <TableHead>HPC Username</TableHead>
+                  <TableHead>Changes</TableHead>
                   <TableHead>Simulation Dates</TableHead>
                 </TableRow>
               </TableHeader>
@@ -681,10 +680,26 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                       </Link>
                     </TableCell>
                     <TableCell className="align-top">
-                      <TableCellText value={simulation.machine?.name ?? '—'} lines={1} />
-                    </TableCell>
-                    <TableCell className="align-top">
-                      <TableCellText value={simulation.hpcUsername ?? '—'} lines={1} />
+                      {simulation.isCanonical ? (
+                        <span
+                          className="text-sm font-medium text-slate-700"
+                          title="Baseline simulation"
+                        >
+                          Baseline
+                        </span>
+                      ) : (
+                        <Badge
+                          variant="secondary"
+                          title={
+                            simulation.runConfigDeltas &&
+                            Object.keys(simulation.runConfigDeltas).length > 0
+                              ? `Changed fields: ${Object.keys(simulation.runConfigDeltas).join(', ')}`
+                              : `${simulation.changeCount} changes from baseline`
+                          }
+                        >
+                          {simulation.changeCount}
+                        </Badge>
+                      )}
                     </TableCell>
                     <TableCell className="align-top">
                       {`${formatCaseDate(simulation.simulationStartDate)} → ${formatCaseDate(

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -515,9 +515,12 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         ),
       },
       {
-        accessorKey: 'caseGroup',
-        header: 'Case Group',
-        cell: ({ row }) => <TableCellText value={row.original.caseGroup ?? '—'} />,
+        id: 'hpcUsers',
+        header: 'HPC Users',
+        accessorFn: (caseRecord) => caseHpcUserSummaries.get(caseRecord.id) ?? '—',
+        cell: ({ row }) => (
+          <TableCellText value={caseHpcUserSummaries.get(row.original.id) ?? '—'} lines={1} />
+        ),
       },
       {
         id: 'machines',
@@ -525,14 +528,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         accessorFn: (caseRecord) => caseMachineSummaries.get(caseRecord.id) ?? '—',
         cell: ({ row }) => (
           <TableCellText value={caseMachineSummaries.get(row.original.id) ?? '—'} lines={1} />
-        ),
-      },
-      {
-        id: 'hpcUsers',
-        header: 'HPC Users',
-        accessorFn: (caseRecord) => caseHpcUserSummaries.get(caseRecord.id) ?? '—',
-        cell: ({ row }) => (
-          <TableCellText value={caseHpcUserSummaries.get(row.original.id) ?? '—'} lines={1} />
         ),
       },
       {
@@ -553,6 +548,11 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
             <Badge variant="secondary">{totalSimulations}</Badge>
           );
         },
+      },
+      {
+        accessorKey: 'caseGroup',
+        header: 'Case Group',
+        cell: ({ row }) => <TableCellText value={row.original.caseGroup ?? '—'} />,
       },
       {
         accessorKey: 'updatedAt',

--- a/frontend/src/features/simulations/SimulationDetailsPage.tsx
+++ b/frontend/src/features/simulations/SimulationDetailsPage.tsx
@@ -7,13 +7,15 @@ export const SimulationDetailsPage = () => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const { data: simulation, loading, error } = useSimulation(id ?? '');
+
   const state = location.state as { from?: string } | null;
   const backHref = typeof state?.from === 'string' ? state.from : '/browse';
-  const backLabel = backHref.startsWith('/cases/')
+  const normalizedBackHref = backHref.split(/[?#]/)[0];
+  const backLabel = normalizedBackHref.startsWith('/cases/')
     ? 'Back to Case'
-    : backHref === '/cases'
+    : normalizedBackHref === '/cases'
       ? 'Back to Cases'
-      : backHref.startsWith('/simulations')
+      : normalizedBackHref.startsWith('/simulations')
         ? 'Back to Simulations'
         : 'Back to Runs';
 
@@ -49,5 +51,7 @@ export const SimulationDetailsPage = () => {
     );
   }
 
-  return <SimulationDetailsView simulation={simulation} backHref={backHref} backLabel={backLabel} />;
+  return (
+    <SimulationDetailsView simulation={simulation} backHref={backHref} backLabel={backLabel} />
+  );
 };

--- a/frontend/src/features/simulations/SimulationDetailsPage.tsx
+++ b/frontend/src/features/simulations/SimulationDetailsPage.tsx
@@ -1,11 +1,21 @@
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 
 import { SimulationDetailsView } from '@/features/simulations/components/SimulationDetailsView';
 import { useSimulation } from '@/features/simulations/hooks/useSimulation';
 
 export const SimulationDetailsPage = () => {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
   const { data: simulation, loading, error } = useSimulation(id ?? '');
+  const state = location.state as { from?: string } | null;
+  const backHref = typeof state?.from === 'string' ? state.from : '/browse';
+  const backLabel = backHref.startsWith('/cases/')
+    ? 'Back to Case'
+    : backHref === '/cases'
+      ? 'Back to Cases'
+      : backHref.startsWith('/simulations')
+        ? 'Back to Simulations'
+        : 'Back to Runs';
 
   if (!id) {
     return (
@@ -39,5 +49,5 @@ export const SimulationDetailsPage = () => {
     );
   }
 
-  return <SimulationDetailsView simulation={simulation} />;
+  return <SimulationDetailsView simulation={simulation} backHref={backHref} backLabel={backLabel} />;
 };

--- a/frontend/src/features/simulations/SimulationsPage.tsx
+++ b/frontend/src/features/simulations/SimulationsPage.tsx
@@ -10,7 +10,7 @@ import {
 } from '@tanstack/react-table';
 import { format } from 'date-fns';
 import { useMemo, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -97,6 +97,8 @@ export const SimulationsPage = ({ simulations }: SimulationsPageProps) => {
   const [viewMode, setViewMode] = useState<'simple' | 'advanced'>('simple');
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const navigate = useNavigate();
+  const location = useLocation();
+  const currentPath = `${location.pathname}${location.search}`;
 
   // Derive unique case names and case groups for filter dropdowns.
   const caseNames = useMemo(
@@ -129,6 +131,7 @@ export const SimulationsPage = ({ simulations }: SimulationsPageProps) => {
         cell: ({ row }) => (
           <Link
             to={`/simulations/${row.original.id}`}
+            state={{ from: currentPath }}
             className="block max-w-full truncate font-mono text-xs text-blue-600 hover:underline"
             title={row.original.executionId}
             onClick={(e) => e.stopPropagation()}
@@ -276,7 +279,7 @@ export const SimulationsPage = ({ simulations }: SimulationsPageProps) => {
         meta: { isAdvanced: true },
       },
     ],
-    [],
+    [currentPath],
   );
 
   const table = useReactTable({

--- a/frontend/src/features/simulations/api/api.ts
+++ b/frontend/src/features/simulations/api/api.ts
@@ -34,6 +34,14 @@ export const listCases = async (url: string = CASES_URL): Promise<CaseOut[]> => 
   return res.data;
 };
 
+export const getCaseById = async (id: string): Promise<CaseOut> => {
+  const res = await api.get<CaseOut>(`${CASES_URL}/${id}`, {
+    headers: { 'Cache-Control': 'no-cache' },
+  });
+
+  return res.data;
+};
+
 export const listCaseNames = async (): Promise<string[]> => {
   const res = await api.get<string[]>(`${CASES_URL}/names`, {
     headers: { 'Cache-Control': 'no-cache' },

--- a/frontend/src/features/simulations/caseUtils.ts
+++ b/frontend/src/features/simulations/caseUtils.ts
@@ -1,0 +1,30 @@
+import { format } from 'date-fns';
+
+import type { CaseOut, SimulationSummaryOut } from '@/types';
+
+export const formatCaseDate = (value?: string | null) => {
+  if (!value) return '—';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+
+  return format(date, 'yyyy-MM-dd');
+};
+
+export const formatSimulationDateRange = (simulation: SimulationSummaryOut) =>
+  `${formatCaseDate(simulation.simulationStartDate)} → ${formatCaseDate(simulation.simulationEndDate)}`;
+
+export const getCanonicalSimulation = (caseRecord: CaseOut) =>
+  caseRecord.simulations.find((simulation) => simulation.id === caseRecord.canonicalSimulationId) ??
+  null;
+
+export const sortSimulationSummaries = (simulations: SimulationSummaryOut[]) =>
+  [...simulations].sort((left, right) => {
+    if (left.isCanonical !== right.isCanonical) {
+      return left.isCanonical ? -1 : 1;
+    }
+
+    return (
+      new Date(right.simulationStartDate).getTime() - new Date(left.simulationStartDate).getTime()
+    );
+  });

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -1,3 +1,4 @@
+import { ArrowLeft } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -20,6 +21,8 @@ import { formatDate, getSimulationDuration } from '@/utils/utils';
 interface SimulationDetailsViewProps {
   simulation: SimulationOut;
   canEdit?: boolean;
+  backHref?: string;
+  backLabel?: string;
 }
 
 // -------------------- Small UI helpers --------------------
@@ -47,6 +50,8 @@ const DiffCell = ({ value, className }: { value: unknown; className?: string }) 
 export const SimulationDetailsView = ({
   simulation,
   canEdit = false,
+  backHref = '/browse',
+  backLabel = 'Back to Runs',
 }: SimulationDetailsViewProps) => {
   const [activeTab, setActiveTab] = useState('summary');
   const [notes, setNotes] = useState(simulation.notesMarkdown || '');
@@ -83,6 +88,12 @@ export const SimulationDetailsView = ({
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
+          <Button variant="outline" size="sm" asChild className="mb-3">
+            <Link to={backHref}>
+              <ArrowLeft className="h-4 w-4" />
+              {backLabel}
+            </Link>
+          </Button>
           <h1 className="text-2xl font-bold">{simulation.executionId}</h1>
           <p className="text-sm text-muted-foreground">{simulation.caseName}</p>
           <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
@@ -98,10 +109,6 @@ export const SimulationDetailsView = ({
                 <code className="rounded bg-muted px-2 py-0.5 text-xs">{simulation.gitTag}</code>
               </>
             )}
-            <span>•</span>
-            <Link to="/browse" className="text-blue-600 hover:underline">
-              Back to results
-            </Link>
           </div>
         </div>
         <div className="flex items-center gap-2">

--- a/frontend/src/features/simulations/hooks/useCase.ts
+++ b/frontend/src/features/simulations/hooks/useCase.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+import { getCaseById } from '@/features/simulations/api/api';
+import type { CaseOut } from '@/types';
+
+export const useCase = (id: string) => {
+  const [data, setData] = useState<CaseOut | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    getCaseById(id)
+      .then((json) => {
+        if (!cancelled) setData(json);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return { data, loading, error };
+};

--- a/frontend/src/features/simulations/hooks/useCases.ts
+++ b/frontend/src/features/simulations/hooks/useCases.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+import { listCases } from '@/features/simulations/api/api';
+import type { CaseOut } from '@/types';
+
+export const useCases = () => {
+  const [data, setData] = useState<CaseOut[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    listCases()
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { data, loading, error };
+};

--- a/frontend/src/features/simulations/routes.tsx
+++ b/frontend/src/features/simulations/routes.tsx
@@ -8,16 +8,28 @@ import type { SimulationOut } from '@/types';
 
 interface SimulationRoutesProps {
   simulations: SimulationOut[];
+  selectedSimulationIds: string[];
+  setSelectedSimulationIds: (ids: string[]) => void;
 }
 
-export const simulationsRoutes = ({ simulations }: SimulationRoutesProps): RouteObject[] => [
+export const simulationsRoutes = ({
+  simulations,
+  selectedSimulationIds,
+  setSelectedSimulationIds,
+}: SimulationRoutesProps): RouteObject[] => [
   {
     path: '/cases',
     element: <CasesPage simulations={simulations} />,
   },
   {
     path: '/cases/:id',
-    element: <CaseDetailsPage simulations={simulations} />,
+    element: (
+      <CaseDetailsPage
+        simulations={simulations}
+        selectedSimulationIds={selectedSimulationIds}
+        setSelectedSimulationIds={setSelectedSimulationIds}
+      />
+    ),
   },
   {
     path: '/simulations',

--- a/frontend/src/features/simulations/routes.tsx
+++ b/frontend/src/features/simulations/routes.tsx
@@ -13,7 +13,7 @@ interface SimulationRoutesProps {
 export const simulationsRoutes = ({ simulations }: SimulationRoutesProps): RouteObject[] => [
   {
     path: '/cases',
-    element: <CasesPage />,
+    element: <CasesPage simulations={simulations} />,
   },
   {
     path: '/cases/:id',

--- a/frontend/src/features/simulations/routes.tsx
+++ b/frontend/src/features/simulations/routes.tsx
@@ -1,5 +1,7 @@
 import type { RouteObject } from 'react-router-dom';
 
+import { CaseDetailsPage } from '@/features/simulations/CaseDetailsPage';
+import { CasesPage } from '@/features/simulations/CasesPage';
 import { SimulationDetailsPage } from '@/features/simulations/SimulationDetailsPage';
 import { SimulationsPage } from '@/features/simulations/SimulationsPage';
 import type { SimulationOut } from '@/types';
@@ -9,6 +11,14 @@ interface SimulationRoutesProps {
 }
 
 export const simulationsRoutes = ({ simulations }: SimulationRoutesProps): RouteObject[] => [
+  {
+    path: '/cases',
+    element: <CasesPage />,
+  },
+  {
+    path: '/cases/:id',
+    element: <CaseDetailsPage />,
+  },
   {
     path: '/simulations',
     element: <SimulationsPage simulations={simulations} />,

--- a/frontend/src/features/simulations/routes.tsx
+++ b/frontend/src/features/simulations/routes.tsx
@@ -17,7 +17,7 @@ export const simulationsRoutes = ({ simulations }: SimulationRoutesProps): Route
   },
   {
     path: '/cases/:id',
-    element: <CaseDetailsPage />,
+    element: <CaseDetailsPage simulations={simulations} />,
   },
   {
     path: '/simulations',


### PR DESCRIPTION
## Description

Adds case-centric navigation and pages to the frontend, aligning browsing UX with the Case → Simulation (execution) hierarchy in the SimBoard data model.

- Adds case-centric browsing and detail routes at `/cases` and `/cases/:id`.
- Makes `Cases` the primary discovery flow with case-first homepage copy, summary stats, and recent-case activity.
- Expands `/cases` with quick filters, advanced filters, active filter pills, expandable simulation summaries, and case-level machine/HPC context.
- Expands `/cases/:id` with case metadata, baseline simulation context, compare selection, richer simulation summaries, and deterministic back navigation.
- Local verification run:
  - `pnpm --dir frontend run type-check`
  - `pnpm --dir frontend run lint`
  - `make frontend-lint`

Closes #121

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [ ] Tests added or updated (if needed)
- [ ] All tests pass (locally and CI/CD)
- [ ] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)
- None.
