### PR TITLE
Replace canonical simulation terminology with reference

### DIFF
--- a/backend/app/features/ingestion/api.py
+++ b/backend/app/features/ingestion/api.py
@@ -384,8 +384,8 @@ def _resolve_ingestion_status(created_count: int, error_count: int) -> str:
     return IngestionStatus.FAILED.value
 
 
-def _set_baseline_simulations(db: Session, created_sims: list[Simulation]) -> None:
-    """Set the baseline simulation per case when one is not already set."""
+def _set_reference_simulations(db: Session, created_sims: list[Simulation]) -> None:
+    """Set the reference simulation per case when one is not already set."""
     case_ids: set[UUID] = {
         case_id for sim in created_sims if isinstance((case_id := sim.case_id), UUID)
     }
@@ -397,10 +397,10 @@ def _set_baseline_simulations(db: Session, created_sims: list[Simulation]) -> No
 
             if (
                 case
-                and case.baseline_simulation_id is None
+                and case.reference_simulation_id is None
                 and isinstance(sim.id, UUID)
             ):
-                case.baseline_simulation_id = sim.id
+                case.reference_simulation_id = sim.id
                 db.add(case)
 
 
@@ -413,9 +413,9 @@ def _persist_simulations(
 ) -> list[Simulation]:
     """Persist simulation records with artifacts and links to the database.
 
-    After all simulations are flushed, sets the baseline simulation on
+    After all simulations are flushed, sets the reference simulation on
     each Case that does not yet have one.  The first simulation per Case
-    (in insertion order) becomes the baseline.
+    (in insertion order) becomes the reference.
 
     Parameters
     ----------
@@ -481,7 +481,7 @@ def _persist_simulations(
 
     db.flush()
 
-    _set_baseline_simulations(db, created_sims)
+    _set_reference_simulations(db, created_sims)
 
     return created_sims
 

--- a/backend/app/features/ingestion/api.py
+++ b/backend/app/features/ingestion/api.py
@@ -384,8 +384,8 @@ def _resolve_ingestion_status(created_count: int, error_count: int) -> str:
     return IngestionStatus.FAILED.value
 
 
-def _set_canonical_simulations(db: Session, created_sims: list[Simulation]) -> None:
-    """Set canonical simulation per case when canonical is not already set."""
+def _set_baseline_simulations(db: Session, created_sims: list[Simulation]) -> None:
+    """Set the baseline simulation per case when one is not already set."""
     case_ids: set[UUID] = {
         case_id for sim in created_sims if isinstance((case_id := sim.case_id), UUID)
     }
@@ -397,10 +397,10 @@ def _set_canonical_simulations(db: Session, created_sims: list[Simulation]) -> N
 
             if (
                 case
-                and case.canonical_simulation_id is None
+                and case.baseline_simulation_id is None
                 and isinstance(sim.id, UUID)
             ):
-                case.canonical_simulation_id = sim.id
+                case.baseline_simulation_id = sim.id
                 db.add(case)
 
 
@@ -413,9 +413,9 @@ def _persist_simulations(
 ) -> list[Simulation]:
     """Persist simulation records with artifacts and links to the database.
 
-    After all simulations are flushed, sets the canonical simulation on
+    After all simulations are flushed, sets the baseline simulation on
     each Case that does not yet have one.  The first simulation per Case
-    (in insertion order) becomes canonical.
+    (in insertion order) becomes the baseline.
 
     Parameters
     ----------
@@ -481,7 +481,7 @@ def _persist_simulations(
 
     db.flush()
 
-    _set_canonical_simulations(db, created_sims)
+    _set_baseline_simulations(db, created_sims)
 
     return created_sims
 

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -1,20 +1,20 @@
 """
 Module for ingesting simulation archives and mapping to DB schemas.
 
-Canonical run semantics for performance_archive ingestion:
+Baseline simulation semantics for performance_archive ingestion:
   - A run is "successful" only if all required metadata files are present.
   - case_name (from timing files) is the identity for Case grouping.
-  - The first successful run per case is the canonical baseline.
+  - The first successful run per case is the baseline simulation.
   - Each run creates a Simulation linked to a Case via case_id.
-  - Canonical simulation has run_config_deltas = None.
-  - Non-canonical runs store config differences vs canonical.
+  - Baseline simulations have run_config_deltas = None.
+  - Non-baseline runs store config differences vs the baseline.
   - Incomplete runs are skipped at the parser level.
   - Re-processing is idempotent due to execution_id uniqueness.
 
-Caching for canonical lookup:
-  - canonical_cache: canonical metadata for new cases in this ingest batch,
+Caching for baseline lookup:
+  - baseline_cache: baseline metadata for new cases in this ingest batch,
     keyed by case_name.
-  - persisted_canonical_cache: canonical metadata for cases already in DB,
+  - persisted_baseline_cache: baseline metadata for cases already in DB,
     keyed by case.id, to avoid repeated DB queries.
 """
 
@@ -106,23 +106,22 @@ def ingest_archive(
 ) -> IngestArchiveResult:
     """Ingest a simulation archive and return summary counts.
 
-    Implements canonical run semantics:
+    Implements baseline simulation semantics:
 
     - Case lookup/creation is done by ``case_name`` from timing files.
-    - The first successful run per case becomes the canonical baseline
+    - The first successful run per case becomes the baseline simulation
       (``run_config_deltas = None``).
-    - Non-canonical simulations store a single dict of configuration
-      differences versus the canonical.
+    - Non-baseline simulations store a single dict of configuration
+      differences versus the baseline.
     - Duplicate detection is based on ``execution_id`` uniqueness.
     - Uses two caches to avoid redundant work:
-       - ``canonical_cache``: Tracks the canonical simulation metadata for each
+       - ``baseline_cache``: Tracks the baseline simulation metadata for each
            new case found in the current ingest batch (keyed by case_name). This
            ensures that if multiple new runs for the same case appear in a
-           single archive, all are compared against the same in-batch canonical
-           baseline.
-       - ``persisted_canonical_cache``: Tracks canonical simulation metadata
+           single archive, all are compared against the same in-batch baseline.
+       - ``persisted_baseline_cache``: Tracks baseline simulation metadata
            for cases already in the database (keyed by case.id). This avoids
-           repeated database queries for the canonical simulation of a case
+           repeated database queries for the baseline simulation of a case
            when processing multiple runs for the same case in a single ingest
            operation.
 
@@ -167,16 +166,16 @@ def ingest_archive(
     simulations: list[SimulationCreate] = []
     duplicate_count = 0
     errors: list[dict[str, str]] = []
-    canonical_cache: dict[str, SimulationConfigSnapshot] = {}
-    persisted_canonical_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
+    baseline_cache: dict[str, SimulationConfigSnapshot] = {}
+    persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
 
     for parsed_simulation in parsed_simulations:
         try:
             simulation, is_duplicate = _process_simulation_for_ingest(
                 parsed_simulation=parsed_simulation,
                 db=db,
-                canonical_cache=canonical_cache,
-                persisted_canonical_cache=persisted_canonical_cache,
+                baseline_cache=baseline_cache,
+                persisted_baseline_cache=persisted_baseline_cache,
             )
 
             if is_duplicate:
@@ -216,8 +215,8 @@ def ingest_archive(
 def _process_simulation_for_ingest(
     parsed_simulation: ParsedSimulation,
     db: Session,
-    canonical_cache: dict[str, SimulationConfigSnapshot],
-    persisted_canonical_cache: dict[UUID, SimulationConfigSnapshot | None],
+    baseline_cache: dict[str, SimulationConfigSnapshot],
+    persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None],
 ) -> tuple[SimulationCreate | None, bool]:
     """Process one parsed simulation entry.
 
@@ -227,10 +226,10 @@ def _process_simulation_for_ingest(
         Parsed archive-derived metadata for the simulation.
     db : Session
         Active database session for lookups and case resolution.
-    canonical_cache : dict[str, SimulationConfigSnapshot]
-        In-memory cache of canonical config values per case_name for the current batch.
-    persisted_canonical_cache : dict[UUID, SimulationConfigSnapshot | None]
-        Cache of canonical metadata loaded from the database by case_id.
+    baseline_cache : dict[str, SimulationConfigSnapshot]
+        In-memory cache of baseline config values per case_name for the current batch.
+    persisted_baseline_cache : dict[UUID, SimulationConfigSnapshot | None]
+        Cache of baseline metadata loaded from the database by case_id.
 
     Returns
     -------
@@ -245,8 +244,8 @@ def _process_simulation_for_ingest(
     case = _resolve_case(parsed_simulation, case_name, db)
 
     if _is_duplicate_simulation(execution_id, parsed_simulation.execution_dir, db):
-        _seed_canonical_cache_from_duplicate(
-            case_name, parsed_simulation, canonical_cache
+        _seed_baseline_cache_from_duplicate(
+            case_name, parsed_simulation, baseline_cache
         )
         return None, True
 
@@ -254,8 +253,8 @@ def _process_simulation_for_ingest(
         parsed_simulation=parsed_simulation,
         machine_id=machine_id,
         case=case,
-        canonical_cache=canonical_cache,
-        persisted_canonical_cache=persisted_canonical_cache,
+        baseline_cache=baseline_cache,
+        persisted_baseline_cache=persisted_baseline_cache,
         db=db,
     )
 
@@ -302,25 +301,25 @@ def _is_duplicate_simulation(
     return True
 
 
-def _seed_canonical_cache_from_duplicate(
+def _seed_baseline_cache_from_duplicate(
     case_name: str,
     parsed_simulation: ParsedSimulation,
-    canonical_cache: dict[str, SimulationConfigSnapshot],
+    baseline_cache: dict[str, SimulationConfigSnapshot],
 ) -> None:
-    """Seed per-case canonical cache using duplicate metadata when needed."""
-    if case_name not in canonical_cache:
-        canonical_cache[case_name] = _build_config_snapshot(parsed_simulation)
+    """Seed per-case baseline cache using duplicate metadata when needed."""
+    if case_name not in baseline_cache:
+        baseline_cache[case_name] = _build_config_snapshot(parsed_simulation)
 
 
 def _build_simulation_create(
     parsed_simulation: ParsedSimulation,
     machine_id: UUID,
     case: Case,
-    canonical_cache: dict[str, SimulationConfigSnapshot],
-    persisted_canonical_cache: dict[UUID, SimulationConfigSnapshot | None],
+    baseline_cache: dict[str, SimulationConfigSnapshot],
+    persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None],
     db: Session,
 ) -> SimulationCreate:
-    """Create a SimulationCreate using canonical baseline semantics.
+    """Create a SimulationCreate using baseline simulation semantics.
 
     Parameters
     ----------
@@ -330,24 +329,24 @@ def _build_simulation_create(
         Resolved machine ID from the database.
     case : Case
         Resolved Case object for this simulation.
-    canonical_cache : dict[str, SimulationConfigSnapshot]
-        In-memory cache of canonical metadata per case_name for the current batch.
-    persisted_canonical_cache : dict[UUID, SimulationConfigSnapshot | None]
-        Cache of canonical metadata loaded from the database by case_id.
+    baseline_cache : dict[str, SimulationConfigSnapshot]
+        In-memory cache of baseline metadata per case_name for the current batch.
+    persisted_baseline_cache : dict[UUID, SimulationConfigSnapshot | None]
+        Cache of baseline metadata loaded from the database by case_id.
     db : Session
         Active database session for lookups and case resolution.
     """
     case_name = case.name
-    canonical_snapshot = _get_canonical_metadata_for_case(
+    baseline_snapshot = _get_baseline_metadata_for_case(
         case=case,
         case_name=case_name,
-        canonical_cache=canonical_cache,
-        persisted_canonical_cache=persisted_canonical_cache,
+        baseline_cache=baseline_cache,
+        persisted_baseline_cache=persisted_baseline_cache,
         db=db,
     )
 
-    if canonical_snapshot is None:
-        canonical_cache[case_name] = _build_config_snapshot(parsed_simulation)
+    if baseline_snapshot is None:
+        baseline_cache[case_name] = _build_config_snapshot(parsed_simulation)
 
         simulation = _validate_simulation_create(
             _build_simulation_create_draft(
@@ -357,14 +356,14 @@ def _build_simulation_create(
             )
         )
         logger.info(
-            "Mapped canonical simulation from %s: %s",
+            "Mapped baseline simulation from %s: %s",
             parsed_simulation.execution_dir,
             case_name,
         )
 
         return simulation
 
-    delta = canonical_snapshot.diff(_build_config_snapshot(parsed_simulation))
+    delta = baseline_snapshot.diff(_build_config_snapshot(parsed_simulation))
     run_config_deltas = delta if delta else None
     simulation_draft = _build_simulation_create_draft(
         parsed_simulation=parsed_simulation,
@@ -376,67 +375,67 @@ def _build_simulation_create(
 
     if delta:
         logger.info(
-            "Non-canonical run in '%s' has config differences from canonical: %s",
+            "Non-baseline run in '%s' has config differences from the baseline: %s",
             parsed_simulation.execution_dir,
             list(delta.keys()),
         )
     else:
         logger.info(
-            "Non-canonical run in '%s' has identical configuration to canonical.",
+            "Non-baseline run in '%s' has identical configuration to the baseline.",
             parsed_simulation.execution_dir,
         )
 
     return simulation
 
 
-def _get_canonical_metadata_for_case(
+def _get_baseline_metadata_for_case(
     case: Case,
     case_name: str,
-    canonical_cache: dict[str, SimulationConfigSnapshot],
-    persisted_canonical_cache: dict[UUID, SimulationConfigSnapshot | None],
+    baseline_cache: dict[str, SimulationConfigSnapshot],
+    persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None],
     db: Session,
 ) -> SimulationConfigSnapshot | None:
-    """Resolve canonical metadata from persisted canonical or batch cache.
+    """Resolve baseline metadata from persisted baseline or batch cache.
 
     This function is useful for ensuring that all simulations of the same case
-    within a batch are compared against a consistent canonical baseline.
+    within a batch are compared against a consistent baseline simulation.
 
     Parameters
     ----------
     case : Case
-        The Case object for which to retrieve canonical metadata.
+        The Case object for which to retrieve baseline metadata.
     case_name : str
         The name of the case, used for in-memory cache lookup.
-    canonical_cache : dict[str, SimulationConfigSnapshot]
-        In-memory cache of canonical metadata per case_name for the current batch.
-    persisted_canonical_cache : dict[UUID, SimulationConfigSnapshot | None]
-        Cache of canonical metadata loaded from the database by case_id.
+    baseline_cache : dict[str, SimulationConfigSnapshot]
+        In-memory cache of baseline metadata per case_name for the current batch.
+    persisted_baseline_cache : dict[UUID, SimulationConfigSnapshot | None]
+        Cache of baseline metadata loaded from the database by case_id.
 
     Returns
     -------
     SimulationConfigSnapshot | None
-        The canonical config snapshot for the case, or None if no canonical run exists.
+        The baseline config snapshot for the case, or None if no baseline run exists.
     """
-    if case.canonical_simulation_id is not None:
-        if case.id in persisted_canonical_cache:
-            return persisted_canonical_cache[case.id]
+    if case.baseline_simulation_id is not None:
+        if case.id in persisted_baseline_cache:
+            return persisted_baseline_cache[case.id]
 
-        canonical_sim = (
+        baseline_simulation = (
             db.query(Simulation)
-            .filter(Simulation.id == case.canonical_simulation_id)
+            .filter(Simulation.id == case.baseline_simulation_id)
             .first()
         )
 
-        if canonical_sim:
-            canonical_snapshot = _build_config_snapshot(canonical_sim)
-            persisted_canonical_cache[case.id] = canonical_snapshot
+        if baseline_simulation:
+            baseline_snapshot = _build_config_snapshot(baseline_simulation)
+            persisted_baseline_cache[case.id] = baseline_snapshot
 
-            return canonical_snapshot
+            return baseline_snapshot
 
-        persisted_canonical_cache[case.id] = None
+        persisted_baseline_cache[case.id] = None
         return None
 
-    return canonical_cache.get(case_name)
+    return baseline_cache.get(case_name)
 
 
 def _get_or_create_case(db: Session, name: str, case_group: str | None = None) -> Case:
@@ -448,7 +447,7 @@ def _get_or_create_case(db: Session, name: str, case_group: str | None = None) -
         Active database session.
     name : str
         Case name derived from the execution (e.g. from timing files).
-        Used as the canonical identity for case grouping.
+        Used as the stable identity for case grouping.
     case_group : str | None
         Optional CASE_GROUP from env_case.xml.  Stored on ``Case``
         if present.  An existing non-null value is never overwritten
@@ -484,7 +483,7 @@ def _get_or_create_case(db: Session, name: str, case_group: str | None = None) -
 def _build_config_snapshot(
     source: ParsedSimulation | Simulation,
 ) -> SimulationConfigSnapshot:
-    """Return a normalized config snapshot for canonical delta comparison."""
+    """Return a normalized config snapshot for baseline delta comparison."""
     snapshot_values: dict[str, str | None] = {}
 
     for field_name in SimulationConfigSnapshot.field_names():
@@ -640,7 +639,7 @@ def _build_simulation_create_draft(
     case_id : UUID
         ID of the Case this simulation belongs to.
     run_config_deltas : dict | None
-        Configuration differences vs canonical baseline, or None.
+        Configuration differences vs the baseline simulation, or None.
 
     Returns
     -------

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -1,20 +1,20 @@
 """
 Module for ingesting simulation archives and mapping to DB schemas.
 
-Baseline simulation semantics for performance_archive ingestion:
+Reference simulation semantics for performance_archive ingestion:
   - A run is "successful" only if all required metadata files are present.
   - case_name (from timing files) is the identity for Case grouping.
-  - The first successful run per case is the baseline simulation.
+  - The first successful run per case is the reference simulation.
   - Each run creates a Simulation linked to a Case via case_id.
-  - Baseline simulations have run_config_deltas = None.
-  - Non-baseline runs store config differences vs the baseline.
+  - Reference simulations have run_config_deltas = None.
+  - Non-reference runs store config differences vs the reference.
   - Incomplete runs are skipped at the parser level.
   - Re-processing is idempotent due to execution_id uniqueness.
 
-Caching for baseline lookup:
-  - baseline_cache: baseline metadata for new cases in this ingest batch,
+Caching for reference lookup:
+  - reference_cache: reference metadata for new cases in this ingest batch,
     keyed by case_name.
-  - persisted_baseline_cache: baseline metadata for cases already in DB,
+  - persisted_reference_cache: reference metadata for cases already in DB,
     keyed by case.id, to avoid repeated DB queries.
 """
 
@@ -106,22 +106,22 @@ def ingest_archive(
 ) -> IngestArchiveResult:
     """Ingest a simulation archive and return summary counts.
 
-    Implements baseline simulation semantics:
+    Implements reference simulation semantics:
 
     - Case lookup/creation is done by ``case_name`` from timing files.
-    - The first successful run per case becomes the baseline simulation
+    - The first successful run per case becomes the reference simulation
       (``run_config_deltas = None``).
-    - Non-baseline simulations store a single dict of configuration
-      differences versus the baseline.
+    - Non-reference simulations store a single dict of configuration
+      differences versus the reference.
     - Duplicate detection is based on ``execution_id`` uniqueness.
     - Uses two caches to avoid redundant work:
-       - ``baseline_cache``: Tracks the baseline simulation metadata for each
+       - ``reference_cache``: Tracks the reference simulation metadata for each
            new case found in the current ingest batch (keyed by case_name). This
            ensures that if multiple new runs for the same case appear in a
-           single archive, all are compared against the same in-batch baseline.
-       - ``persisted_baseline_cache``: Tracks baseline simulation metadata
+           single archive, all are compared against the same in-batch reference.
+       - ``persisted_reference_cache``: Tracks reference simulation metadata
            for cases already in the database (keyed by case.id). This avoids
-           repeated database queries for the baseline simulation of a case
+           repeated database queries for the reference simulation of a case
            when processing multiple runs for the same case in a single ingest
            operation.
 
@@ -166,16 +166,16 @@ def ingest_archive(
     simulations: list[SimulationCreate] = []
     duplicate_count = 0
     errors: list[dict[str, str]] = []
-    baseline_cache: dict[str, SimulationConfigSnapshot] = {}
-    persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
+    reference_cache: dict[str, SimulationConfigSnapshot] = {}
+    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
 
     for parsed_simulation in parsed_simulations:
         try:
             simulation, is_duplicate = _process_simulation_for_ingest(
                 parsed_simulation=parsed_simulation,
                 db=db,
-                baseline_cache=baseline_cache,
-                persisted_baseline_cache=persisted_baseline_cache,
+                reference_cache=reference_cache,
+                persisted_reference_cache=persisted_reference_cache,
             )
 
             if is_duplicate:
@@ -215,8 +215,8 @@ def ingest_archive(
 def _process_simulation_for_ingest(
     parsed_simulation: ParsedSimulation,
     db: Session,
-    baseline_cache: dict[str, SimulationConfigSnapshot],
-    persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None],
+    reference_cache: dict[str, SimulationConfigSnapshot],
+    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
 ) -> tuple[SimulationCreate | None, bool]:
     """Process one parsed simulation entry.
 
@@ -226,10 +226,10 @@ def _process_simulation_for_ingest(
         Parsed archive-derived metadata for the simulation.
     db : Session
         Active database session for lookups and case resolution.
-    baseline_cache : dict[str, SimulationConfigSnapshot]
-        In-memory cache of baseline config values per case_name for the current batch.
-    persisted_baseline_cache : dict[UUID, SimulationConfigSnapshot | None]
-        Cache of baseline metadata loaded from the database by case_id.
+    reference_cache : dict[str, SimulationConfigSnapshot]
+        In-memory cache of reference config values per case_name for the current batch.
+    persisted_reference_cache : dict[UUID, SimulationConfigSnapshot | None]
+        Cache of reference metadata loaded from the database by case_id.
 
     Returns
     -------
@@ -244,8 +244,8 @@ def _process_simulation_for_ingest(
     case = _resolve_case(parsed_simulation, case_name, db)
 
     if _is_duplicate_simulation(execution_id, parsed_simulation.execution_dir, db):
-        _seed_baseline_cache_from_duplicate(
-            case_name, parsed_simulation, baseline_cache
+        _seed_reference_cache_from_duplicate(
+            case_name, parsed_simulation, reference_cache
         )
         return None, True
 
@@ -253,8 +253,8 @@ def _process_simulation_for_ingest(
         parsed_simulation=parsed_simulation,
         machine_id=machine_id,
         case=case,
-        baseline_cache=baseline_cache,
-        persisted_baseline_cache=persisted_baseline_cache,
+        reference_cache=reference_cache,
+        persisted_reference_cache=persisted_reference_cache,
         db=db,
     )
 
@@ -301,25 +301,25 @@ def _is_duplicate_simulation(
     return True
 
 
-def _seed_baseline_cache_from_duplicate(
+def _seed_reference_cache_from_duplicate(
     case_name: str,
     parsed_simulation: ParsedSimulation,
-    baseline_cache: dict[str, SimulationConfigSnapshot],
+    reference_cache: dict[str, SimulationConfigSnapshot],
 ) -> None:
-    """Seed per-case baseline cache using duplicate metadata when needed."""
-    if case_name not in baseline_cache:
-        baseline_cache[case_name] = _build_config_snapshot(parsed_simulation)
+    """Seed per-case reference cache using duplicate metadata when needed."""
+    if case_name not in reference_cache:
+        reference_cache[case_name] = _build_config_snapshot(parsed_simulation)
 
 
 def _build_simulation_create(
     parsed_simulation: ParsedSimulation,
     machine_id: UUID,
     case: Case,
-    baseline_cache: dict[str, SimulationConfigSnapshot],
-    persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None],
+    reference_cache: dict[str, SimulationConfigSnapshot],
+    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
     db: Session,
 ) -> SimulationCreate:
-    """Create a SimulationCreate using baseline simulation semantics.
+    """Create a SimulationCreate using reference simulation semantics.
 
     Parameters
     ----------
@@ -329,24 +329,24 @@ def _build_simulation_create(
         Resolved machine ID from the database.
     case : Case
         Resolved Case object for this simulation.
-    baseline_cache : dict[str, SimulationConfigSnapshot]
-        In-memory cache of baseline metadata per case_name for the current batch.
-    persisted_baseline_cache : dict[UUID, SimulationConfigSnapshot | None]
-        Cache of baseline metadata loaded from the database by case_id.
+    reference_cache : dict[str, SimulationConfigSnapshot]
+        In-memory cache of reference metadata per case_name for the current batch.
+    persisted_reference_cache : dict[UUID, SimulationConfigSnapshot | None]
+        Cache of reference metadata loaded from the database by case_id.
     db : Session
         Active database session for lookups and case resolution.
     """
     case_name = case.name
-    baseline_snapshot = _get_baseline_metadata_for_case(
+    reference_snapshot = _get_reference_metadata_for_case(
         case=case,
         case_name=case_name,
-        baseline_cache=baseline_cache,
-        persisted_baseline_cache=persisted_baseline_cache,
+        reference_cache=reference_cache,
+        persisted_reference_cache=persisted_reference_cache,
         db=db,
     )
 
-    if baseline_snapshot is None:
-        baseline_cache[case_name] = _build_config_snapshot(parsed_simulation)
+    if reference_snapshot is None:
+        reference_cache[case_name] = _build_config_snapshot(parsed_simulation)
 
         simulation = _validate_simulation_create(
             _build_simulation_create_draft(
@@ -356,14 +356,14 @@ def _build_simulation_create(
             )
         )
         logger.info(
-            "Mapped baseline simulation from %s: %s",
+            "Mapped reference simulation from %s: %s",
             parsed_simulation.execution_dir,
             case_name,
         )
 
         return simulation
 
-    delta = baseline_snapshot.diff(_build_config_snapshot(parsed_simulation))
+    delta = reference_snapshot.diff(_build_config_snapshot(parsed_simulation))
     run_config_deltas = delta if delta else None
     simulation_draft = _build_simulation_create_draft(
         parsed_simulation=parsed_simulation,
@@ -375,67 +375,67 @@ def _build_simulation_create(
 
     if delta:
         logger.info(
-            "Non-baseline run in '%s' has config differences from the baseline: %s",
+            "Non-reference run in '%s' has config differences from the reference: %s",
             parsed_simulation.execution_dir,
             list(delta.keys()),
         )
     else:
         logger.info(
-            "Non-baseline run in '%s' has identical configuration to the baseline.",
+            "Non-reference run in '%s' has identical configuration to the reference.",
             parsed_simulation.execution_dir,
         )
 
     return simulation
 
 
-def _get_baseline_metadata_for_case(
+def _get_reference_metadata_for_case(
     case: Case,
     case_name: str,
-    baseline_cache: dict[str, SimulationConfigSnapshot],
-    persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None],
+    reference_cache: dict[str, SimulationConfigSnapshot],
+    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
     db: Session,
 ) -> SimulationConfigSnapshot | None:
-    """Resolve baseline metadata from persisted baseline or batch cache.
+    """Resolve reference metadata from persisted reference or batch cache.
 
     This function is useful for ensuring that all simulations of the same case
-    within a batch are compared against a consistent baseline simulation.
+    within a batch are compared against a consistent reference simulation.
 
     Parameters
     ----------
     case : Case
-        The Case object for which to retrieve baseline metadata.
+        The Case object for which to retrieve reference metadata.
     case_name : str
         The name of the case, used for in-memory cache lookup.
-    baseline_cache : dict[str, SimulationConfigSnapshot]
-        In-memory cache of baseline metadata per case_name for the current batch.
-    persisted_baseline_cache : dict[UUID, SimulationConfigSnapshot | None]
-        Cache of baseline metadata loaded from the database by case_id.
+    reference_cache : dict[str, SimulationConfigSnapshot]
+        In-memory cache of reference metadata per case_name for the current batch.
+    persisted_reference_cache : dict[UUID, SimulationConfigSnapshot | None]
+        Cache of reference metadata loaded from the database by case_id.
 
     Returns
     -------
     SimulationConfigSnapshot | None
-        The baseline config snapshot for the case, or None if no baseline run exists.
+        The reference config snapshot for the case, or None if no reference run exists.
     """
-    if case.baseline_simulation_id is not None:
-        if case.id in persisted_baseline_cache:
-            return persisted_baseline_cache[case.id]
+    if case.reference_simulation_id is not None:
+        if case.id in persisted_reference_cache:
+            return persisted_reference_cache[case.id]
 
-        baseline_simulation = (
+        reference_simulation = (
             db.query(Simulation)
-            .filter(Simulation.id == case.baseline_simulation_id)
+            .filter(Simulation.id == case.reference_simulation_id)
             .first()
         )
 
-        if baseline_simulation:
-            baseline_snapshot = _build_config_snapshot(baseline_simulation)
-            persisted_baseline_cache[case.id] = baseline_snapshot
+        if reference_simulation:
+            reference_snapshot = _build_config_snapshot(reference_simulation)
+            persisted_reference_cache[case.id] = reference_snapshot
 
-            return baseline_snapshot
+            return reference_snapshot
 
-        persisted_baseline_cache[case.id] = None
+        persisted_reference_cache[case.id] = None
         return None
 
-    return baseline_cache.get(case_name)
+    return reference_cache.get(case_name)
 
 
 def _get_or_create_case(db: Session, name: str, case_group: str | None = None) -> Case:
@@ -483,7 +483,7 @@ def _get_or_create_case(db: Session, name: str, case_group: str | None = None) -
 def _build_config_snapshot(
     source: ParsedSimulation | Simulation,
 ) -> SimulationConfigSnapshot:
-    """Return a normalized config snapshot for baseline delta comparison."""
+    """Return a normalized config snapshot for reference delta comparison."""
     snapshot_values: dict[str, str | None] = {}
 
     for field_name in SimulationConfigSnapshot.field_names():
@@ -639,7 +639,7 @@ def _build_simulation_create_draft(
     case_id : UUID
         ID of the Case this simulation belongs to.
     run_config_deltas : dict | None
-        Configuration differences vs the baseline simulation, or None.
+        Configuration differences vs the reference simulation, or None.
 
     Returns
     -------

--- a/backend/app/features/ingestion/parsers/parser.py
+++ b/backend/app/features/ingestion/parsers/parser.py
@@ -15,7 +15,7 @@ Key behaviors:
   - Only directories with all required files are included in results.
   - Skipped/incomplete runs are counted and logged.
   - Parsing is deterministic: execution subdirectories are sorted to ensure
-    reproducible canonical run selection.
+    reproducible baseline run selection.
 
 This parser is used by the ingestion workflow to provide a consistent,
 reliable mapping from raw archive contents to structured simulation metadata.
@@ -156,7 +156,7 @@ def main_parser(
     skipped with a warning rather than aborting the entire ingestion.
 
     Within each case (parent directory), execution subdirectories are sorted
-    deterministically so that canonical run selection is reproducible.
+    deterministically so that baseline run selection is reproducible.
 
     Parameters
     ----------

--- a/backend/app/features/ingestion/parsers/parser.py
+++ b/backend/app/features/ingestion/parsers/parser.py
@@ -15,7 +15,7 @@ Key behaviors:
   - Only directories with all required files are included in results.
   - Skipped/incomplete runs are counted and logged.
   - Parsing is deterministic: execution subdirectories are sorted to ensure
-    reproducible baseline run selection.
+    reproducible reference run selection.
 
 This parser is used by the ingestion workflow to provide a consistent,
 reliable mapping from raw archive contents to structured simulation metadata.
@@ -156,7 +156,7 @@ def main_parser(
     skipped with a warning rather than aborting the entire ingestion.
 
     Within each case (parent directory), execution subdirectories are sorted
-    deterministically so that baseline run selection is reproducible.
+    deterministically so that reference run selection is reproducible.
 
     Parameters
     ----------

--- a/backend/app/features/simulation/api.py
+++ b/backend/app/features/simulation/api.py
@@ -156,7 +156,7 @@ def _case_to_out(case: Case) -> CaseOut:
     )
 
     for sim in case.simulations:
-        is_baseline = sim.id == case.baseline_simulation_id
+        is_reference = sim.id == case.reference_simulation_id
         change_count = len(sim.run_config_deltas) if sim.run_config_deltas else 0
 
         summaries.append(
@@ -164,7 +164,7 @@ def _case_to_out(case: Case) -> CaseOut:
                 id=sim.id,
                 execution_id=sim.execution_id,
                 status=sim.status,
-                is_baseline=is_baseline,
+                is_reference=is_reference,
                 change_count=change_count,
                 simulation_start_date=sim.simulation_start_date,
                 simulation_end_date=sim.simulation_end_date,
@@ -175,7 +175,7 @@ def _case_to_out(case: Case) -> CaseOut:
         id=case.id,
         name=case.name,
         case_group=case.case_group,
-        baseline_simulation_id=case.baseline_simulation_id,
+        reference_simulation_id=case.reference_simulation_id,
         simulations=summaries,
         machine_names=machine_names,
         hpc_usernames=hpc_usernames,
@@ -257,9 +257,9 @@ def create_simulation(
         db.add(sim)
         db.flush()
 
-        if case.baseline_simulation_id is None:
+        if case.reference_simulation_id is None:
             sim.run_config_deltas = None
-            case.baseline_simulation_id = sim.id
+            case.reference_simulation_id = sim.id
             db.add(case)
 
     # Re-query with relationships loaded
@@ -396,7 +396,7 @@ def get_simulation(sim_id: UUID, db: Session = Depends(get_database_session)):
 def _simulation_to_out(sim: Simulation) -> SimulationOut:
     """Convert a Simulation ORM instance to a SimulationOut schema.
 
-    Derives ``case_name``, ``is_baseline``, and ``change_count`` from
+    Derives ``case_name``, ``is_reference``, and ``change_count`` from
     the associated Case relationship.
 
     Parameters
@@ -411,7 +411,7 @@ def _simulation_to_out(sim: Simulation) -> SimulationOut:
         fields.
     """
     case = sim.case
-    is_baseline = sim.id == case.baseline_simulation_id
+    is_reference = sim.id == case.reference_simulation_id
     change_count = len(sim.run_config_deltas) if sim.run_config_deltas else 0
 
     result = SimulationOut.model_validate(
@@ -419,7 +419,7 @@ def _simulation_to_out(sim: Simulation) -> SimulationOut:
             **{k: v for k, v in sim.__dict__.items() if not k.startswith("_")},
             "case_name": case.name,
             "case_group": case.case_group,
-            "is_baseline": is_baseline,
+            "is_reference": is_reference,
             "change_count": change_count,
         },
         from_attributes=True,

--- a/backend/app/features/simulation/api.py
+++ b/backend/app/features/simulation/api.py
@@ -156,7 +156,7 @@ def _case_to_out(case: Case) -> CaseOut:
     )
 
     for sim in case.simulations:
-        is_canonical = sim.id == case.canonical_simulation_id
+        is_baseline = sim.id == case.baseline_simulation_id
         change_count = len(sim.run_config_deltas) if sim.run_config_deltas else 0
 
         summaries.append(
@@ -164,7 +164,7 @@ def _case_to_out(case: Case) -> CaseOut:
                 id=sim.id,
                 execution_id=sim.execution_id,
                 status=sim.status,
-                is_canonical=is_canonical,
+                is_baseline=is_baseline,
                 change_count=change_count,
                 simulation_start_date=sim.simulation_start_date,
                 simulation_end_date=sim.simulation_end_date,
@@ -175,7 +175,7 @@ def _case_to_out(case: Case) -> CaseOut:
         id=case.id,
         name=case.name,
         case_group=case.case_group,
-        canonical_simulation_id=case.canonical_simulation_id,
+        baseline_simulation_id=case.baseline_simulation_id,
         simulations=summaries,
         machine_names=machine_names,
         hpc_usernames=hpc_usernames,
@@ -257,9 +257,9 @@ def create_simulation(
         db.add(sim)
         db.flush()
 
-        if case.canonical_simulation_id is None:
+        if case.baseline_simulation_id is None:
             sim.run_config_deltas = None
-            case.canonical_simulation_id = sim.id
+            case.baseline_simulation_id = sim.id
             db.add(case)
 
     # Re-query with relationships loaded
@@ -396,7 +396,7 @@ def get_simulation(sim_id: UUID, db: Session = Depends(get_database_session)):
 def _simulation_to_out(sim: Simulation) -> SimulationOut:
     """Convert a Simulation ORM instance to a SimulationOut schema.
 
-    Derives ``case_name``, ``is_canonical``, and ``change_count`` from
+    Derives ``case_name``, ``is_baseline``, and ``change_count`` from
     the associated Case relationship.
 
     Parameters
@@ -411,7 +411,7 @@ def _simulation_to_out(sim: Simulation) -> SimulationOut:
         fields.
     """
     case = sim.case
-    is_canonical = sim.id == case.canonical_simulation_id
+    is_baseline = sim.id == case.baseline_simulation_id
     change_count = len(sim.run_config_deltas) if sim.run_config_deltas else 0
 
     result = SimulationOut.model_validate(
@@ -419,7 +419,7 @@ def _simulation_to_out(sim: Simulation) -> SimulationOut:
             **{k: v for k, v in sim.__dict__.items() if not k.startswith("_")},
             "case_name": case.name,
             "case_group": case.case_group,
-            "is_canonical": is_canonical,
+            "is_baseline": is_baseline,
             "change_count": change_count,
         },
         from_attributes=True,

--- a/backend/app/features/simulation/config_delta.py
+++ b/backend/app/features/simulation/config_delta.py
@@ -4,7 +4,7 @@ from dataclasses import fields as dataclass_fields
 
 @dataclass(frozen=True)
 class SimulationConfigSnapshot:
-    """Normalized configuration fields used for canonical delta comparison."""
+    """Normalized configuration fields used for baseline delta comparison."""
 
     compset: str | None
     compset_alias: str | None
@@ -22,7 +22,7 @@ class SimulationConfigSnapshot:
 
     @classmethod
     def field_names(cls) -> frozenset[str]:
-        """Return the config field set tracked for canonical comparisons."""
+        """Return the config field set tracked for baseline comparisons."""
         return frozenset(field.name for field in dataclass_fields(cls))
 
     def diff(
@@ -33,11 +33,11 @@ class SimulationConfigSnapshot:
 
         for field in dataclass_fields(self):
             field_name = field.name
-            canonical_value = getattr(self, field_name)
+            baseline_value = getattr(self, field_name)
             current_value = getattr(other, field_name)
-            if canonical_value != current_value:
+            if baseline_value != current_value:
                 delta[field_name] = {
-                    "canonical": canonical_value,
+                    "baseline": baseline_value,
                     "current": current_value,
                 }
 

--- a/backend/app/features/simulation/config_delta.py
+++ b/backend/app/features/simulation/config_delta.py
@@ -4,7 +4,7 @@ from dataclasses import fields as dataclass_fields
 
 @dataclass(frozen=True)
 class SimulationConfigSnapshot:
-    """Normalized configuration fields used for baseline delta comparison."""
+    """Normalized configuration fields used for reference delta comparison."""
 
     compset: str | None
     compset_alias: str | None
@@ -22,7 +22,7 @@ class SimulationConfigSnapshot:
 
     @classmethod
     def field_names(cls) -> frozenset[str]:
-        """Return the config field set tracked for baseline comparisons."""
+        """Return the config field set tracked for reference comparisons."""
         return frozenset(field.name for field in dataclass_fields(cls))
 
     def diff(
@@ -33,11 +33,11 @@ class SimulationConfigSnapshot:
 
         for field in dataclass_fields(self):
             field_name = field.name
-            baseline_value = getattr(self, field_name)
+            reference_value = getattr(self, field_name)
             current_value = getattr(other, field_name)
-            if baseline_value != current_value:
+            if reference_value != current_value:
                 delta[field_name] = {
-                    "baseline": baseline_value,
+                    "reference": reference_value,
                     "current": current_value,
                 }
 

--- a/backend/app/features/simulation/models.py
+++ b/backend/app/features/simulation/models.py
@@ -30,17 +30,17 @@ class Case(Base, IDMixin, TimestampMixin):
     """A logical experiment grouped by case name.
 
     Each Case contains one or more Simulation executions.  Exactly one
-    Simulation may be designated as the baseline via
-    :attr:`baseline_simulation_id`.
+    Simulation may be designated as the reference via
+    :attr:`reference_simulation_id`.
     """
 
     __tablename__ = "cases"
 
     name: Mapped[str] = mapped_column(Text, unique=True, index=True)
     case_group: Mapped[str | None] = mapped_column(Text, index=True, nullable=True)
-    baseline_simulation_id: Mapped[UUID | None] = mapped_column(
+    reference_simulation_id: Mapped[UUID | None] = mapped_column(
         PG_UUID(as_uuid=True),
-        ForeignKey("simulations.id", use_alter=True, name="fk_cases_baseline_sim"),
+        ForeignKey("simulations.id", use_alter=True, name="fk_cases_reference_sim"),
         nullable=True,
     )
 
@@ -52,8 +52,8 @@ class Case(Base, IDMixin, TimestampMixin):
         cascade="all, delete-orphan",
         passive_deletes=True,
     )
-    baseline_simulation: Mapped[Simulation | None] = relationship(
-        "Simulation", foreign_keys=[baseline_simulation_id], post_update=True
+    reference_simulation: Mapped[Simulation | None] = relationship(
+        "Simulation", foreign_keys=[reference_simulation_id], post_update=True
     )
 
 

--- a/backend/app/features/simulation/models.py
+++ b/backend/app/features/simulation/models.py
@@ -30,17 +30,17 @@ class Case(Base, IDMixin, TimestampMixin):
     """A logical experiment grouped by case name.
 
     Each Case contains one or more Simulation executions.  Exactly one
-    Simulation may be designated as the *canonical baseline* via
-    :attr:`canonical_simulation_id`.
+    Simulation may be designated as the baseline via
+    :attr:`baseline_simulation_id`.
     """
 
     __tablename__ = "cases"
 
     name: Mapped[str] = mapped_column(Text, unique=True, index=True)
     case_group: Mapped[str | None] = mapped_column(Text, index=True, nullable=True)
-    canonical_simulation_id: Mapped[UUID | None] = mapped_column(
+    baseline_simulation_id: Mapped[UUID | None] = mapped_column(
         PG_UUID(as_uuid=True),
-        ForeignKey("simulations.id", use_alter=True, name="fk_cases_canonical_sim"),
+        ForeignKey("simulations.id", use_alter=True, name="fk_cases_baseline_sim"),
         nullable=True,
     )
 
@@ -52,8 +52,8 @@ class Case(Base, IDMixin, TimestampMixin):
         cascade="all, delete-orphan",
         passive_deletes=True,
     )
-    canonical_simulation: Mapped[Simulation | None] = relationship(
-        "Simulation", foreign_keys=[canonical_simulation_id], post_update=True
+    baseline_simulation: Mapped[Simulation | None] = relationship(
+        "Simulation", foreign_keys=[baseline_simulation_id], post_update=True
     )
 
 

--- a/backend/app/features/simulation/schemas.py
+++ b/backend/app/features/simulation/schemas.py
@@ -251,7 +251,7 @@ class SimulationCreate(CamelInBaseModel):
             None,
             description=(
                 "Configuration differences between this simulation and the "
-                "baseline simulation for the same case. None for baseline "
+                "reference simulation for the same case. None for reference "
                 "simulations or when no differences exist."
             ),
         ),
@@ -297,11 +297,11 @@ class SimulationSummaryOut(CamelOutBaseModel):
     status: Annotated[
         SimulationStatus, Field(..., description="Current status of the simulation")
     ]
-    is_baseline: Annotated[
+    is_reference: Annotated[
         bool,
         Field(
             ...,
-            description="Whether this simulation is the baseline for its case",
+            description="Whether this simulation is the reference for its case",
         ),
     ]
     change_count: Annotated[
@@ -309,8 +309,8 @@ class SimulationSummaryOut(CamelOutBaseModel):
         Field(
             ...,
             description=(
-                "Number of configuration differences vs the baseline simulation. "
-                "0 for baseline simulations."
+                "Number of configuration differences vs the reference simulation. "
+                "0 for reference simulations."
             ),
         ),
     ]
@@ -337,9 +337,9 @@ class CaseOut(CamelOutBaseModel):
             ),
         ),
     ]
-    baseline_simulation_id: Annotated[
+    reference_simulation_id: Annotated[
         UUID | None,
-        Field(None, description="ID of the baseline simulation for this case."),
+        Field(None, description="ID of the reference simulation for this case."),
     ]
     simulations: Annotated[
         list[SimulationSummaryOut],
@@ -404,11 +404,11 @@ class SimulationOut(CamelOutBaseModel):
             ),
         ),
     ]
-    is_baseline: Annotated[
+    is_reference: Annotated[
         bool,
         Field(
             ...,
-            description="Whether this simulation is the baseline for its case",
+            description="Whether this simulation is the reference for its case",
         ),
     ]
     change_count: Annotated[
@@ -416,8 +416,8 @@ class SimulationOut(CamelOutBaseModel):
         Field(
             ...,
             description=(
-                "Number of configuration differences vs the baseline simulation. "
-                "0 for baseline simulations."
+                "Number of configuration differences vs the reference simulation. "
+                "0 for reference simulations."
             ),
         ),
     ]
@@ -566,7 +566,7 @@ class SimulationOut(CamelOutBaseModel):
             None,
             description=(
                 "Configuration differences between this simulation and the "
-                "baseline simulation for the same case. None for baseline "
+                "reference simulation for the same case. None for reference "
                 "simulations or when no differences exist."
             ),
         ),

--- a/backend/app/features/simulation/schemas.py
+++ b/backend/app/features/simulation/schemas.py
@@ -251,7 +251,7 @@ class SimulationCreate(CamelInBaseModel):
             None,
             description=(
                 "Configuration differences between this simulation and the "
-                "canonical baseline for the same case. None for canonical "
+                "baseline simulation for the same case. None for baseline "
                 "simulations or when no differences exist."
             ),
         ),
@@ -297,11 +297,11 @@ class SimulationSummaryOut(CamelOutBaseModel):
     status: Annotated[
         SimulationStatus, Field(..., description="Current status of the simulation")
     ]
-    is_canonical: Annotated[
+    is_baseline: Annotated[
         bool,
         Field(
             ...,
-            description="Whether this simulation is the canonical baseline for its case",
+            description="Whether this simulation is the baseline for its case",
         ),
     ]
     change_count: Annotated[
@@ -309,8 +309,8 @@ class SimulationSummaryOut(CamelOutBaseModel):
         Field(
             ...,
             description=(
-                "Number of configuration differences vs the canonical baseline. "
-                "0 for canonical simulations."
+                "Number of configuration differences vs the baseline simulation. "
+                "0 for baseline simulations."
             ),
         ),
     ]
@@ -337,9 +337,9 @@ class CaseOut(CamelOutBaseModel):
             ),
         ),
     ]
-    canonical_simulation_id: Annotated[
+    baseline_simulation_id: Annotated[
         UUID | None,
-        Field(None, description="ID of the canonical simulation for this case."),
+        Field(None, description="ID of the baseline simulation for this case."),
     ]
     simulations: Annotated[
         list[SimulationSummaryOut],
@@ -404,11 +404,11 @@ class SimulationOut(CamelOutBaseModel):
             ),
         ),
     ]
-    is_canonical: Annotated[
+    is_baseline: Annotated[
         bool,
         Field(
             ...,
-            description="Whether this simulation is the canonical baseline for its case",
+            description="Whether this simulation is the baseline for its case",
         ),
     ]
     change_count: Annotated[
@@ -416,8 +416,8 @@ class SimulationOut(CamelOutBaseModel):
         Field(
             ...,
             description=(
-                "Number of configuration differences vs the canonical baseline. "
-                "0 for canonical simulations."
+                "Number of configuration differences vs the baseline simulation. "
+                "0 for baseline simulations."
             ),
         ),
     ]
@@ -566,7 +566,7 @@ class SimulationOut(CamelOutBaseModel):
             None,
             description=(
                 "Configuration differences between this simulation and the "
-                "canonical baseline for the same case. None for canonical "
+                "baseline simulation for the same case. None for baseline "
                 "simulations or when no differences exist."
             ),
         ),

--- a/backend/app/scripts/db/rollback_seed.py
+++ b/backend/app/scripts/db/rollback_seed.py
@@ -72,12 +72,12 @@ def rollback_seed(db: Session):
                     )
                 )
 
-                # Clear baseline_simulation_id on cases before deleting simulations
+                # Clear reference_simulation_id on cases before deleting simulations
                 if case_ids:
                     db.execute(
                         update(Case)
                         .where(Case.__table__.c.id.in_(case_ids))
-                        .values(baseline_simulation_id=None)
+                        .values(reference_simulation_id=None)
                     )
 
                 db.execute(

--- a/backend/app/scripts/db/rollback_seed.py
+++ b/backend/app/scripts/db/rollback_seed.py
@@ -72,12 +72,12 @@ def rollback_seed(db: Session):
                     )
                 )
 
-                # Clear canonical_simulation_id on cases before deleting simulations
+                # Clear baseline_simulation_id on cases before deleting simulations
                 if case_ids:
                     db.execute(
                         update(Case)
                         .where(Case.__table__.c.id.in_(case_ids))
-                        .values(canonical_simulation_id=None)
+                        .values(baseline_simulation_id=None)
                     )
 
                 db.execute(

--- a/backend/app/scripts/db/seed.py
+++ b/backend/app/scripts/db/seed.py
@@ -177,10 +177,10 @@ def seed_from_json(db: Session, json_path: str):
 
             total_sims += 1
 
-        # Set the first simulation as the baseline for this case
+        # Set the first simulation as the reference for this case
         if first_sim is not None:
             if first_sim.id is not None:
-                case.baseline_simulation_id = first_sim.id
+                case.reference_simulation_id = first_sim.id
             db.flush()
 
     db.commit()

--- a/backend/app/scripts/db/seed.py
+++ b/backend/app/scripts/db/seed.py
@@ -177,10 +177,10 @@ def seed_from_json(db: Session, json_path: str):
 
             total_sims += 1
 
-        # Set the first simulation as canonical for this case
+        # Set the first simulation as the baseline for this case
         if first_sim is not None:
             if first_sim.id is not None:
-                case.canonical_simulation_id = first_sim.id
+                case.baseline_simulation_id = first_sim.id
             db.flush()
 
     db.commit()

--- a/backend/app/scripts/db/simulations.json
+++ b/backend/app/scripts/db/simulations.json
@@ -77,7 +77,7 @@
         "runEndDate": "2019-12-01T00:00:00Z",
         "compiler": "intel",
         "keyFeatures": "Continuation of piControl run from year 45.",
-        "notesMarkdown": "Continuation run; matches canonical configuration.",
+        "notesMarkdown": "Continuation run; matches the baseline configuration.",
         "gitRepositoryUrl": "https://github.com/E3SM-Project/E3SM",
         "gitBranch": "main",
         "gitTag": "v1.1.0",
@@ -361,11 +361,11 @@
         "extra": {},
         "runConfigDeltas": {
           "compiler": {
-            "canonical": "gnu",
+            "baseline": "gnu",
             "current": "intel"
           },
           "git_commit_hash": {
-            "canonical": "mno7890",
+            "baseline": "mno7890",
             "current": "mno7891"
           }
         },

--- a/backend/app/scripts/db/simulations.json
+++ b/backend/app/scripts/db/simulations.json
@@ -5,7 +5,7 @@
     "simulations": [
       {
         "executionId": "1000001.240101-120000",
-        "description": "Baseline preindustrial control run for E3SM version 1.1.0.",
+        "description": "Reference preindustrial control run for E3SM version 1.1.0.",
         "compset": "PICNTRL",
         "compsetAlias": "piControl",
         "gridName": "ne30_oECv3",
@@ -25,7 +25,7 @@
         "compiler": "intel",
         "keyFeatures": "Fully coupled atmosphere, ocean, land, and sea ice components.",
         "knownIssues": "Occasional model drift after year 45.",
-        "notesMarkdown": "This is the baseline preindustrial control run for E3SM v1.1.0, featuring fully coupled components. Known issues include occasional model drift after year 45.",
+        "notesMarkdown": "This is the reference preindustrial control run for E3SM v1.1.0, featuring fully coupled components. Known issues include occasional model drift after year 45.",
         "gitRepositoryUrl": "https://github.com/E3SM-Project/E3SM",
         "gitBranch": "main",
         "gitTag": "v1.1.0",
@@ -77,7 +77,7 @@
         "runEndDate": "2019-12-01T00:00:00Z",
         "compiler": "intel",
         "keyFeatures": "Continuation of piControl run from year 45.",
-        "notesMarkdown": "Continuation run; matches the baseline configuration.",
+        "notesMarkdown": "Continuation run; matches the reference configuration.",
         "gitRepositoryUrl": "https://github.com/E3SM-Project/E3SM",
         "gitBranch": "main",
         "gitTag": "v1.1.0",
@@ -309,8 +309,8 @@
         "simulationStartDate": "1850-01-01T00:00:00Z",
         "simulationEndDate": "1900-12-31T00:00:00Z",
         "compiler": "gnu",
-        "notesMarkdown": "This preindustrial climate simulation serves as a baseline for DECK experiments.",
-        "keyFeatures": "Baseline preindustrial climate simulation.",
+        "notesMarkdown": "This preindustrial climate simulation serves as a reference for DECK experiments.",
+        "keyFeatures": "Reference preindustrial climate simulation.",
         "knownIssues": "None reported.",
         "gitRepositoryUrl": "https://github.com/E3SM-Project/E3SM",
         "gitBranch": "main",
@@ -361,11 +361,11 @@
         "extra": {},
         "runConfigDeltas": {
           "compiler": {
-            "baseline": "gnu",
+            "reference": "gnu",
             "current": "intel"
           },
           "git_commit_hash": {
-            "baseline": "mno7890",
+            "reference": "mno7890",
             "current": "mno7891"
           }
         },

--- a/backend/migrations/versions/20260331_000000_rename_canonical_to_baseline.py
+++ b/backend/migrations/versions/20260331_000000_rename_canonical_to_baseline.py
@@ -1,0 +1,73 @@
+"""Rename canonical simulation terminology to baseline.
+
+Revision ID: 20260331_000000
+Revises: 20260323_000000
+Create Date: 2026-03-31 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260331_000000"
+down_revision: Union[str, Sequence[str], None] = "20260323_000000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _rename_run_config_delta_key(source_key: str, target_key: str) -> None:
+    op.execute(
+        f"""
+        UPDATE simulations
+        SET run_config_deltas = (
+            SELECT jsonb_object_agg(
+                delta.key,
+                CASE
+                    WHEN jsonb_typeof(delta.value) = 'object' AND delta.value ? '{source_key}'
+                    THEN jsonb_build_object('{target_key}', delta.value -> '{source_key}')
+                         || (delta.value - '{source_key}')
+                    ELSE delta.value
+                END
+            )
+            FROM jsonb_each(run_config_deltas) AS delta(key, value)
+        )
+        WHERE run_config_deltas IS NOT NULL;
+        """
+    )
+
+
+def upgrade() -> None:
+    """Rename persisted canonical fields and delta payloads to baseline."""
+    op.drop_constraint("fk_cases_canonical_sim", "cases", type_="foreignkey")
+    op.alter_column(
+        "cases",
+        "canonical_simulation_id",
+        new_column_name="baseline_simulation_id",
+    )
+    op.create_foreign_key(
+        "fk_cases_baseline_sim",
+        "cases",
+        "simulations",
+        ["baseline_simulation_id"],
+        ["id"],
+    )
+    _rename_run_config_delta_key("canonical", "baseline")
+
+
+def downgrade() -> None:
+    """Restore canonical terminology for persisted case and delta fields."""
+    _rename_run_config_delta_key("baseline", "canonical")
+    op.drop_constraint("fk_cases_baseline_sim", "cases", type_="foreignkey")
+    op.alter_column(
+        "cases",
+        "baseline_simulation_id",
+        new_column_name="canonical_simulation_id",
+    )
+    op.create_foreign_key(
+        "fk_cases_canonical_sim",
+        "cases",
+        "simulations",
+        ["canonical_simulation_id"],
+        ["id"],
+    )

--- a/backend/migrations/versions/20260331_000000_rename_canonical_to_reference.py
+++ b/backend/migrations/versions/20260331_000000_rename_canonical_to_reference.py
@@ -1,4 +1,4 @@
-"""Rename canonical simulation terminology to baseline.
+"""Rename canonical simulation terminology to reference.
 
 Revision ID: 20260331_000000
 Revises: 20260323_000000
@@ -38,30 +38,30 @@ def _rename_run_config_delta_key(source_key: str, target_key: str) -> None:
 
 
 def upgrade() -> None:
-    """Rename persisted canonical fields and delta payloads to baseline."""
+    """Rename persisted canonical fields and delta payloads to reference."""
     op.drop_constraint("fk_cases_canonical_sim", "cases", type_="foreignkey")
     op.alter_column(
         "cases",
         "canonical_simulation_id",
-        new_column_name="baseline_simulation_id",
+        new_column_name="reference_simulation_id",
     )
     op.create_foreign_key(
-        "fk_cases_baseline_sim",
+        "fk_cases_reference_sim",
         "cases",
         "simulations",
-        ["baseline_simulation_id"],
+        ["reference_simulation_id"],
         ["id"],
     )
-    _rename_run_config_delta_key("canonical", "baseline")
+    _rename_run_config_delta_key("canonical", "reference")
 
 
 def downgrade() -> None:
     """Restore canonical terminology for persisted case and delta fields."""
-    _rename_run_config_delta_key("baseline", "canonical")
-    op.drop_constraint("fk_cases_baseline_sim", "cases", type_="foreignkey")
+    _rename_run_config_delta_key("reference", "canonical")
+    op.drop_constraint("fk_cases_reference_sim", "cases", type_="foreignkey")
     op.alter_column(
         "cases",
-        "baseline_simulation_id",
+        "reference_simulation_id",
         new_column_name="canonical_simulation_id",
     )
     op.create_foreign_key(

--- a/backend/migrations/versions/20260331_000000_rename_canonical_to_reference.py
+++ b/backend/migrations/versions/20260331_000000_rename_canonical_to_reference.py
@@ -20,18 +20,21 @@ def _rename_run_config_delta_key(source_key: str, target_key: str) -> None:
     op.execute(
         f"""
         UPDATE simulations
-        SET run_config_deltas = (
-            SELECT jsonb_object_agg(
-                delta.key,
-                CASE
-                    WHEN jsonb_typeof(delta.value) = 'object' AND delta.value ? '{source_key}'
-                    THEN jsonb_build_object('{target_key}', delta.value -> '{source_key}')
-                         || (delta.value - '{source_key}')
-                    ELSE delta.value
-                END
+        SET run_config_deltas = CASE
+            WHEN jsonb_typeof(run_config_deltas) = 'object' THEN (
+                SELECT jsonb_object_agg(
+                    delta.key,
+                    CASE
+                        WHEN jsonb_typeof(delta.value) = 'object' AND delta.value ? '{source_key}'
+                        THEN jsonb_build_object('{target_key}', delta.value -> '{source_key}')
+                             || (delta.value - '{source_key}')
+                        ELSE delta.value
+                    END
+                )
+                FROM jsonb_each(run_config_deltas) AS delta(key, value)
             )
-            FROM jsonb_each(run_config_deltas) AS delta(key, value)
-        )
+            ELSE run_config_deltas
+        END
         WHERE run_config_deltas IS NOT NULL;
         """
     )

--- a/backend/tests/features/ingestion/test_api.py
+++ b/backend/tests/features/ingestion/test_api.py
@@ -18,7 +18,7 @@ from app.api.version import API_BASE
 from app.features.ingestion.api import (
     _run_ingest_archive,
     _save_uploaded_file_and_hash,
-    _set_baseline_simulations,
+    _set_reference_simulations,
     _validate_archive_path,
     _validate_upload_file,
     ingest_from_upload,
@@ -1139,14 +1139,14 @@ class TestIngestFromUploadEndpoint:
 
 
 class TestIngestionApiCoverage:
-    def test_set_baseline_simulations_skips_non_uuid_case_id(self):
+    def test_set_reference_simulations_skips_non_uuid_case_id(self):
         """Covers defensive skip when a created simulation has a non-UUID case_id."""
         db = MagicMock(spec=Session)
         db.query.return_value.filter.return_value.all.return_value = []
 
         sim = Simulation(case_id="not-a-uuid", id=uuid.uuid4())
 
-        _set_baseline_simulations(db, [sim])
+        _set_reference_simulations(db, [sim])
 
         db.add.assert_not_called()
 

--- a/backend/tests/features/ingestion/test_api.py
+++ b/backend/tests/features/ingestion/test_api.py
@@ -18,7 +18,7 @@ from app.api.version import API_BASE
 from app.features.ingestion.api import (
     _run_ingest_archive,
     _save_uploaded_file_and_hash,
-    _set_canonical_simulations,
+    _set_baseline_simulations,
     _validate_archive_path,
     _validate_upload_file,
     ingest_from_upload,
@@ -1139,14 +1139,14 @@ class TestIngestFromUploadEndpoint:
 
 
 class TestIngestionApiCoverage:
-    def test_set_canonical_simulations_skips_non_uuid_case_id(self):
+    def test_set_baseline_simulations_skips_non_uuid_case_id(self):
         """Covers defensive skip when a created simulation has a non-UUID case_id."""
         db = MagicMock(spec=Session)
         db.query.return_value.filter.return_value.all.return_value = []
 
         sim = Simulation(case_id="not-a-uuid", id=uuid.uuid4())
 
-        _set_canonical_simulations(db, [sim])
+        _set_baseline_simulations(db, [sim])
 
         db.add.assert_not_called()
 

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -11,7 +11,7 @@ from app.features.ingestion.ingest import (
     SimulationCreateDraft,
     _build_config_snapshot,
     _build_simulation_create_draft,
-    _get_canonical_metadata_for_case,
+    _get_baseline_metadata_for_case,
     _get_or_create_case,
     _normalize_git_url,
     _normalize_simulation_status,
@@ -1236,12 +1236,12 @@ class TestNormalizeGitUrl:
         return machine
 
 
-class TestCanonicalRunIngestion:
-    """Tests for canonical run selection and config delta semantics.
+class TestBaselineRunIngestion:
+    """Tests for baseline run selection and config delta semantics.
 
     These tests verify that:
     - Multiple runs under the same casename are grouped properly
-    - The first successful run is treated as canonical
+    - The first successful run is treated as baseline
     - Subsequent runs record only config deltas
     - Idempotent re-ingestion works correctly
     - Incremental ingestion adds deltas without overwriting
@@ -1298,8 +1298,8 @@ class TestCanonicalRunIngestion:
         base.update(overrides)
         return base
 
-    def test_canonical_run_selected_from_multiple_runs(self, db: Session) -> None:
-        """First run per case is canonical (None deltas), subsequent runs
+    def test_baseline_run_selected_from_multiple_runs(self, db: Session) -> None:
+        """First run per case is baseline (None deltas), subsequent runs
         with config differences get a delta dict."""
         self._create_machine(db, "test-machine")
 
@@ -1326,16 +1326,16 @@ class TestCanonicalRunIngestion:
         # Both runs are created as simulations
         assert result.created_count == 2
         assert len(result.simulations) == 2
-        # Canonical run has run_config_deltas=None
-        canonical = [s for s in result.simulations if s.run_config_deltas is None]
-        non_canonical = [
+        # Baseline run has run_config_deltas=None
+        baseline = [s for s in result.simulations if s.run_config_deltas is None]
+        non_baseline = [
             s for s in result.simulations if s.run_config_deltas is not None
         ]
-        assert len(canonical) == 1
-        assert len(non_canonical) == 1
+        assert len(baseline) == 1
+        assert len(non_baseline) == 1
 
-    def test_config_delta_stored_for_non_canonical_run(self, db: Session) -> None:
-        """Non-canonical runs with config differences record deltas as a dict."""
+    def test_config_delta_stored_for_non_baseline_run(self, db: Session) -> None:
+        """Non-baseline runs with config differences record deltas as a dict."""
         self._create_machine(db, "test-machine")
 
         mock_simulations = {
@@ -1359,21 +1359,21 @@ class TestCanonicalRunIngestion:
 
         # Both runs created
         assert result.created_count == 2
-        # Find canonical (run_config_deltas=None) and non-canonical
-        canonical = [s for s in result.simulations if s.run_config_deltas is None]
-        non_canonical = [
+        # Find baseline (run_config_deltas=None) and non-baseline
+        baseline = [s for s in result.simulations if s.run_config_deltas is None]
+        non_baseline = [
             s for s in result.simulations if s.run_config_deltas is not None
         ]
-        assert len(canonical) == 1
-        assert len(non_canonical) == 1
-        deltas = non_canonical[0].run_config_deltas
+        assert len(baseline) == 1
+        assert len(non_baseline) == 1
+        deltas = non_baseline[0].run_config_deltas
         assert deltas is not None
         assert "compiler" in deltas
-        assert deltas["compiler"]["canonical"] == "gcc-11"
+        assert deltas["compiler"]["baseline"] == "gcc-11"
         assert deltas["compiler"]["current"] == "gcc-12"
 
     def test_no_delta_when_configs_identical(self, db: Session) -> None:
-        """Non-canonical runs with identical config have run_config_deltas=None."""
+        """Non-baseline runs with identical config have run_config_deltas=None."""
         self._create_machine(db, "test-machine")
 
         mock_simulations = {
@@ -1401,7 +1401,7 @@ class TestCanonicalRunIngestion:
     def test_different_case_names_create_separate_simulations(
         self, db: Session
     ) -> None:
-        """Runs with different case_names are independent canonical selections."""
+        """Runs with different case_names are independent baseline selections."""
         self._create_machine(db, "test-machine")
 
         mock_simulations = {
@@ -1421,7 +1421,7 @@ class TestCanonicalRunIngestion:
         ):
             result = ingest_archive(Path("/tmp/a.zip"), Path("/tmp/o"), db)
 
-        # Each case_name gets its own canonical simulation
+        # Each case_name gets its own baseline simulation
         assert result.created_count == 2
         assert result.skipped_count == 0
         # Verify Cases were created
@@ -1501,7 +1501,7 @@ class TestCanonicalRunIngestion:
         """A new run under an existing case records config delta."""
         machine = self._create_machine(db, "test-machine")
 
-        # Pre-populate DB with a canonical simulation
+        # Pre-populate DB with a baseline simulation
         user = User(
             email="test@example.com",
             is_active=True,
@@ -1544,9 +1544,9 @@ class TestCanonicalRunIngestion:
         db.add(sim)
         db.flush()
 
-        # Set canonical_simulation_id on the case
+        # Set baseline_simulation_id on the case
         assert sim.id is not None
-        case.canonical_simulation_id = sim.id
+        case.baseline_simulation_id = sim.id
         db.commit()
 
         # Ingest archive containing the existing run plus a new one
@@ -1577,7 +1577,7 @@ class TestCanonicalRunIngestion:
         new_sim = result.simulations[0]
         assert new_sim.run_config_deltas is not None
         assert "compiler" in new_sim.run_config_deltas
-        assert new_sim.run_config_deltas["compiler"]["canonical"] == "gcc-11"
+        assert new_sim.run_config_deltas["compiler"]["baseline"] == "gcc-11"
         assert new_sim.run_config_deltas["compiler"]["current"] == "gcc-12"
 
     def test_incremental_ingestion_normalizes_git_url_for_delta(
@@ -1629,7 +1629,7 @@ class TestCanonicalRunIngestion:
         db.flush()
 
         assert sim.id is not None
-        case.canonical_simulation_id = sim.id
+        case.baseline_simulation_id = sim.id
         db.commit()
 
         mock_simulations = {
@@ -1653,7 +1653,7 @@ class TestCanonicalRunIngestion:
     def test_incremental_ingestion_persisted_simulation_type_adds_delta(
         self, db: Session
     ) -> None:
-        """Persisted canonical simulation_type differences are reflected in deltas."""
+        """Persisted baseline simulation_type differences are reflected in deltas."""
         machine = self._create_machine(db, "test-machine")
 
         user = User(
@@ -1698,7 +1698,7 @@ class TestCanonicalRunIngestion:
         db.flush()
 
         assert sim.id is not None
-        case.canonical_simulation_id = sim.id
+        case.baseline_simulation_id = sim.id
         db.commit()
 
         mock_simulations = {
@@ -1724,7 +1724,7 @@ class TestCanonicalRunIngestion:
         assert result.simulations[0].run_config_deltas is not None
         assert "simulation_type" in result.simulations[0].run_config_deltas
         assert result.simulations[0].run_config_deltas["simulation_type"] == {
-            "canonical": SimulationType.PRODUCTION.value,
+            "baseline": SimulationType.PRODUCTION.value,
             "current": SimulationType.UNKNOWN.value,
         }
 
@@ -1811,30 +1811,30 @@ class TestIngestHelpers:
         assert updated.case_group == "groupA"
         mock_warning.assert_called_once()
 
-    def test_get_canonical_metadata_caches_missing_persisted_canonical(self) -> None:
+    def test_get_baseline_metadata_caches_missing_persisted_baseline(self) -> None:
         case = MagicMock(spec=Case)
         case.id = uuid4()
-        case.canonical_simulation_id = uuid4()
+        case.baseline_simulation_id = uuid4()
 
         db = MagicMock(spec=Session)
         db.query.return_value.filter.return_value.first.return_value = None
 
-        canonical_cache: dict[str, SimulationConfigSnapshot] = {}
-        persisted_canonical_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
+        baseline_cache: dict[str, SimulationConfigSnapshot] = {}
+        persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
 
-        result = _get_canonical_metadata_for_case(
+        result = _get_baseline_metadata_for_case(
             case=case,
-            case_name="missing_canonical_case",
-            canonical_cache=canonical_cache,
-            persisted_canonical_cache=persisted_canonical_cache,
+            case_name="missing_baseline_case",
+            baseline_cache=baseline_cache,
+            persisted_baseline_cache=persisted_baseline_cache,
             db=db,
         )
 
         assert result is None
-        assert case.id in persisted_canonical_cache
-        assert persisted_canonical_cache[case.id] is None
+        assert case.id in persisted_baseline_cache
+        assert persisted_baseline_cache[case.id] is None
 
-    def test_get_canonical_metadata_uses_persisted_cache_on_second_lookup(
+    def test_get_baseline_metadata_uses_persisted_cache_on_second_lookup(
         self, db: Session
     ) -> None:
         machine = Machine(
@@ -1864,7 +1864,7 @@ class TestIngestHelpers:
         db.add(ingestion)
         db.commit()
 
-        case = Case(name="canonical_cache_case")
+        case = Case(name="baseline_cache_case")
         db.add(case)
         db.flush()
 
@@ -1889,28 +1889,28 @@ class TestIngestHelpers:
         db.flush()
 
         assert sim.id is not None
-        case.canonical_simulation_id = sim.id
+        case.baseline_simulation_id = sim.id
         db.commit()
 
-        canonical_cache: dict[str, SimulationConfigSnapshot] = {}
-        persisted_canonical_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
+        baseline_cache: dict[str, SimulationConfigSnapshot] = {}
+        persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
 
-        first = _get_canonical_metadata_for_case(
+        first = _get_baseline_metadata_for_case(
             case=case,
             case_name=case.name,
-            canonical_cache=canonical_cache,
-            persisted_canonical_cache=persisted_canonical_cache,
+            baseline_cache=baseline_cache,
+            persisted_baseline_cache=persisted_baseline_cache,
             db=db,
         )
         assert first is not None
         assert first.compiler == "gcc-11"
 
         with patch.object(db, "query", side_effect=AssertionError):
-            second = _get_canonical_metadata_for_case(
+            second = _get_baseline_metadata_for_case(
                 case=case,
                 case_name=case.name,
-                canonical_cache=canonical_cache,
-                persisted_canonical_cache=persisted_canonical_cache,
+                baseline_cache=baseline_cache,
+                persisted_baseline_cache=persisted_baseline_cache,
                 db=db,
             )
         assert second == first
@@ -2099,7 +2099,7 @@ class TestIngestHelpers:
         assert parsed_snapshot.diff(persisted_snapshot) == {}
 
     def test_snapshot_diff_returns_only_changed_fields(self) -> None:
-        canonical = SimulationConfigSnapshot(
+        baseline = SimulationConfigSnapshot(
             compset="FHIST",
             compset_alias="alias1",
             grid_name="grid1",
@@ -2130,11 +2130,11 @@ class TestIngestHelpers:
             simulation_type=SimulationType.UNKNOWN.value,
         )
 
-        delta = canonical.diff(current)
+        delta = baseline.diff(current)
 
         assert delta == {
-            "compiler": {"canonical": "gcc-11", "current": "gcc-12"},
-            "git_branch": {"canonical": "main", "current": "feature"},
+            "compiler": {"baseline": "gcc-11", "current": "gcc-12"},
+            "git_branch": {"baseline": "main", "current": "feature"},
         }
 
     def test_simulation_create_draft_validates_by_field_name(self) -> None:

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -11,8 +11,8 @@ from app.features.ingestion.ingest import (
     SimulationCreateDraft,
     _build_config_snapshot,
     _build_simulation_create_draft,
-    _get_baseline_metadata_for_case,
     _get_or_create_case,
+    _get_reference_metadata_for_case,
     _normalize_git_url,
     _normalize_simulation_status,
     _normalize_simulation_type,
@@ -1236,12 +1236,12 @@ class TestNormalizeGitUrl:
         return machine
 
 
-class TestBaselineRunIngestion:
-    """Tests for baseline run selection and config delta semantics.
+class TestReferenceRunIngestion:
+    """Tests for reference run selection and config delta semantics.
 
     These tests verify that:
     - Multiple runs under the same casename are grouped properly
-    - The first successful run is treated as baseline
+    - The first successful run is treated as reference
     - Subsequent runs record only config deltas
     - Idempotent re-ingestion works correctly
     - Incremental ingestion adds deltas without overwriting
@@ -1298,8 +1298,8 @@ class TestBaselineRunIngestion:
         base.update(overrides)
         return base
 
-    def test_baseline_run_selected_from_multiple_runs(self, db: Session) -> None:
-        """First run per case is baseline (None deltas), subsequent runs
+    def test_reference_run_selected_from_multiple_runs(self, db: Session) -> None:
+        """First run per case is reference (None deltas), subsequent runs
         with config differences get a delta dict."""
         self._create_machine(db, "test-machine")
 
@@ -1326,16 +1326,16 @@ class TestBaselineRunIngestion:
         # Both runs are created as simulations
         assert result.created_count == 2
         assert len(result.simulations) == 2
-        # Baseline run has run_config_deltas=None
-        baseline = [s for s in result.simulations if s.run_config_deltas is None]
-        non_baseline = [
+        # Reference run has run_config_deltas=None
+        reference = [s for s in result.simulations if s.run_config_deltas is None]
+        non_reference = [
             s for s in result.simulations if s.run_config_deltas is not None
         ]
-        assert len(baseline) == 1
-        assert len(non_baseline) == 1
+        assert len(reference) == 1
+        assert len(non_reference) == 1
 
-    def test_config_delta_stored_for_non_baseline_run(self, db: Session) -> None:
-        """Non-baseline runs with config differences record deltas as a dict."""
+    def test_config_delta_stored_for_non_reference_run(self, db: Session) -> None:
+        """Non-reference runs with config differences record deltas as a dict."""
         self._create_machine(db, "test-machine")
 
         mock_simulations = {
@@ -1359,21 +1359,21 @@ class TestBaselineRunIngestion:
 
         # Both runs created
         assert result.created_count == 2
-        # Find baseline (run_config_deltas=None) and non-baseline
-        baseline = [s for s in result.simulations if s.run_config_deltas is None]
-        non_baseline = [
+        # Find reference (run_config_deltas=None) and non-reference
+        reference = [s for s in result.simulations if s.run_config_deltas is None]
+        non_reference = [
             s for s in result.simulations if s.run_config_deltas is not None
         ]
-        assert len(baseline) == 1
-        assert len(non_baseline) == 1
-        deltas = non_baseline[0].run_config_deltas
+        assert len(reference) == 1
+        assert len(non_reference) == 1
+        deltas = non_reference[0].run_config_deltas
         assert deltas is not None
         assert "compiler" in deltas
-        assert deltas["compiler"]["baseline"] == "gcc-11"
+        assert deltas["compiler"]["reference"] == "gcc-11"
         assert deltas["compiler"]["current"] == "gcc-12"
 
     def test_no_delta_when_configs_identical(self, db: Session) -> None:
-        """Non-baseline runs with identical config have run_config_deltas=None."""
+        """Non-reference runs with identical config have run_config_deltas=None."""
         self._create_machine(db, "test-machine")
 
         mock_simulations = {
@@ -1401,7 +1401,7 @@ class TestBaselineRunIngestion:
     def test_different_case_names_create_separate_simulations(
         self, db: Session
     ) -> None:
-        """Runs with different case_names are independent baseline selections."""
+        """Runs with different case_names are independent reference selections."""
         self._create_machine(db, "test-machine")
 
         mock_simulations = {
@@ -1421,7 +1421,7 @@ class TestBaselineRunIngestion:
         ):
             result = ingest_archive(Path("/tmp/a.zip"), Path("/tmp/o"), db)
 
-        # Each case_name gets its own baseline simulation
+        # Each case_name gets its own reference simulation
         assert result.created_count == 2
         assert result.skipped_count == 0
         # Verify Cases were created
@@ -1501,7 +1501,7 @@ class TestBaselineRunIngestion:
         """A new run under an existing case records config delta."""
         machine = self._create_machine(db, "test-machine")
 
-        # Pre-populate DB with a baseline simulation
+        # Pre-populate DB with a reference simulation
         user = User(
             email="test@example.com",
             is_active=True,
@@ -1544,9 +1544,9 @@ class TestBaselineRunIngestion:
         db.add(sim)
         db.flush()
 
-        # Set baseline_simulation_id on the case
+        # Set reference_simulation_id on the case
         assert sim.id is not None
-        case.baseline_simulation_id = sim.id
+        case.reference_simulation_id = sim.id
         db.commit()
 
         # Ingest archive containing the existing run plus a new one
@@ -1577,7 +1577,7 @@ class TestBaselineRunIngestion:
         new_sim = result.simulations[0]
         assert new_sim.run_config_deltas is not None
         assert "compiler" in new_sim.run_config_deltas
-        assert new_sim.run_config_deltas["compiler"]["baseline"] == "gcc-11"
+        assert new_sim.run_config_deltas["compiler"]["reference"] == "gcc-11"
         assert new_sim.run_config_deltas["compiler"]["current"] == "gcc-12"
 
     def test_incremental_ingestion_normalizes_git_url_for_delta(
@@ -1629,7 +1629,7 @@ class TestBaselineRunIngestion:
         db.flush()
 
         assert sim.id is not None
-        case.baseline_simulation_id = sim.id
+        case.reference_simulation_id = sim.id
         db.commit()
 
         mock_simulations = {
@@ -1653,7 +1653,7 @@ class TestBaselineRunIngestion:
     def test_incremental_ingestion_persisted_simulation_type_adds_delta(
         self, db: Session
     ) -> None:
-        """Persisted baseline simulation_type differences are reflected in deltas."""
+        """Persisted reference simulation_type differences are reflected in deltas."""
         machine = self._create_machine(db, "test-machine")
 
         user = User(
@@ -1698,7 +1698,7 @@ class TestBaselineRunIngestion:
         db.flush()
 
         assert sim.id is not None
-        case.baseline_simulation_id = sim.id
+        case.reference_simulation_id = sim.id
         db.commit()
 
         mock_simulations = {
@@ -1724,7 +1724,7 @@ class TestBaselineRunIngestion:
         assert result.simulations[0].run_config_deltas is not None
         assert "simulation_type" in result.simulations[0].run_config_deltas
         assert result.simulations[0].run_config_deltas["simulation_type"] == {
-            "baseline": SimulationType.PRODUCTION.value,
+            "reference": SimulationType.PRODUCTION.value,
             "current": SimulationType.UNKNOWN.value,
         }
 
@@ -1811,30 +1811,30 @@ class TestIngestHelpers:
         assert updated.case_group == "groupA"
         mock_warning.assert_called_once()
 
-    def test_get_baseline_metadata_caches_missing_persisted_baseline(self) -> None:
+    def test_get_reference_metadata_caches_missing_persisted_reference(self) -> None:
         case = MagicMock(spec=Case)
         case.id = uuid4()
-        case.baseline_simulation_id = uuid4()
+        case.reference_simulation_id = uuid4()
 
         db = MagicMock(spec=Session)
         db.query.return_value.filter.return_value.first.return_value = None
 
-        baseline_cache: dict[str, SimulationConfigSnapshot] = {}
-        persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
+        reference_cache: dict[str, SimulationConfigSnapshot] = {}
+        persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
 
-        result = _get_baseline_metadata_for_case(
+        result = _get_reference_metadata_for_case(
             case=case,
-            case_name="missing_baseline_case",
-            baseline_cache=baseline_cache,
-            persisted_baseline_cache=persisted_baseline_cache,
+            case_name="missing_reference_case",
+            reference_cache=reference_cache,
+            persisted_reference_cache=persisted_reference_cache,
             db=db,
         )
 
         assert result is None
-        assert case.id in persisted_baseline_cache
-        assert persisted_baseline_cache[case.id] is None
+        assert case.id in persisted_reference_cache
+        assert persisted_reference_cache[case.id] is None
 
-    def test_get_baseline_metadata_uses_persisted_cache_on_second_lookup(
+    def test_get_reference_metadata_uses_persisted_cache_on_second_lookup(
         self, db: Session
     ) -> None:
         machine = Machine(
@@ -1864,7 +1864,7 @@ class TestIngestHelpers:
         db.add(ingestion)
         db.commit()
 
-        case = Case(name="baseline_cache_case")
+        case = Case(name="reference_cache_case")
         db.add(case)
         db.flush()
 
@@ -1889,28 +1889,28 @@ class TestIngestHelpers:
         db.flush()
 
         assert sim.id is not None
-        case.baseline_simulation_id = sim.id
+        case.reference_simulation_id = sim.id
         db.commit()
 
-        baseline_cache: dict[str, SimulationConfigSnapshot] = {}
-        persisted_baseline_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
+        reference_cache: dict[str, SimulationConfigSnapshot] = {}
+        persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
 
-        first = _get_baseline_metadata_for_case(
+        first = _get_reference_metadata_for_case(
             case=case,
             case_name=case.name,
-            baseline_cache=baseline_cache,
-            persisted_baseline_cache=persisted_baseline_cache,
+            reference_cache=reference_cache,
+            persisted_reference_cache=persisted_reference_cache,
             db=db,
         )
         assert first is not None
         assert first.compiler == "gcc-11"
 
         with patch.object(db, "query", side_effect=AssertionError):
-            second = _get_baseline_metadata_for_case(
+            second = _get_reference_metadata_for_case(
                 case=case,
                 case_name=case.name,
-                baseline_cache=baseline_cache,
-                persisted_baseline_cache=persisted_baseline_cache,
+                reference_cache=reference_cache,
+                persisted_reference_cache=persisted_reference_cache,
                 db=db,
             )
         assert second == first
@@ -2099,7 +2099,7 @@ class TestIngestHelpers:
         assert parsed_snapshot.diff(persisted_snapshot) == {}
 
     def test_snapshot_diff_returns_only_changed_fields(self) -> None:
-        baseline = SimulationConfigSnapshot(
+        reference = SimulationConfigSnapshot(
             compset="FHIST",
             compset_alias="alias1",
             grid_name="grid1",
@@ -2130,11 +2130,11 @@ class TestIngestHelpers:
             simulation_type=SimulationType.UNKNOWN.value,
         )
 
-        delta = baseline.diff(current)
+        delta = reference.diff(current)
 
         assert delta == {
-            "compiler": {"baseline": "gcc-11", "current": "gcc-12"},
-            "git_branch": {"baseline": "main", "current": "feature"},
+            "compiler": {"reference": "gcc-11", "current": "gcc-12"},
+            "git_branch": {"reference": "main", "current": "feature"},
         }
 
     def test_simulation_create_draft_validates_by_field_name(self) -> None:

--- a/backend/tests/features/simulation/test_api.py
+++ b/backend/tests/features/simulation/test_api.py
@@ -103,18 +103,16 @@ class TestListCases:
             status="created",
             machine_id=machine.id,
             simulation_start_date="2023-02-01T00:00:00Z",
-            run_config_deltas={
-                "compiler": {"canonical": "gcc-11", "current": "gcc-12"}
-            },
+            run_config_deltas={"compiler": {"baseline": "gcc-11", "current": "gcc-12"}},
             created_by=normal_user_sync["id"],
             last_updated_by=admin_user_sync["id"],
             ingestion_id=ingestion.id,
         )
         db.add(sim1)
         db.flush()
-        # Set canonical
+        # Set baseline
         assert sim1.id is not None
-        case.canonical_simulation_id = sim1.id
+        case.baseline_simulation_id = sim1.id
         db.add(sim2)
         db.commit()
 
@@ -125,7 +123,7 @@ class TestListCases:
 
         case_data = data[0]
         assert case_data["name"] == "test_case_nested"
-        assert case_data["canonicalSimulationId"] == str(sim1.id)
+        assert case_data["baselineSimulationId"] == str(sim1.id)
         assert case_data["machineNames"] == [machine.name]
         assert case_data["hpcUsernames"] == []
 
@@ -138,7 +136,7 @@ class TestListCases:
             assert "id" in s
             assert "executionId" in s
             assert "status" in s
-            assert "isCanonical" in s
+            assert "isBaseline" in s
             assert "changeCount" in s
             assert "simulationStartDate" in s
             # Must NOT include heavy fields
@@ -150,11 +148,11 @@ class TestListCases:
             assert "runConfigDeltas" not in s
             assert "createdByUser" not in s
 
-        # Verify canonical and change_count derivation
+        # Verify baseline and change_count derivation
         exec_ids = {s["executionId"]: s for s in sims}
-        assert exec_ids["case-nested-exec-1"]["isCanonical"] is True
+        assert exec_ids["case-nested-exec-1"]["isBaseline"] is True
         assert exec_ids["case-nested-exec-1"]["changeCount"] == 0
-        assert exec_ids["case-nested-exec-2"]["isCanonical"] is False
+        assert exec_ids["case-nested-exec-2"]["isBaseline"] is False
         assert exec_ids["case-nested-exec-2"]["changeCount"] == 1
 
 
@@ -218,7 +216,7 @@ class TestGetCase:
         db.add(sim)
         db.flush()
         assert sim.id is not None
-        case.canonical_simulation_id = sim.id
+        case.baseline_simulation_id = sim.id
         db.commit()
 
         res = client.get(f"{API_BASE}/cases/{case.id}")
@@ -229,7 +227,7 @@ class TestGetCase:
         assert data["machineNames"] == [machine.name]
         assert data["hpcUsernames"] == []
         assert data["simulations"][0]["executionId"] == "case-detail-exec-1"
-        assert data["simulations"][0]["isCanonical"] is True
+        assert data["simulations"][0]["isBaseline"] is True
 
     def test_endpoint_raises_404_if_case_not_found(self, client):
         res = client.get(f"{API_BASE}/cases/{uuid4()}")
@@ -311,12 +309,12 @@ class TestCreateSimulation:
         assert res.status_code == 400
         assert "not found" in res.json()["detail"].lower()
 
-    def test_first_manual_create_sets_canonical_on_case(
+    def test_first_manual_create_sets_baseline_on_case(
         self, client, db: Session
     ) -> None:
         machine = db.query(Machine).first()
         assert machine is not None, "No machine found in the database"
-        case = _create_case(db, "test_case_first_manual_canonical")
+        case = _create_case(db, "test_case_first_manual_baseline")
         db.commit()
 
         payload = {
@@ -337,12 +335,12 @@ class TestCreateSimulation:
         assert res.status_code == 201
         data = res.json()
 
-        assert data["isCanonical"] is True
+        assert data["isBaseline"] is True
         assert data["runConfigDeltas"] is None
 
         db.refresh(case)
-        assert case.canonical_simulation_id is not None
-        assert str(case.canonical_simulation_id) == data["id"]
+        assert case.baseline_simulation_id is not None
+        assert str(case.baseline_simulation_id) == data["id"]
 
     def test_create_simulation_raises_500_when_reload_fails(self) -> None:
         case_id = uuid4()

--- a/backend/tests/features/simulation/test_api.py
+++ b/backend/tests/features/simulation/test_api.py
@@ -103,16 +103,18 @@ class TestListCases:
             status="created",
             machine_id=machine.id,
             simulation_start_date="2023-02-01T00:00:00Z",
-            run_config_deltas={"compiler": {"baseline": "gcc-11", "current": "gcc-12"}},
+            run_config_deltas={
+                "compiler": {"reference": "gcc-11", "current": "gcc-12"}
+            },
             created_by=normal_user_sync["id"],
             last_updated_by=admin_user_sync["id"],
             ingestion_id=ingestion.id,
         )
         db.add(sim1)
         db.flush()
-        # Set baseline
+        # Set reference
         assert sim1.id is not None
-        case.baseline_simulation_id = sim1.id
+        case.reference_simulation_id = sim1.id
         db.add(sim2)
         db.commit()
 
@@ -123,7 +125,7 @@ class TestListCases:
 
         case_data = data[0]
         assert case_data["name"] == "test_case_nested"
-        assert case_data["baselineSimulationId"] == str(sim1.id)
+        assert case_data["referenceSimulationId"] == str(sim1.id)
         assert case_data["machineNames"] == [machine.name]
         assert case_data["hpcUsernames"] == []
 
@@ -136,7 +138,7 @@ class TestListCases:
             assert "id" in s
             assert "executionId" in s
             assert "status" in s
-            assert "isBaseline" in s
+            assert "isReference" in s
             assert "changeCount" in s
             assert "simulationStartDate" in s
             # Must NOT include heavy fields
@@ -148,11 +150,11 @@ class TestListCases:
             assert "runConfigDeltas" not in s
             assert "createdByUser" not in s
 
-        # Verify baseline and change_count derivation
+        # Verify reference and change_count derivation
         exec_ids = {s["executionId"]: s for s in sims}
-        assert exec_ids["case-nested-exec-1"]["isBaseline"] is True
+        assert exec_ids["case-nested-exec-1"]["isReference"] is True
         assert exec_ids["case-nested-exec-1"]["changeCount"] == 0
-        assert exec_ids["case-nested-exec-2"]["isBaseline"] is False
+        assert exec_ids["case-nested-exec-2"]["isReference"] is False
         assert exec_ids["case-nested-exec-2"]["changeCount"] == 1
 
 
@@ -216,7 +218,7 @@ class TestGetCase:
         db.add(sim)
         db.flush()
         assert sim.id is not None
-        case.baseline_simulation_id = sim.id
+        case.reference_simulation_id = sim.id
         db.commit()
 
         res = client.get(f"{API_BASE}/cases/{case.id}")
@@ -227,7 +229,7 @@ class TestGetCase:
         assert data["machineNames"] == [machine.name]
         assert data["hpcUsernames"] == []
         assert data["simulations"][0]["executionId"] == "case-detail-exec-1"
-        assert data["simulations"][0]["isBaseline"] is True
+        assert data["simulations"][0]["isReference"] is True
 
     def test_endpoint_raises_404_if_case_not_found(self, client):
         res = client.get(f"{API_BASE}/cases/{uuid4()}")
@@ -309,12 +311,12 @@ class TestCreateSimulation:
         assert res.status_code == 400
         assert "not found" in res.json()["detail"].lower()
 
-    def test_first_manual_create_sets_baseline_on_case(
+    def test_first_manual_create_sets_reference_on_case(
         self, client, db: Session
     ) -> None:
         machine = db.query(Machine).first()
         assert machine is not None, "No machine found in the database"
-        case = _create_case(db, "test_case_first_manual_baseline")
+        case = _create_case(db, "test_case_first_manual_reference")
         db.commit()
 
         payload = {
@@ -335,12 +337,12 @@ class TestCreateSimulation:
         assert res.status_code == 201
         data = res.json()
 
-        assert data["isBaseline"] is True
+        assert data["isReference"] is True
         assert data["runConfigDeltas"] is None
 
         db.refresh(case)
-        assert case.baseline_simulation_id is not None
-        assert str(case.baseline_simulation_id) == data["id"]
+        assert case.reference_simulation_id is not None
+        assert str(case.reference_simulation_id) == data["id"]
 
     def test_create_simulation_raises_500_when_reload_fails(self) -> None:
         case_id = uuid4()

--- a/backend/tests/features/simulation/test_schemas.py
+++ b/backend/tests/features/simulation/test_schemas.py
@@ -70,7 +70,7 @@ class TestSimulationCreateSchema:
             "lastUpdatedBy": uuid4(),
             "extra": {"key": "value"},
             "runConfigDeltas": {
-                "compiler": {"canonical": "gcc-11", "current": "gcc-12"}
+                "compiler": {"baseline": "gcc-11", "current": "gcc-12"}
             },
             "artifacts": [
                 {
@@ -113,7 +113,7 @@ class TestSimulationOutSchema:
             "case_id": case_id,
             "case_name": "test_case",
             "execution_id": "1081156.251218-200923",
-            "is_canonical": True,
+            "is_baseline": True,
             "change_count": 0,
             "compset": "AQUAPLANET",
             "compset_alias": "QPC4",
@@ -192,7 +192,7 @@ class TestSimulationOutSchema:
             "case_id": case_id,
             "case_name": "test_case",
             "execution_id": "1081156.251218-200923",
-            "is_canonical": False,
+            "is_baseline": False,
             "change_count": 2,
             "compset": "AQUAPLANET",
             "compset_alias": "QPC4",
@@ -242,7 +242,7 @@ class TestSimulationOutSchema:
             "git_commit_hash": "abc123",
             "extra": {"key": "value"},
             "run_config_deltas": {
-                "compiler": {"canonical": "gcc-11", "current": "gcc-12"}
+                "compiler": {"baseline": "gcc-11", "current": "gcc-12"}
             },
             "artifacts": [
                 {
@@ -287,7 +287,7 @@ class TestSimulationOutSchema:
             case_id=uuid4(),
             case_name="test_case",
             execution_id="1081156.251218-200923",
-            is_canonical=True,
+            is_baseline=True,
             change_count=0,
             compset="AQUAPLANET",
             compset_alias="QPC4",
@@ -358,7 +358,7 @@ class TestSimulationOutSchema:
             case_id=uuid4(),
             case_name="test_case",
             execution_id="1081156.251218-200923",
-            is_canonical=True,
+            is_baseline=True,
             change_count=0,
             compset="AQUAPLANET",
             compset_alias="QPC4",
@@ -422,26 +422,26 @@ class TestSimulationSummaryOutSchema:
             id=uuid4(),
             execution_id="1081156.251218-200923",
             status="created",
-            is_canonical=True,
+            is_baseline=True,
             change_count=0,
             simulation_start_date=datetime(2023, 1, 1, 0, 0, 0),
             simulation_end_date=None,
         )
-        assert summary.is_canonical is True
+        assert summary.is_baseline is True
         assert summary.change_count == 0
         assert summary.simulation_end_date is None
 
-    def test_non_canonical_with_changes(self):
+    def test_non_baseline_with_changes(self):
         summary = SimulationSummaryOut(
             id=uuid4(),
             execution_id="1081290.251218-211543",
             status="completed",
-            is_canonical=False,
+            is_baseline=False,
             change_count=3,
             simulation_start_date=datetime(2023, 1, 1, 0, 0, 0),
             simulation_end_date=datetime(2023, 12, 31, 0, 0, 0),
         )
-        assert summary.is_canonical is False
+        assert summary.is_baseline is False
         assert summary.change_count == 3
         assert summary.simulation_end_date == datetime(2023, 12, 31, 0, 0, 0)
 
@@ -453,13 +453,13 @@ class TestCaseOutSchema:
             id=uuid4(),
             name="v3.LR.historical_0121",
             case_group="ensemble_v3",
-            canonical_simulation_id=sim_id,
+            baseline_simulation_id=sim_id,
             simulations=[
                 SimulationSummaryOut(
                     id=sim_id,
                     execution_id="1081156.251218-200923",
                     status="completed",
-                    is_canonical=True,
+                    is_baseline=True,
                     change_count=0,
                     simulation_start_date=datetime(2023, 1, 1, 0, 0, 0),
                     simulation_end_date=datetime(2023, 12, 31, 0, 0, 0),
@@ -468,7 +468,7 @@ class TestCaseOutSchema:
                     id=uuid4(),
                     execution_id="1081290.251218-211543",
                     status="completed",
-                    is_canonical=False,
+                    is_baseline=False,
                     change_count=2,
                     simulation_start_date=datetime(2023, 2, 1, 0, 0, 0),
                     simulation_end_date=None,
@@ -482,9 +482,9 @@ class TestCaseOutSchema:
         assert case_out.name == "v3.LR.historical_0121"
         assert case_out.case_group == "ensemble_v3"
         assert len(case_out.simulations) == 2
+        assert case_out.simulations[0].is_baseline is True
         assert case_out.machine_names == ["chrysalis"]
         assert case_out.hpc_usernames == ["ac.tvo"]
-        assert case_out.simulations[0].is_canonical is True
         assert case_out.simulations[1].change_count == 2
 
     def test_case_out_empty_simulations(self):
@@ -492,14 +492,14 @@ class TestCaseOutSchema:
             id=uuid4(),
             name="empty_case",
             case_group=None,
-            canonical_simulation_id=None,
+            baseline_simulation_id=None,
             simulations=[],
             machine_names=[],
             hpc_usernames=[],
             created_at=datetime(2023, 1, 1, 0, 0, 0),
             updated_at=datetime(2023, 1, 2, 0, 0, 0),
         )
-        assert case_out.canonical_simulation_id is None
+        assert case_out.baseline_simulation_id is None
         assert case_out.simulations == []
         assert case_out.machine_names == []
         assert case_out.hpc_usernames == []

--- a/backend/tests/features/simulation/test_schemas.py
+++ b/backend/tests/features/simulation/test_schemas.py
@@ -70,7 +70,7 @@ class TestSimulationCreateSchema:
             "lastUpdatedBy": uuid4(),
             "extra": {"key": "value"},
             "runConfigDeltas": {
-                "compiler": {"baseline": "gcc-11", "current": "gcc-12"}
+                "compiler": {"reference": "gcc-11", "current": "gcc-12"}
             },
             "artifacts": [
                 {
@@ -113,7 +113,7 @@ class TestSimulationOutSchema:
             "case_id": case_id,
             "case_name": "test_case",
             "execution_id": "1081156.251218-200923",
-            "is_baseline": True,
+            "is_reference": True,
             "change_count": 0,
             "compset": "AQUAPLANET",
             "compset_alias": "QPC4",
@@ -192,7 +192,7 @@ class TestSimulationOutSchema:
             "case_id": case_id,
             "case_name": "test_case",
             "execution_id": "1081156.251218-200923",
-            "is_baseline": False,
+            "is_reference": False,
             "change_count": 2,
             "compset": "AQUAPLANET",
             "compset_alias": "QPC4",
@@ -242,7 +242,7 @@ class TestSimulationOutSchema:
             "git_commit_hash": "abc123",
             "extra": {"key": "value"},
             "run_config_deltas": {
-                "compiler": {"baseline": "gcc-11", "current": "gcc-12"}
+                "compiler": {"reference": "gcc-11", "current": "gcc-12"}
             },
             "artifacts": [
                 {
@@ -287,7 +287,7 @@ class TestSimulationOutSchema:
             case_id=uuid4(),
             case_name="test_case",
             execution_id="1081156.251218-200923",
-            is_baseline=True,
+            is_reference=True,
             change_count=0,
             compset="AQUAPLANET",
             compset_alias="QPC4",
@@ -358,7 +358,7 @@ class TestSimulationOutSchema:
             case_id=uuid4(),
             case_name="test_case",
             execution_id="1081156.251218-200923",
-            is_baseline=True,
+            is_reference=True,
             change_count=0,
             compset="AQUAPLANET",
             compset_alias="QPC4",
@@ -422,26 +422,26 @@ class TestSimulationSummaryOutSchema:
             id=uuid4(),
             execution_id="1081156.251218-200923",
             status="created",
-            is_baseline=True,
+            is_reference=True,
             change_count=0,
             simulation_start_date=datetime(2023, 1, 1, 0, 0, 0),
             simulation_end_date=None,
         )
-        assert summary.is_baseline is True
+        assert summary.is_reference is True
         assert summary.change_count == 0
         assert summary.simulation_end_date is None
 
-    def test_non_baseline_with_changes(self):
+    def test_non_reference_with_changes(self):
         summary = SimulationSummaryOut(
             id=uuid4(),
             execution_id="1081290.251218-211543",
             status="completed",
-            is_baseline=False,
+            is_reference=False,
             change_count=3,
             simulation_start_date=datetime(2023, 1, 1, 0, 0, 0),
             simulation_end_date=datetime(2023, 12, 31, 0, 0, 0),
         )
-        assert summary.is_baseline is False
+        assert summary.is_reference is False
         assert summary.change_count == 3
         assert summary.simulation_end_date == datetime(2023, 12, 31, 0, 0, 0)
 
@@ -453,13 +453,13 @@ class TestCaseOutSchema:
             id=uuid4(),
             name="v3.LR.historical_0121",
             case_group="ensemble_v3",
-            baseline_simulation_id=sim_id,
+            reference_simulation_id=sim_id,
             simulations=[
                 SimulationSummaryOut(
                     id=sim_id,
                     execution_id="1081156.251218-200923",
                     status="completed",
-                    is_baseline=True,
+                    is_reference=True,
                     change_count=0,
                     simulation_start_date=datetime(2023, 1, 1, 0, 0, 0),
                     simulation_end_date=datetime(2023, 12, 31, 0, 0, 0),
@@ -468,7 +468,7 @@ class TestCaseOutSchema:
                     id=uuid4(),
                     execution_id="1081290.251218-211543",
                     status="completed",
-                    is_baseline=False,
+                    is_reference=False,
                     change_count=2,
                     simulation_start_date=datetime(2023, 2, 1, 0, 0, 0),
                     simulation_end_date=None,
@@ -482,7 +482,7 @@ class TestCaseOutSchema:
         assert case_out.name == "v3.LR.historical_0121"
         assert case_out.case_group == "ensemble_v3"
         assert len(case_out.simulations) == 2
-        assert case_out.simulations[0].is_baseline is True
+        assert case_out.simulations[0].is_reference is True
         assert case_out.machine_names == ["chrysalis"]
         assert case_out.hpc_usernames == ["ac.tvo"]
         assert case_out.simulations[1].change_count == 2
@@ -492,14 +492,14 @@ class TestCaseOutSchema:
             id=uuid4(),
             name="empty_case",
             case_group=None,
-            baseline_simulation_id=None,
+            reference_simulation_id=None,
             simulations=[],
             machine_names=[],
             hpc_usernames=[],
             created_at=datetime(2023, 1, 1, 0, 0, 0),
             updated_at=datetime(2023, 1, 2, 0, 0, 0),
         )
-        assert case_out.baseline_simulation_id is None
+        assert case_out.reference_simulation_id is None
         assert case_out.simulations == []
         assert case_out.machine_names == []
         assert case_out.hpc_usernames == []

--- a/frontend/src/features/browse/BrowsePage.tsx
+++ b/frontend/src/features/browse/BrowsePage.tsx
@@ -59,8 +59,8 @@ export interface FilterState {
   compiler: string[];
   status: string[];
 
-  // Baseline Status
-  baselineStatus: string;
+  // Reference Status
+  referenceStatus: string;
 
   // Metadata & Provenance
   gitTag: string[];
@@ -93,8 +93,8 @@ const createEmptyFilters = (): FilterState => ({
   compiler: [],
   status: [],
 
-  // Baseline Status
-  baselineStatus: '',
+  // Reference Status
+  referenceStatus: '',
 
   // Metadata & Provenance
   gitTag: [],
@@ -103,13 +103,13 @@ const createEmptyFilters = (): FilterState => ({
 });
 
 const FILTER_KEYS = Object.keys(createEmptyFilters()) as (keyof FilterState)[];
-const MULTI_SELECT_FILTER_KEYS = FILTER_KEYS.filter((key) => key !== 'baselineStatus');
+const MULTI_SELECT_FILTER_KEYS = FILTER_KEYS.filter((key) => key !== 'referenceStatus');
 
 const areStringArraysEqual = (left: string[], right: string[]): boolean =>
   left.length === right.length && left.every((value, index) => value === right[index]);
 
 const areFiltersEqual = (left: FilterState, right: FilterState): boolean =>
-  left.baselineStatus === right.baselineStatus &&
+  left.referenceStatus === right.referenceStatus &&
   MULTI_SELECT_FILTER_KEYS.every((key) =>
     areStringArraysEqual(left[key] as string[], right[key] as string[]),
   );
@@ -296,8 +296,8 @@ export const BrowsePage = ({
         }
       }
 
-      if (appliedFilters.baselineStatus === 'baseline' && !record.isBaseline) return false;
-      if (appliedFilters.baselineStatus === 'non-baseline' && record.isBaseline) return false;
+      if (appliedFilters.referenceStatus === 'reference' && !record.isReference) return false;
+      if (appliedFilters.referenceStatus === 'non-reference' && record.isReference) return false;
 
       return true;
     });
@@ -359,10 +359,10 @@ export const BrowsePage = ({
       }
     });
 
-    const baselineStatus = searchParams.get('baselineStatus');
-    next.baselineStatus =
-      baselineStatus !== null && ['', 'baseline', 'non-baseline'].includes(baselineStatus)
-        ? baselineStatus
+    const referenceStatus = searchParams.get('referenceStatus');
+    next.referenceStatus =
+      referenceStatus !== null && ['', 'reference', 'non-reference'].includes(referenceStatus)
+        ? referenceStatus
         : '';
 
     setAppliedFilters((current) => (areFiltersEqual(current, next) ? current : next));
@@ -381,7 +381,7 @@ export const BrowsePage = ({
     });
 
     if (prevPageResetSignature.current === null) {
-      // First render — record baseline without resetting page.
+      // First render — record reference without resetting page.
       prevPageResetSignature.current = currentSignature;
       return;
     }

--- a/frontend/src/features/browse/BrowsePage.tsx
+++ b/frontend/src/features/browse/BrowsePage.tsx
@@ -59,8 +59,8 @@ export interface FilterState {
   compiler: string[];
   status: string[];
 
-  // Canonical Status
-  canonicalStatus: string;
+  // Baseline Status
+  baselineStatus: string;
 
   // Metadata & Provenance
   gitTag: string[];
@@ -93,8 +93,8 @@ const createEmptyFilters = (): FilterState => ({
   compiler: [],
   status: [],
 
-  // Canonical Status
-  canonicalStatus: '',
+  // Baseline Status
+  baselineStatus: '',
 
   // Metadata & Provenance
   gitTag: [],
@@ -103,13 +103,13 @@ const createEmptyFilters = (): FilterState => ({
 });
 
 const FILTER_KEYS = Object.keys(createEmptyFilters()) as (keyof FilterState)[];
-const MULTI_SELECT_FILTER_KEYS = FILTER_KEYS.filter((key) => key !== 'canonicalStatus');
+const MULTI_SELECT_FILTER_KEYS = FILTER_KEYS.filter((key) => key !== 'baselineStatus');
 
 const areStringArraysEqual = (left: string[], right: string[]): boolean =>
   left.length === right.length && left.every((value, index) => value === right[index]);
 
 const areFiltersEqual = (left: FilterState, right: FilterState): boolean =>
-  left.canonicalStatus === right.canonicalStatus &&
+  left.baselineStatus === right.baselineStatus &&
   MULTI_SELECT_FILTER_KEYS.every((key) =>
     areStringArraysEqual(left[key] as string[], right[key] as string[]),
   );
@@ -296,8 +296,8 @@ export const BrowsePage = ({
         }
       }
 
-      if (appliedFilters.canonicalStatus === 'canonical' && !record.isCanonical) return false;
-      if (appliedFilters.canonicalStatus === 'non-canonical' && record.isCanonical) return false;
+      if (appliedFilters.baselineStatus === 'baseline' && !record.isBaseline) return false;
+      if (appliedFilters.baselineStatus === 'non-baseline' && record.isBaseline) return false;
 
       return true;
     });
@@ -359,10 +359,10 @@ export const BrowsePage = ({
       }
     });
 
-    const canonicalStatus = searchParams.get('canonicalStatus');
-    next.canonicalStatus =
-      canonicalStatus !== null && ['', 'canonical', 'non-canonical'].includes(canonicalStatus)
-        ? canonicalStatus
+    const baselineStatus = searchParams.get('baselineStatus');
+    next.baselineStatus =
+      baselineStatus !== null && ['', 'baseline', 'non-baseline'].includes(baselineStatus)
+        ? baselineStatus
         : '';
 
     setAppliedFilters((current) => (areFiltersEqual(current, next) ? current : next));

--- a/frontend/src/features/browse/components/BrowseFiltersSidePanel.tsx
+++ b/frontend/src/features/browse/components/BrowseFiltersSidePanel.tsx
@@ -182,24 +182,24 @@ export const BrowseFiltersSidePanel = ({
         />
 
         <div>
-          <label className={filterLabelClassName}>Baseline Status</label>
+          <label className={filterLabelClassName}>Reference Status</label>
           <div className="space-y-1.5">
             {[
               { value: '', label: 'All' },
-              { value: 'baseline', label: 'Baseline Only' },
-              { value: 'non-baseline', label: 'Non-Baseline Only' },
+              { value: 'reference', label: 'Reference Only' },
+              { value: 'non-reference', label: 'Non-Reference Only' },
             ].map((opt) => (
               <div key={opt.value} className="flex items-center gap-2">
                 <input
                   type="radio"
-                  id={`baseline-${opt.value || 'all'}`}
-                  name="baselineStatus"
-                  checked={appliedFilters.baselineStatus === opt.value}
-                  onChange={() => handleChange('baselineStatus', opt.value)}
+                  id={`reference-${opt.value || 'all'}`}
+                  name="referenceStatus"
+                  checked={appliedFilters.referenceStatus === opt.value}
+                  onChange={() => handleChange('referenceStatus', opt.value)}
                   className="h-4 w-4"
                 />
                 <label
-                  htmlFor={`baseline-${opt.value || 'all'}`}
+                  htmlFor={`reference-${opt.value || 'all'}`}
                   className="text-sm text-slate-700"
                 >
                   {opt.label}

--- a/frontend/src/features/browse/components/BrowseFiltersSidePanel.tsx
+++ b/frontend/src/features/browse/components/BrowseFiltersSidePanel.tsx
@@ -182,24 +182,24 @@ export const BrowseFiltersSidePanel = ({
         />
 
         <div>
-          <label className={filterLabelClassName}>Canonical Status</label>
+          <label className={filterLabelClassName}>Baseline Status</label>
           <div className="space-y-1.5">
             {[
               { value: '', label: 'All' },
-              { value: 'canonical', label: 'Canonical Only' },
-              { value: 'non-canonical', label: 'Non-Canonical Only' },
+              { value: 'baseline', label: 'Baseline Only' },
+              { value: 'non-baseline', label: 'Non-Baseline Only' },
             ].map((opt) => (
               <div key={opt.value} className="flex items-center gap-2">
                 <input
                   type="radio"
-                  id={`canonical-${opt.value || 'all'}`}
-                  name="canonicalStatus"
-                  checked={appliedFilters.canonicalStatus === opt.value}
-                  onChange={() => handleChange('canonicalStatus', opt.value)}
+                  id={`baseline-${opt.value || 'all'}`}
+                  name="baselineStatus"
+                  checked={appliedFilters.baselineStatus === opt.value}
+                  onChange={() => handleChange('baselineStatus', opt.value)}
                   className="h-4 w-4"
                 />
                 <label
-                  htmlFor={`canonical-${opt.value || 'all'}`}
+                  htmlFor={`baseline-${opt.value || 'all'}`}
                   className="text-sm text-slate-700"
                 >
                   {opt.label}

--- a/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
@@ -132,11 +132,11 @@ export const SimulationBrowseDetailsDialog = ({
                 </div>
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                    Baseline
+                    Reference
                   </p>
                   <p className="mt-1 text-sm text-slate-700">
-                    {simulation.isBaseline ? 'Yes' : 'No'}
-                    {!simulation.isBaseline && simulation.changeCount > 0
+                    {simulation.isReference ? 'Yes' : 'No'}
+                    {!simulation.isReference && simulation.changeCount > 0
                       ? ` (${simulation.changeCount} changes)`
                       : ''}
                   </p>

--- a/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
@@ -132,11 +132,11 @@ export const SimulationBrowseDetailsDialog = ({
                 </div>
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                    Canonical
+                    Baseline
                   </p>
                   <p className="mt-1 text-sm text-slate-700">
-                    {simulation.isCanonical ? 'Yes' : 'No'}
-                    {!simulation.isCanonical && simulation.changeCount > 0
+                    {simulation.isBaseline ? 'Yes' : 'No'}
+                    {!simulation.isBaseline && simulation.changeCount > 0
                       ? ` (${simulation.changeCount} changes)`
                       : ''}
                   </p>

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
@@ -178,8 +178,8 @@ export const SimulationResultCard = ({
                 variant="secondary"
                 className="flex items-center gap-1 border border-slate-200 bg-slate-50 px-2 py-1 text-sm text-slate-700"
               >
-                Baseline: {simulation.isBaseline ? 'Yes' : 'No'}
-                {!simulation.isBaseline && simulation.changeCount > 0 && (
+                Reference: {simulation.isReference ? 'Yes' : 'No'}
+                {!simulation.isReference && simulation.changeCount > 0 && (
                   <span className="ml-1 text-xs text-muted-foreground">
                     (Changes: {simulation.changeCount})
                   </span>

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
@@ -178,8 +178,8 @@ export const SimulationResultCard = ({
                 variant="secondary"
                 className="flex items-center gap-1 border border-slate-200 bg-slate-50 px-2 py-1 text-sm text-slate-700"
               >
-                Canonical: {simulation.isCanonical ? 'Yes' : 'No'}
-                {!simulation.isCanonical && simulation.changeCount > 0 && (
+                Baseline: {simulation.isBaseline ? 'Yes' : 'No'}
+                {!simulation.isBaseline && simulation.changeCount > 0 && (
                   <span className="ml-1 text-xs text-muted-foreground">
                     (Changes: {simulation.changeCount})
                   </span>

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
@@ -147,15 +147,15 @@ const columns: ColumnDef<SimulationOut>[] = [
     meta: { width: 220 },
   },
   {
-    accessorKey: 'isBaseline',
-    header: renderSortableHeader('Baseline'),
+    accessorKey: 'isReference',
+    header: renderSortableHeader('Reference'),
     cell: ({ row }) => {
-      const isBaseline = row.original.isBaseline;
+      const isReference = row.original.isReference;
       const changeCount = row.original.changeCount;
       return (
         <div>
-          {isBaseline ? 'Yes' : 'No'}
-          {!isBaseline && changeCount > 0 && (
+          {isReference ? 'Yes' : 'No'}
+          {!isReference && changeCount > 0 && (
             <span className="ml-1 text-slate-400">({changeCount})</span>
           )}
         </div>

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
@@ -147,15 +147,15 @@ const columns: ColumnDef<SimulationOut>[] = [
     meta: { width: 220 },
   },
   {
-    accessorKey: 'isCanonical',
-    header: renderSortableHeader('Canonical'),
+    accessorKey: 'isBaseline',
+    header: renderSortableHeader('Baseline'),
     cell: ({ row }) => {
-      const isCanonical = row.original.isCanonical;
+      const isBaseline = row.original.isBaseline;
       const changeCount = row.original.changeCount;
       return (
         <div>
-          {isCanonical ? 'Yes' : 'No'}
-          {!isCanonical && changeCount > 0 && (
+          {isBaseline ? 'Yes' : 'No'}
+          {!isBaseline && changeCount > 0 && (
             <span className="ml-1 text-slate-400">({changeCount})</span>
           )}
         </div>

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -19,7 +19,7 @@ import { TableCellText } from '@/components/ui/table-cell-text';
 import {
   formatCaseDate,
   formatSimulationDateRange,
-  getBaselineSimulation,
+  getReferenceSimulation,
   sortSimulationSummaries,
 } from '@/features/simulations/caseUtils';
 import { useCase } from '@/features/simulations/hooks/useCase';
@@ -124,7 +124,7 @@ export const CaseDetailsPage = ({
     );
   }
 
-  const baselineSimulation = getBaselineSimulation(caseRecord);
+  const referenceSimulation = getReferenceSimulation(caseRecord);
   const simulations = sortSimulationSummaries(caseRecord.simulations).map((simulation) => ({
     summary: simulation,
     details: simulationDetailsById.get(simulation.id),
@@ -193,28 +193,28 @@ export const CaseDetailsPage = ({
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-base">Baseline Simulation</CardTitle>
+            <CardTitle className="text-base">Reference Simulation</CardTitle>
           </CardHeader>
           <CardContent>
-            {baselineSimulation ? (
+            {referenceSimulation ? (
               <>
                 <p className="mb-4 text-sm leading-6 text-muted-foreground">
-                  This is the first successful run for the case and serves as the baseline used to
+                  This is the first successful run for the case and serves as the reference used to
                   compare configuration changes across the other simulations.
                 </p>
                 <MetadataRow
                   label="Execution ID"
                   value={
                     <Link
-                      to={`/simulations/${baselineSimulation.id}`}
+                      to={`/simulations/${referenceSimulation.id}`}
                       state={{ from: currentPath }}
                       className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                     >
-                      {baselineSimulation.executionId}
+                      {referenceSimulation.executionId}
                       <span
                         className="inline-flex items-center"
-                        title="Baseline simulation"
-                        aria-label="Baseline simulation"
+                        title="Reference simulation"
+                        aria-label="Reference simulation"
                       >
                         <Pin className="h-3.5 w-3.5 text-amber-600" />
                       </span>
@@ -223,16 +223,16 @@ export const CaseDetailsPage = ({
                 />
                 <MetadataRow
                   label="Status"
-                  value={<SimulationStatusBadge status={baselineSimulation.status} />}
+                  value={<SimulationStatusBadge status={referenceSimulation.status} />}
                 />
                 <MetadataRow
                   label="Simulation Dates"
-                  value={formatSimulationDateRange(baselineSimulation)}
+                  value={formatSimulationDateRange(referenceSimulation)}
                 />
               </>
             ) : (
               <p className="text-sm text-muted-foreground">
-                No baseline simulation is set for this case.
+                No reference simulation is set for this case.
               </p>
             )}
           </CardContent>
@@ -310,11 +310,11 @@ export const CaseDetailsPage = ({
                         className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                       >
                         {summary.executionId}
-                        {summary.isBaseline && (
+                        {summary.isReference && (
                           <span
                             className="inline-flex items-center"
-                            title="Baseline simulation"
-                            aria-label="Baseline simulation"
+                            title="Reference simulation"
+                            aria-label="Reference simulation"
                           >
                             <Pin className="h-3.5 w-3.5 text-amber-600" />
                           </span>
@@ -322,8 +322,8 @@ export const CaseDetailsPage = ({
                       </Link>
                     </TableCell>
                     <TableCell className="align-top">
-                      {summary.isBaseline ? (
-                        <span className="text-sm font-medium text-slate-700">Baseline</span>
+                      {summary.isReference ? (
+                        <span className="text-sm font-medium text-slate-700">Reference</span>
                       ) : (
                         summary.changeCount
                       )}

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -19,7 +19,7 @@ import { TableCellText } from '@/components/ui/table-cell-text';
 import {
   formatCaseDate,
   formatSimulationDateRange,
-  getCanonicalSimulation,
+  getBaselineSimulation,
   sortSimulationSummaries,
 } from '@/features/simulations/caseUtils';
 import { useCase } from '@/features/simulations/hooks/useCase';
@@ -124,7 +124,7 @@ export const CaseDetailsPage = ({
     );
   }
 
-  const canonicalSimulation = getCanonicalSimulation(caseRecord);
+  const baselineSimulation = getBaselineSimulation(caseRecord);
   const simulations = sortSimulationSummaries(caseRecord.simulations).map((simulation) => ({
     summary: simulation,
     details: simulationDetailsById.get(simulation.id),
@@ -196,7 +196,7 @@ export const CaseDetailsPage = ({
             <CardTitle className="text-base">Baseline Simulation</CardTitle>
           </CardHeader>
           <CardContent>
-            {canonicalSimulation ? (
+            {baselineSimulation ? (
               <>
                 <p className="mb-4 text-sm leading-6 text-muted-foreground">
                   This is the first successful run for the case and serves as the baseline used to
@@ -206,11 +206,11 @@ export const CaseDetailsPage = ({
                   label="Execution ID"
                   value={
                     <Link
-                      to={`/simulations/${canonicalSimulation.id}`}
+                      to={`/simulations/${baselineSimulation.id}`}
                       state={{ from: currentPath }}
                       className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                     >
-                      {canonicalSimulation.executionId}
+                      {baselineSimulation.executionId}
                       <span
                         className="inline-flex items-center"
                         title="Baseline simulation"
@@ -223,16 +223,16 @@ export const CaseDetailsPage = ({
                 />
                 <MetadataRow
                   label="Status"
-                  value={<SimulationStatusBadge status={canonicalSimulation.status} />}
+                  value={<SimulationStatusBadge status={baselineSimulation.status} />}
                 />
                 <MetadataRow
                   label="Simulation Dates"
-                  value={formatSimulationDateRange(canonicalSimulation)}
+                  value={formatSimulationDateRange(baselineSimulation)}
                 />
               </>
             ) : (
               <p className="text-sm text-muted-foreground">
-                No canonical simulation is set for this case.
+                No baseline simulation is set for this case.
               </p>
             )}
           </CardContent>
@@ -310,7 +310,7 @@ export const CaseDetailsPage = ({
                         className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                       >
                         {summary.executionId}
-                        {summary.isCanonical && (
+                        {summary.isBaseline && (
                           <span
                             className="inline-flex items-center"
                             title="Baseline simulation"
@@ -322,7 +322,7 @@ export const CaseDetailsPage = ({
                       </Link>
                     </TableCell>
                     <TableCell className="align-top">
-                      {summary.isCanonical ? (
+                      {summary.isBaseline ? (
                         <span className="text-sm font-medium text-slate-700">Baseline</span>
                       ) : (
                         summary.changeCount

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -35,7 +35,7 @@ import { useCases } from '@/features/simulations/hooks/useCases';
 import { cn } from '@/lib/utils';
 import type { CaseOut, SimulationOut, SimulationSummaryOut } from '@/types';
 
-type CanonicalFilter = 'all' | 'with-canonical' | 'without-canonical';
+type BaselineFilter = 'all' | 'with-baseline' | 'without-baseline';
 type ActiveFilterKey =
   | 'caseName'
   | 'hpcUsername'
@@ -47,7 +47,7 @@ type ActiveFilterKey =
   | 'gitTag'
   | 'createdBy'
   | 'caseGroup'
-  | 'canonical';
+  | 'baseline';
 
 interface CasesPageProps {
   simulations: SimulationOut[];
@@ -93,8 +93,8 @@ const sortStringValues = (values: string[]) =>
 
 const sortCaseSimulations = (caseSimulations: CaseSimulationListItem[]) =>
   [...caseSimulations].sort((left, right) => {
-    if (left.isCanonical !== right.isCanonical) {
-      return left.isCanonical ? -1 : 1;
+    if (left.isBaseline !== right.isBaseline) {
+      return left.isBaseline ? -1 : 1;
     }
 
     return (
@@ -124,7 +124,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   const [simulationFilters, setSimulationFilters] = useState<CaseSimulationFilters>(
     createEmptySimulationFilters,
   );
-  const [canonicalFilter, setCanonicalFilter] = useState<CanonicalFilter>('all');
+  const [baselineFilter, setBaselineFilter] = useState<BaselineFilter>('all');
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const [expandedCaseId, setExpandedCaseId] = useState<string | null>(null);
   const [sorting, setSorting] = useState<SortingState>([
@@ -275,7 +275,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   const hasActiveFilters =
     caseNameFilter.trim().length > 0 ||
     caseGroupFilter.length > 0 ||
-    canonicalFilter !== 'all' ||
+    baselineFilter !== 'all' ||
     hasActiveSimulationFilters;
   const advancedFilterCount = useMemo(
     () =>
@@ -288,9 +288,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         simulationFilters.gitTag,
         simulationFilters.createdBy,
         caseGroupFilter,
-        canonicalFilter !== 'all' ? canonicalFilter : '',
+        baselineFilter !== 'all' ? baselineFilter : '',
       ].filter(Boolean).length,
-    [canonicalFilter, caseGroupFilter, simulationFilters],
+    [baselineFilter, caseGroupFilter, simulationFilters],
   );
   const matchingSimulationsByCaseId = useMemo(() => {
     const matchingMap = new Map<string, SimulationOut[]>();
@@ -404,17 +404,17 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
 
     if (caseGroupFilter) filters.push({ key: 'caseGroup', label: 'Group', value: caseGroupFilter });
 
-    if (canonicalFilter !== 'all') {
+    if (baselineFilter !== 'all') {
       filters.push({
-        key: 'canonical',
-        label: 'Canonical',
-        value: canonicalFilter === 'with-canonical' ? 'Present' : 'Missing',
+        key: 'baseline',
+        label: 'Baseline',
+        value: baselineFilter === 'with-baseline' ? 'Present' : 'Missing',
       });
     }
 
     return filters;
   }, [
-    canonicalFilter,
+    baselineFilter,
     caseGroupFilter,
     caseNameFilter,
     creatorOptions,
@@ -434,7 +434,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     setCaseNameFilter('');
     setCaseGroupFilter('');
     setSimulationFilters(createEmptySimulationFilters());
-    setCanonicalFilter('all');
+    setBaselineFilter('all');
     setShowAdvancedFilters(false);
     table.setPageIndex(0);
   };
@@ -447,8 +447,8 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
       case 'caseGroup':
         setCaseGroupFilter('');
         break;
-      case 'canonical':
-        setCanonicalFilter('all');
+      case 'baseline':
+        setBaselineFilter('all');
         break;
       default:
         setSimulationFilters((current) => ({
@@ -469,21 +469,21 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         normalizedNameFilter.length === 0 ||
         caseRecord.name.toLowerCase().includes(normalizedNameFilter);
       const matchesGroup = !caseGroupFilter || caseRecord.caseGroup === caseGroupFilter;
-      const hasCanonicalSimulation = caseRecord.canonicalSimulationId != null;
-      const matchesCanonical =
-        canonicalFilter === 'all' ||
-        (canonicalFilter === 'with-canonical' && hasCanonicalSimulation) ||
-        (canonicalFilter === 'without-canonical' && !hasCanonicalSimulation);
+      const hasBaselineSimulation = caseRecord.baselineSimulationId != null;
+      const matchesBaseline =
+        baselineFilter === 'all' ||
+        (baselineFilter === 'with-baseline' && hasBaselineSimulation) ||
+        (baselineFilter === 'without-baseline' && !hasBaselineSimulation);
       const matchesSimulationFilters =
         !hasActiveSimulationFilters ||
         (matchingSimulationsByCaseId.get(caseRecord.id)?.length ?? 0) > 0;
 
-      return matchesName && matchesGroup && matchesCanonical && matchesSimulationFilters;
+      return matchesName && matchesGroup && matchesBaseline && matchesSimulationFilters;
     });
   }, [
     caseGroupFilter,
     cases,
-    canonicalFilter,
+    baselineFilter,
     caseNameFilter,
     hasActiveSimulationFilters,
     matchingSimulationsByCaseId,
@@ -710,7 +710,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                         className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                       >
                         {simulation.executionId}
-                        {simulation.isCanonical && (
+                        {simulation.isBaseline && (
                           <span
                             className="inline-flex items-center"
                             title="Baseline simulation"
@@ -722,7 +722,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                       </Link>
                     </TableCell>
                     <TableCell className="align-top">
-                      {simulation.isCanonical ? (
+                      {simulation.isBaseline ? (
                         <span
                           className="text-sm font-medium text-slate-700"
                           title="Baseline simulation"
@@ -776,7 +776,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                 <h1 className="text-3xl font-semibold tracking-tight text-slate-950">Cases</h1>
                 <p className="max-w-3xl text-sm leading-6 text-slate-600 sm:text-[15px]">
                   Find the cases behind your runs. Start with HPC username or machine, then refine
-                  by campaign, version context, and canonical state.
+                  by campaign, version context, and baseline state.
                 </p>
               </div>
             </div>
@@ -992,12 +992,12 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                         })}
                         <div className="space-y-2">
                           <label className="text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
-                            Canonical state
+                            Baseline state
                           </label>
                           <Select
-                            value={canonicalFilter}
-                            onValueChange={(value: CanonicalFilter) => {
-                              setCanonicalFilter(value);
+                            value={baselineFilter}
+                            onValueChange={(value: BaselineFilter) => {
+                              setBaselineFilter(value);
                               table.setPageIndex(0);
                             }}
                           >
@@ -1005,9 +1005,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                              <SelectItem value="all">All canonical states</SelectItem>
-                              <SelectItem value="with-canonical">Canonical present</SelectItem>
-                              <SelectItem value="without-canonical">Canonical missing</SelectItem>
+                              <SelectItem value="all">All baseline states</SelectItem>
+                              <SelectItem value="with-baseline">Baseline present</SelectItem>
+                              <SelectItem value="without-baseline">Baseline missing</SelectItem>
                             </SelectContent>
                           </Select>
                         </div>

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -35,7 +35,7 @@ import { useCases } from '@/features/simulations/hooks/useCases';
 import { cn } from '@/lib/utils';
 import type { CaseOut, SimulationOut, SimulationSummaryOut } from '@/types';
 
-type BaselineFilter = 'all' | 'with-baseline' | 'without-baseline';
+type ReferenceFilter = 'all' | 'with-reference' | 'without-reference';
 type ActiveFilterKey =
   | 'caseName'
   | 'hpcUsername'
@@ -47,7 +47,7 @@ type ActiveFilterKey =
   | 'gitTag'
   | 'createdBy'
   | 'caseGroup'
-  | 'baseline';
+  | 'reference';
 
 interface CasesPageProps {
   simulations: SimulationOut[];
@@ -93,8 +93,8 @@ const sortStringValues = (values: string[]) =>
 
 const sortCaseSimulations = (caseSimulations: CaseSimulationListItem[]) =>
   [...caseSimulations].sort((left, right) => {
-    if (left.isBaseline !== right.isBaseline) {
-      return left.isBaseline ? -1 : 1;
+    if (left.isReference !== right.isReference) {
+      return left.isReference ? -1 : 1;
     }
 
     return (
@@ -111,7 +111,7 @@ const getSimulationChangeTitle = (simulation: CaseSimulationListItem) => {
     }
   }
 
-  return `${simulation.changeCount} changes from baseline`;
+  return `${simulation.changeCount} changes from reference`;
 };
 
 export const CasesPage = ({ simulations }: CasesPageProps) => {
@@ -124,7 +124,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   const [simulationFilters, setSimulationFilters] = useState<CaseSimulationFilters>(
     createEmptySimulationFilters,
   );
-  const [baselineFilter, setBaselineFilter] = useState<BaselineFilter>('all');
+  const [referenceFilter, setReferenceFilter] = useState<ReferenceFilter>('all');
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const [expandedCaseId, setExpandedCaseId] = useState<string | null>(null);
   const [sorting, setSorting] = useState<SortingState>([
@@ -275,7 +275,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   const hasActiveFilters =
     caseNameFilter.trim().length > 0 ||
     caseGroupFilter.length > 0 ||
-    baselineFilter !== 'all' ||
+    referenceFilter !== 'all' ||
     hasActiveSimulationFilters;
   const advancedFilterCount = useMemo(
     () =>
@@ -288,9 +288,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         simulationFilters.gitTag,
         simulationFilters.createdBy,
         caseGroupFilter,
-        baselineFilter !== 'all' ? baselineFilter : '',
+        referenceFilter !== 'all' ? referenceFilter : '',
       ].filter(Boolean).length,
-    [baselineFilter, caseGroupFilter, simulationFilters],
+    [referenceFilter, caseGroupFilter, simulationFilters],
   );
   const matchingSimulationsByCaseId = useMemo(() => {
     const matchingMap = new Map<string, SimulationOut[]>();
@@ -404,17 +404,17 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
 
     if (caseGroupFilter) filters.push({ key: 'caseGroup', label: 'Group', value: caseGroupFilter });
 
-    if (baselineFilter !== 'all') {
+    if (referenceFilter !== 'all') {
       filters.push({
-        key: 'baseline',
-        label: 'Baseline',
-        value: baselineFilter === 'with-baseline' ? 'Present' : 'Missing',
+        key: 'reference',
+        label: 'Reference',
+        value: referenceFilter === 'with-reference' ? 'Present' : 'Missing',
       });
     }
 
     return filters;
   }, [
-    baselineFilter,
+    referenceFilter,
     caseGroupFilter,
     caseNameFilter,
     creatorOptions,
@@ -434,7 +434,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     setCaseNameFilter('');
     setCaseGroupFilter('');
     setSimulationFilters(createEmptySimulationFilters());
-    setBaselineFilter('all');
+    setReferenceFilter('all');
     setShowAdvancedFilters(false);
     table.setPageIndex(0);
   };
@@ -447,8 +447,8 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
       case 'caseGroup':
         setCaseGroupFilter('');
         break;
-      case 'baseline':
-        setBaselineFilter('all');
+      case 'reference':
+        setReferenceFilter('all');
         break;
       default:
         setSimulationFilters((current) => ({
@@ -469,21 +469,21 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         normalizedNameFilter.length === 0 ||
         caseRecord.name.toLowerCase().includes(normalizedNameFilter);
       const matchesGroup = !caseGroupFilter || caseRecord.caseGroup === caseGroupFilter;
-      const hasBaselineSimulation = caseRecord.baselineSimulationId != null;
-      const matchesBaseline =
-        baselineFilter === 'all' ||
-        (baselineFilter === 'with-baseline' && hasBaselineSimulation) ||
-        (baselineFilter === 'without-baseline' && !hasBaselineSimulation);
+      const hasReferenceSimulation = caseRecord.referenceSimulationId != null;
+      const matchesReference =
+        referenceFilter === 'all' ||
+        (referenceFilter === 'with-reference' && hasReferenceSimulation) ||
+        (referenceFilter === 'without-reference' && !hasReferenceSimulation);
       const matchesSimulationFilters =
         !hasActiveSimulationFilters ||
         (matchingSimulationsByCaseId.get(caseRecord.id)?.length ?? 0) > 0;
 
-      return matchesName && matchesGroup && matchesBaseline && matchesSimulationFilters;
+      return matchesName && matchesGroup && matchesReference && matchesSimulationFilters;
     });
   }, [
     caseGroupFilter,
     cases,
-    baselineFilter,
+    referenceFilter,
     caseNameFilter,
     hasActiveSimulationFilters,
     matchingSimulationsByCaseId,
@@ -710,11 +710,11 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                         className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                       >
                         {simulation.executionId}
-                        {simulation.isBaseline && (
+                        {simulation.isReference && (
                           <span
                             className="inline-flex items-center"
-                            title="Baseline simulation"
-                            aria-label="Baseline simulation"
+                            title="Reference simulation"
+                            aria-label="Reference simulation"
                           >
                             <Pin className="h-3.5 w-3.5 text-amber-600" />
                           </span>
@@ -722,12 +722,12 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                       </Link>
                     </TableCell>
                     <TableCell className="align-top">
-                      {simulation.isBaseline ? (
+                      {simulation.isReference ? (
                         <span
                           className="text-sm font-medium text-slate-700"
-                          title="Baseline simulation"
+                          title="Reference simulation"
                         >
-                          Baseline
+                          Reference
                         </span>
                       ) : (
                         <Badge variant="secondary" title={getSimulationChangeTitle(simulation)}>
@@ -776,7 +776,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                 <h1 className="text-3xl font-semibold tracking-tight text-slate-950">Cases</h1>
                 <p className="max-w-3xl text-sm leading-6 text-slate-600 sm:text-[15px]">
                   Find the cases behind your runs. Start with HPC username or machine, then refine
-                  by campaign, version context, and baseline state.
+                  by campaign, version context, and reference state.
                 </p>
               </div>
             </div>
@@ -976,7 +976,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                       <div className="space-y-1">
                         <p className="text-sm font-medium text-slate-900">Case settings</p>
                         <p className="text-xs text-slate-500">
-                          Narrow the result set using case-level metadata and baseline state.
+                          Narrow the result set using case-level metadata and reference state.
                         </p>
                       </div>
                       <div className="grid gap-3">
@@ -992,12 +992,12 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                         })}
                         <div className="space-y-2">
                           <label className="text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
-                            Baseline state
+                            Reference state
                           </label>
                           <Select
-                            value={baselineFilter}
-                            onValueChange={(value: BaselineFilter) => {
-                              setBaselineFilter(value);
+                            value={referenceFilter}
+                            onValueChange={(value: ReferenceFilter) => {
+                              setReferenceFilter(value);
                               table.setPageIndex(0);
                             }}
                           >
@@ -1005,9 +1005,9 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                              <SelectItem value="all">All baseline states</SelectItem>
-                              <SelectItem value="with-baseline">Baseline present</SelectItem>
-                              <SelectItem value="without-baseline">Baseline missing</SelectItem>
+                              <SelectItem value="all">All reference states</SelectItem>
+                              <SelectItem value="with-reference">Reference present</SelectItem>
+                              <SelectItem value="without-reference">Reference missing</SelectItem>
                             </SelectContent>
                           </Select>
                         </div>

--- a/frontend/src/features/simulations/SimulationsPage.tsx
+++ b/frontend/src/features/simulations/SimulationsPage.tsx
@@ -151,12 +151,12 @@ export const SimulationsPage = ({ simulations }: SimulationsPageProps) => {
         size: 380,
       },
       {
-        accessorKey: 'isCanonical',
-        header: 'Canonical',
+        accessorKey: 'isBaseline',
+        header: 'Baseline',
         cell: ({ row }) =>
-          row.original.isCanonical ? (
+          row.original.isBaseline ? (
             <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-              Canonical
+              Baseline
             </Badge>
           ) : null,
         size: 100,

--- a/frontend/src/features/simulations/SimulationsPage.tsx
+++ b/frontend/src/features/simulations/SimulationsPage.tsx
@@ -151,12 +151,12 @@ export const SimulationsPage = ({ simulations }: SimulationsPageProps) => {
         size: 380,
       },
       {
-        accessorKey: 'isBaseline',
-        header: 'Baseline',
+        accessorKey: 'isReference',
+        header: 'Reference',
         cell: ({ row }) =>
-          row.original.isBaseline ? (
+          row.original.isReference ? (
             <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-              Baseline
+              Reference
             </Badge>
           ) : null,
         size: 100,

--- a/frontend/src/features/simulations/caseUtils.ts
+++ b/frontend/src/features/simulations/caseUtils.ts
@@ -14,14 +14,14 @@ export const formatCaseDate = (value?: string | null) => {
 export const formatSimulationDateRange = (simulation: SimulationSummaryOut) =>
   `${formatCaseDate(simulation.simulationStartDate)} → ${formatCaseDate(simulation.simulationEndDate)}`;
 
-export const getCanonicalSimulation = (caseRecord: CaseOut) =>
-  caseRecord.simulations.find((simulation) => simulation.id === caseRecord.canonicalSimulationId) ??
+export const getBaselineSimulation = (caseRecord: CaseOut) =>
+  caseRecord.simulations.find((simulation) => simulation.id === caseRecord.baselineSimulationId) ??
   null;
 
 export const sortSimulationSummaries = (simulations: SimulationSummaryOut[]) =>
   [...simulations].sort((left, right) => {
-    if (left.isCanonical !== right.isCanonical) {
-      return left.isCanonical ? -1 : 1;
+    if (left.isBaseline !== right.isBaseline) {
+      return left.isBaseline ? -1 : 1;
     }
 
     return (

--- a/frontend/src/features/simulations/caseUtils.ts
+++ b/frontend/src/features/simulations/caseUtils.ts
@@ -14,14 +14,14 @@ export const formatCaseDate = (value?: string | null) => {
 export const formatSimulationDateRange = (simulation: SimulationSummaryOut) =>
   `${formatCaseDate(simulation.simulationStartDate)} → ${formatCaseDate(simulation.simulationEndDate)}`;
 
-export const getBaselineSimulation = (caseRecord: CaseOut) =>
-  caseRecord.simulations.find((simulation) => simulation.id === caseRecord.baselineSimulationId) ??
+export const getReferenceSimulation = (caseRecord: CaseOut) =>
+  caseRecord.simulations.find((simulation) => simulation.id === caseRecord.referenceSimulationId) ??
   null;
 
 export const sortSimulationSummaries = (simulations: SimulationSummaryOut[]) =>
   [...simulations].sort((left, right) => {
-    if (left.isBaseline !== right.isBaseline) {
-      return left.isBaseline ? -1 : 1;
+    if (left.isReference !== right.isReference) {
+      return left.isReference ? -1 : 1;
     }
 
     return (

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -137,11 +137,11 @@ export const SimulationDetailsView = ({
                 <FieldRow label="Case Name">
                   <ReadonlyInput value={simulation.caseName} />
                 </FieldRow>
-                <FieldRow label="Canonical">
-                  <span className="text-sm">{simulation.isCanonical ? 'Yes' : 'No'}</span>
+                <FieldRow label="Baseline">
+                  <span className="text-sm">{simulation.isBaseline ? 'Yes' : 'No'}</span>
                 </FieldRow>
-                {!simulation.isCanonical && (
-                  <FieldRow label="Changes vs canonical">
+                {!simulation.isBaseline && (
+                  <FieldRow label="Changes vs baseline">
                     <span className="text-sm">{simulation.changeCount}</span>
                   </FieldRow>
                 )}
@@ -189,8 +189,8 @@ export const SimulationDetailsView = ({
             </Card>
           </div>
 
-          {/* Config diff section for non-canonical simulations */}
-          {!simulation.isCanonical && (
+          {/* Config diff section for non-baseline simulations */}
+          {!simulation.isBaseline && (
             <Card>
               <CardHeader className="pb-2">
                 <CardTitle className="text-base">Configuration Differences</CardTitle>
@@ -206,7 +206,7 @@ export const SimulationDetailsView = ({
                             Field
                           </th>
                           <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                            Canonical
+                            Baseline
                           </th>
                           <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
                             Current
@@ -215,7 +215,7 @@ export const SimulationDetailsView = ({
                       </thead>
                       <tbody>
                         {Object.entries(simulation.runConfigDeltas).map(([field, diff]) => {
-                          const canonical = (diff as Record<string, unknown>).canonical;
+                          const baseline = (diff as Record<string, unknown>).baseline;
                           const current = (diff as Record<string, unknown>).current;
                           return (
                             <tr key={field} className="border-b last:border-0">
@@ -226,7 +226,7 @@ export const SimulationDetailsView = ({
                                 />
                               </td>
                               <td className="p-2 align-top">
-                                <DiffCell value={canonical} className="max-w-[240px]" />
+                                <DiffCell value={baseline} className="max-w-[240px]" />
                               </td>
                               <td className="p-2 align-top">
                                 <DiffCell value={current} className="max-w-[240px]" />

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -137,11 +137,11 @@ export const SimulationDetailsView = ({
                 <FieldRow label="Case Name">
                   <ReadonlyInput value={simulation.caseName} />
                 </FieldRow>
-                <FieldRow label="Baseline">
-                  <span className="text-sm">{simulation.isBaseline ? 'Yes' : 'No'}</span>
+                <FieldRow label="Reference">
+                  <span className="text-sm">{simulation.isReference ? 'Yes' : 'No'}</span>
                 </FieldRow>
-                {!simulation.isBaseline && (
-                  <FieldRow label="Changes vs baseline">
+                {!simulation.isReference && (
+                  <FieldRow label="Changes vs reference">
                     <span className="text-sm">{simulation.changeCount}</span>
                   </FieldRow>
                 )}
@@ -189,8 +189,8 @@ export const SimulationDetailsView = ({
             </Card>
           </div>
 
-          {/* Config diff section for non-baseline simulations */}
-          {!simulation.isBaseline && (
+          {/* Config diff section for non-reference simulations */}
+          {!simulation.isReference && (
             <Card>
               <CardHeader className="pb-2">
                 <CardTitle className="text-base">Configuration Differences</CardTitle>
@@ -206,7 +206,7 @@ export const SimulationDetailsView = ({
                             Field
                           </th>
                           <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                            Baseline
+                            Reference
                           </th>
                           <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
                             Current
@@ -215,7 +215,7 @@ export const SimulationDetailsView = ({
                       </thead>
                       <tbody>
                         {Object.entries(simulation.runConfigDeltas).map(([field, diff]) => {
-                          const baseline = (diff as Record<string, unknown>).baseline;
+                          const reference = (diff as Record<string, unknown>).reference;
                           const current = (diff as Record<string, unknown>).current;
                           return (
                             <tr key={field} className="border-b last:border-0">
@@ -226,7 +226,7 @@ export const SimulationDetailsView = ({
                                 />
                               </td>
                               <td className="p-2 align-top">
-                                <DiffCell value={baseline} className="max-w-[240px]" />
+                                <DiffCell value={reference} className="max-w-[240px]" />
                               </td>
                               <td className="p-2 align-top">
                                 <DiffCell value={current} className="max-w-[240px]" />

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -16,7 +16,7 @@ export interface CaseOut {
   id: string;
   name: string;
   caseGroup: string | null;
-  baselineSimulationId: string | null;
+  referenceSimulationId: string | null;
   simulations: SimulationSummaryOut[];
   machineNames: string[];
   hpcUsernames: string[];
@@ -32,7 +32,7 @@ export interface SimulationSummaryOut {
   id: string;
   executionId: string;
   status: string;
-  isBaseline: boolean;
+  isReference: boolean;
   changeCount: number;
   simulationStartDate: string;
   simulationEndDate: string | null;
@@ -92,7 +92,7 @@ export interface SimulationCreate {
   // Miscellaneous
   // ~~~~~~~~~~~~~~~~~
   extra?: Record<string, unknown>;
-  runConfigDeltas?: Record<string, { baseline: unknown; current: unknown }> | null;
+  runConfigDeltas?: Record<string, { reference: unknown; current: unknown }> | null;
 
   // Relationships
   // ~~~~~~~~~~~~~~
@@ -117,7 +117,7 @@ export interface SimulationOut extends SimulationCreate {
   id: string;
   caseName: string;
   caseGroup: string | null;
-  isBaseline: boolean;
+  isReference: boolean;
   changeCount: number;
 
   // Provenance & submission

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -16,7 +16,7 @@ export interface CaseOut {
   id: string;
   name: string;
   caseGroup: string | null;
-  canonicalSimulationId: string | null;
+  baselineSimulationId: string | null;
   simulations: SimulationSummaryOut[];
   machineNames: string[];
   hpcUsernames: string[];
@@ -32,7 +32,7 @@ export interface SimulationSummaryOut {
   id: string;
   executionId: string;
   status: string;
-  isCanonical: boolean;
+  isBaseline: boolean;
   changeCount: number;
   simulationStartDate: string;
   simulationEndDate: string | null;
@@ -92,7 +92,7 @@ export interface SimulationCreate {
   // Miscellaneous
   // ~~~~~~~~~~~~~~~~~
   extra?: Record<string, unknown>;
-  runConfigDeltas?: Record<string, { canonical: unknown; current: unknown }> | null;
+  runConfigDeltas?: Record<string, { baseline: unknown; current: unknown }> | null;
 
   // Relationships
   // ~~~~~~~~~~~~~~
@@ -117,7 +117,7 @@ export interface SimulationOut extends SimulationCreate {
   id: string;
   caseName: string;
   caseGroup: string | null;
-  isCanonical: boolean;
+  isBaseline: boolean;
   changeCount: number;
 
   // Provenance & submission


### PR DESCRIPTION
## Description
<!--
  Summarize the change, motivation, and any dependencies.
-->

- Closes #156
- Renames canonical simulation terminology to reference across backend models, API schemas, frontend types, and UI text
- Adds an Alembic/data migration to rename `cases.canonical_simulation_id` and rewrite persisted `run_config_deltas[*].canonical` JSON keys to `reference`
- Updates seed fixtures and test coverage while preserving first-successful-run reference selection behavior

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [x] Tests added or updated (if needed)
- [ ] All tests pass (locally and CI/CD)
- [x] Documentation/comments updated (if needed)
- [x] Breaking change noted (if applicable)

## Deployment Notes (if any)
<!--
  Add any special deployment or migration steps here.
-->

- Backend migration `20260331_000000` renames `cases.canonical_simulation_id` to `baseline_simulation_id` and rewrites persisted `simulations.run_config_deltas[*].canonical` JSON keys to `baseline`.
- Backend and frontend should be deployed together because the API contract now uses `baselineSimulationId`, `isBaseline`, and `runConfigDeltas[*].baseline`, and the browse filter query parameter is now `baselineStatus`.
