### PR TITLE
Replace manual simulation submission with archive upload

### DIFF
--- a/backend/app/features/ingestion/api.py
+++ b/backend/app/features/ingestion/api.py
@@ -18,6 +18,7 @@ from app.features.ingestion.schemas import (
     IngestFromPathRequest,
     IngestionCreate,
     IngestionResponse,
+    IngestionSimulationSummary,
     IngestionStatus,
 )
 from app.features.machine.utils import resolve_machine_by_name
@@ -184,7 +185,7 @@ def ingest_from_upload(
 
         response = _process_ingestion(
             ingest_result=ingest_result,
-            source_type=IngestionSourceType.HPC_UPLOAD,
+            source_type=IngestionSourceType.BROWSER_UPLOAD,
             source_reference=filename,
             machine_id=machine.id,
             user=user,
@@ -361,14 +362,14 @@ def _process_ingestion(
         db.add(ingestion)
         db.flush()
 
-        _persist_simulations(
+        created_sims = _persist_simulations(
             ingestion.id, ingest_result.simulations, db, user, hpc_username
         )
 
     return IngestionResponse(
         created_count=ingest_result.created_count,
         duplicate_count=ingest_result.duplicate_count,
-        simulations=ingest_result.simulations,
+        simulations=_build_ingestion_simulation_summaries(created_sims, db),
         errors=ingest_result.errors,
     )
 
@@ -409,7 +410,7 @@ def _persist_simulations(
     db: Session,
     user: User,
     hpc_username: str | None = None,
-) -> None:
+) -> list[Simulation]:
     """Persist simulation records with artifacts and links to the database.
 
     After all simulations are flushed, sets the canonical simulation on
@@ -482,4 +483,27 @@ def _persist_simulations(
 
     _set_canonical_simulations(db, created_sims)
 
-    db.flush()
+    return created_sims
+
+
+def _build_ingestion_simulation_summaries(
+    created_sims: list[Simulation], db: Session
+) -> list[IngestionSimulationSummary]:
+    if not created_sims:
+        return []
+
+    case_ids = list({sim.case_id for sim in created_sims})
+    cases = {
+        case.id: case for case in db.query(Case).filter(Case.id.in_(case_ids)).all()
+    }
+
+    return [
+        IngestionSimulationSummary(
+            id=sim.id,
+            case_id=sim.case_id,
+            case_name=cases[sim.case_id].name,
+            execution_id=sim.execution_id,
+        )
+        for sim in created_sims
+        if sim.id is not None and sim.case_id in cases
+    ]

--- a/backend/app/features/ingestion/api.py
+++ b/backend/app/features/ingestion/api.py
@@ -2,6 +2,7 @@ import hashlib
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import NoReturn
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
@@ -12,6 +13,7 @@ from app.common.dependencies import get_database_session
 from app.core.database import transaction
 from app.features.ingestion.ingest import IngestArchiveResult, ingest_archive
 from app.features.ingestion.models import Ingestion, IngestionSourceType
+from app.features.ingestion.parsers.parser import ArchiveValidationError
 from app.features.ingestion.schemas import (
     IngestFromPathRequest,
     IngestionCreate,
@@ -25,6 +27,8 @@ from app.features.user.manager import current_active_user
 from app.features.user.models import User, UserRole
 
 router = APIRouter(prefix="/ingestions", tags=["Ingestions"])
+
+MAX_UPLOAD_SIZE_BYTES = 50 * 1024 * 1024
 
 
 def _resolve_request_machine(db: Session, machine_name: str):
@@ -169,8 +173,14 @@ def ingest_from_upload(
             sha256_hex = _save_uploaded_file_and_hash(file, archive_path)
 
             ingest_result = _run_ingest_archive(
-                archive_path=str(archive_path), output_dir=tmpdir, db=db
+                archive_path=str(archive_path),
+                output_dir=tmpdir,
+                db=db,
+                strict_validation=True,
             )
+
+        if ingest_result.errors:
+            _raise_archive_validation_error(ingest_result.errors)
 
         response = _process_ingestion(
             ingest_result=ingest_result,
@@ -185,7 +195,10 @@ def ingest_from_upload(
 
         return response
     finally:
-        file.file.close()
+        try:
+            file.file.close()
+        except Exception:
+            pass
 
 
 def _validate_archive_path(archive_path: Path) -> None:
@@ -217,18 +230,20 @@ def _validate_upload_file(file: UploadFile) -> None:
             status_code=400, detail="File must be a .zip, .tar.gz, or .tgz archive"
         )
 
-    if hasattr(file, "size") and file.size and file.size > 20 * 1024 * 1024:
-        raise HTTPException(status_code=413, detail="File too large")
-
 
 def _save_uploaded_file_and_hash(
     file: UploadFile,
     archive_path: Path,
 ) -> str:
     sha256_hash = hashlib.sha256()
+    total_bytes = 0
 
     with archive_path.open("wb") as out_file:
         for chunk in iter(lambda: file.file.read(8192), b""):
+            total_bytes += len(chunk)
+            if total_bytes > MAX_UPLOAD_SIZE_BYTES:
+                raise HTTPException(status_code=413, detail="File too large")
+
             out_file.write(chunk)
             sha256_hash.update(chunk)
 
@@ -236,10 +251,21 @@ def _save_uploaded_file_and_hash(
 
 
 def _run_ingest_archive(
-    archive_path: str, output_dir: str, db: Session
+    archive_path: str,
+    output_dir: str,
+    db: Session,
+    *,
+    strict_validation: bool = False,
 ) -> IngestArchiveResult:
     try:
-        return ingest_archive(archive_path=archive_path, output_dir=output_dir, db=db)
+        return ingest_archive(
+            archive_path=archive_path,
+            output_dir=output_dir,
+            db=db,
+            strict_validation=strict_validation,
+        )
+    except ArchiveValidationError as exc:
+        _raise_archive_validation_error(exc.errors)
     except ValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
@@ -256,6 +282,16 @@ def _run_ingest_archive(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
         ) from exc
+
+
+def _raise_archive_validation_error(errors: list[dict[str, str]]) -> NoReturn:
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail={
+            "message": "Archive validation failed.",
+            "errors": errors,
+        },
+    )
 
 
 def _process_ingestion(

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -101,6 +101,8 @@ def ingest_archive(
     archive_path: Path | str,
     output_dir: Path | str,
     db: Session,
+    *,
+    strict_validation: bool = False,
 ) -> IngestArchiveResult:
     """Ingest a simulation archive and return summary counts.
 
@@ -147,7 +149,9 @@ def ingest_archive(
     )
 
     parsed_simulations, skipped_count = main_parser(
-        archive_path_resolved, output_dir_resolved
+        archive_path_resolved,
+        output_dir_resolved,
+        strict_validation=strict_validation,
     )
 
     if not parsed_simulations:
@@ -645,7 +649,7 @@ def _build_simulation_create_draft(
     """
     # Parse datetime fields using the shared utility function.
     simulation_start_date = _parse_datetime_field(
-        parsed_simulation.simulation_start_date
+        parsed_simulation.simulation_start_date or parsed_simulation.run_start_date
     )
     simulation_end_date = _parse_datetime_field(parsed_simulation.simulation_end_date)
 
@@ -667,7 +671,7 @@ def _build_simulation_create_draft(
         status=status,
         campaign=parsed_simulation.campaign,
         experiment_type=parsed_simulation.experiment_type,
-        initialization_type=parsed_simulation.initialization_type,
+        initialization_type=parsed_simulation.initialization_type or "unknown",
         machine_id=machine_id,
         simulation_start_date=simulation_start_date,
         simulation_end_date=simulation_end_date,

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -649,7 +649,7 @@ def _build_simulation_create_draft(
     """
     # Parse datetime fields using the shared utility function.
     simulation_start_date = _parse_datetime_field(
-        parsed_simulation.simulation_start_date or parsed_simulation.run_start_date
+        parsed_simulation.simulation_start_date
     )
     simulation_end_date = _parse_datetime_field(parsed_simulation.simulation_end_date)
 
@@ -671,7 +671,7 @@ def _build_simulation_create_draft(
         status=status,
         campaign=parsed_simulation.campaign,
         experiment_type=parsed_simulation.experiment_type,
-        initialization_type=parsed_simulation.initialization_type or "unknown",
+        initialization_type=parsed_simulation.initialization_type,
         machine_id=machine_id,
         simulation_start_date=simulation_start_date,
         simulation_end_date=simulation_end_date,

--- a/backend/app/features/ingestion/parsers/parser.py
+++ b/backend/app/features/ingestion/parsers/parser.py
@@ -68,6 +68,14 @@ class ArchiveValidationError(ValueError):
         super().__init__("Archive validation failed.")
 
 
+class IncompleteArchiveError(FileNotFoundError):
+    """Missing required metadata for an execution directory."""
+
+    def __init__(self, errors: list[dict[str, str]]):
+        self.errors = errors
+        super().__init__("; ".join(error["message"] for error in errors))
+
+
 FILE_SPECS: dict[str, FileSpec] = {
     "case_docs_env_case": {
         "pattern": r"env_case\.xml\..*\.gz",
@@ -231,12 +239,18 @@ def _process_execution_dir(
     try:
         metadata_files = _locate_metadata_files(exec_dir)
         return _parse_all_files(exec_dir, metadata_files), [], 0
+    except IncompleteArchiveError as exc:
+        if strict_validation:
+            return None, exc.errors, 0
+
+        logger.warning("Skipping incomplete run in '%s': %s", exec_dir, exc)
+        return None, [], 1
     except ArchiveValidationError as exc:
         if strict_validation:
             return None, exc.errors, 0
 
         logger.warning(
-            "Skipping incomplete run in '%s': %s",
+            "Skipping invalid run in '%s': %s",
             exec_dir,
             "; ".join(error["message"] for error in exc.errors),
         )
@@ -371,7 +385,8 @@ def _map_case_to_execution_dirs(root_dir: str) -> dict[str, list[str]]:
 def _locate_metadata_files(exp_dir: str) -> SimulationFiles:
     """Locate required and optional files in the execution directory."""
     files: SimulationFiles = {key: None for key in FILE_SPECS}
-    validation_errors: list[dict[str, str]] = []
+    invalid_archive_errors: list[dict[str, str]] = []
+    missing_required_errors: list[dict[str, str]] = []
     missing_optional: list[str] = []
     casedocs_dirs = _find_casedocs_dirs(exp_dir)
 
@@ -379,7 +394,7 @@ def _locate_metadata_files(exp_dir: str) -> SimulationFiles:
         matches = _find_spec_matches(exp_dir, casedocs_dirs, spec)
 
         if len(matches) > 1:
-            validation_errors.append(
+            invalid_archive_errors.append(
                 {
                     "code": "multiple_matching_files",
                     "execution_dir": exp_dir,
@@ -398,7 +413,7 @@ def _locate_metadata_files(exp_dir: str) -> SimulationFiles:
             continue
 
         if spec.get("required", False):
-            validation_errors.append(
+            missing_required_errors.append(
                 {
                     "code": "missing_required_file",
                     "execution_dir": exp_dir,
@@ -414,8 +429,11 @@ def _locate_metadata_files(exp_dir: str) -> SimulationFiles:
 
         missing_optional.append(key)
 
-    if validation_errors:
-        raise ArchiveValidationError(validation_errors)
+    if invalid_archive_errors:
+        raise ArchiveValidationError(invalid_archive_errors + missing_required_errors)
+
+    if missing_required_errors:
+        raise IncompleteArchiveError(missing_required_errors)
 
     if missing_optional:
         logger.warning(
@@ -468,18 +486,28 @@ def _build_file_not_found_validation_error(
     exec_dir: str, exc: FileNotFoundError
 ) -> dict[str, str]:
     message = str(exc)
+    if "timing-file LID" in message:
+        return _build_missing_timing_lid_error(exec_dir)
+
     error = {
         "code": "file_not_found",
         "execution_dir": exec_dir,
         "message": message,
     }
 
-    if "timing-file LID" in message:
-        error["code"] = "missing_required_value"
-        error["file_spec"] = FILE_SPECS["e3sm_timing"]["display_pattern"]
-        error["location"] = _location_label(FILE_SPECS["e3sm_timing"]["location"])
-
     return error
+
+
+def _build_missing_timing_lid_error(exec_dir: str) -> dict[str, str]:
+    return {
+        "code": "missing_required_value",
+        "execution_dir": exec_dir,
+        "file_spec": FILE_SPECS["e3sm_timing"]["display_pattern"],
+        "location": _location_label(FILE_SPECS["e3sm_timing"]["location"]),
+        "message": (
+            f"Required timing-file LID missing for execution directory '{exec_dir}'"
+        ),
+    }
 
 
 def _parse_all_files(exec_dir: str, files: dict[str, str | None]) -> ParsedSimulation:
@@ -549,15 +577,11 @@ def _parse_all_files(exec_dir: str, files: dict[str, str | None]) -> ParsedSimul
 def _resolve_execution_id(execution_id: str | None, exec_dir: str) -> str:
     """Return a stable execution_id or treat the run as incomplete."""
     if execution_id is None:
-        raise FileNotFoundError(
-            f"Required timing-file LID missing for execution directory '{exec_dir}'"
-        )
+        raise IncompleteArchiveError([_build_missing_timing_lid_error(exec_dir)])
 
     normalized = execution_id.strip()
     if not normalized:
-        raise FileNotFoundError(
-            f"Required timing-file LID missing for execution directory '{exec_dir}'"
-        )
+        raise IncompleteArchiveError([_build_missing_timing_lid_error(exec_dir)])
 
     exec_dir_basename = os.path.basename(exec_dir)
     if exec_dir_basename and exec_dir_basename != normalized:

--- a/backend/app/features/ingestion/parsers/parser.py
+++ b/backend/app/features/ingestion/parsers/parser.py
@@ -322,13 +322,6 @@ def _is_within_directory(base_dir: Path, target_path: Path) -> bool:
     return True
 
 
-def _location_label(location: str) -> str:
-    if location == "root":
-        return "archive root"
-
-    return "casedocs/"
-
-
 def _map_case_to_execution_dirs(root_dir: str) -> dict[str, list[str]]:
     """Maps case directories to their execution subdirectories.
 
@@ -459,6 +452,13 @@ def _find_spec_matches(
                 matches.append(os.path.join(directory, fname))
 
     return matches
+
+
+def _location_label(location: str) -> str:
+    if location == "root":
+        return "archive root"
+
+    return "casedocs/"
 
 
 def _parse_all_files(exec_dir: str, files: dict[str, str | None]) -> ParsedSimulation:

--- a/backend/app/features/ingestion/parsers/parser.py
+++ b/backend/app/features/ingestion/parsers/parser.py
@@ -242,7 +242,10 @@ def _process_execution_dir(
         )
         return None, [], 1
     except FileNotFoundError as exc:
-        logger.warning(f"Skipping incomplete run in '{exec_dir}': {exc}")
+        if strict_validation:
+            return None, [_build_file_not_found_validation_error(exec_dir, exc)], 0
+
+        logger.warning("Skipping incomplete run in '%s': %s", exec_dir, exc)
         return None, [], 1
 
 
@@ -459,6 +462,24 @@ def _location_label(location: str) -> str:
         return "archive root"
 
     return "casedocs/"
+
+
+def _build_file_not_found_validation_error(
+    exec_dir: str, exc: FileNotFoundError
+) -> dict[str, str]:
+    message = str(exc)
+    error = {
+        "code": "file_not_found",
+        "execution_dir": exec_dir,
+        "message": message,
+    }
+
+    if "timing-file LID" in message:
+        error["code"] = "missing_required_value"
+        error["file_spec"] = FILE_SPECS["e3sm_timing"]["display_pattern"]
+        error["location"] = _location_label(FILE_SPECS["e3sm_timing"]["location"])
+
+    return error
 
 
 def _parse_all_files(exec_dir: str, files: dict[str, str | None]) -> ParsedSimulation:

--- a/backend/app/features/ingestion/parsers/parser.py
+++ b/backend/app/features/ingestion/parsers/parser.py
@@ -54,62 +54,80 @@ class FileSpec(TypedDict, total=False):
     """Specifications for each file type to be parsed."""
 
     pattern: str
+    display_pattern: str
     location: str
     parser: Callable
     required: bool
 
 
+class ArchiveValidationError(ValueError):
+    """Structured archive validation failure."""
+
+    def __init__(self, errors: list[dict[str, str]]):
+        self.errors = errors
+        super().__init__("Archive validation failed.")
+
+
 FILE_SPECS: dict[str, FileSpec] = {
     "case_docs_env_case": {
         "pattern": r"env_case\.xml\..*\.gz",
+        "display_pattern": "env_case.xml..*.gz",
         "location": "casedocs",
         "parser": parse_env_case,
         "required": True,
     },
     "case_docs_env_build": {
         "pattern": r"env_build\.xml\..*\.gz",
+        "display_pattern": "env_build.xml..*.gz",
         "location": "casedocs",
         "parser": parse_env_build,
         "required": True,
     },
     "case_docs_env_run": {
         "pattern": r"env_run\.xml\..*",
+        "display_pattern": "env_run.xml..*",
         "location": "casedocs",
         "parser": parse_env_run,
         "required": True,
     },
     "readme_case": {
         "pattern": r"README\.case\..*\.gz",
+        "display_pattern": "README.case..*.gz",
         "location": "casedocs",
         "parser": parse_readme_case,
         "required": True,
     },
     "case_status": {
         "pattern": r"CaseStatus\..*\.gz",
+        "display_pattern": "CaseStatus..*.gz",
         "location": "root",
         "parser": parse_case_status,
-        "required": False,
+        "required": True,
     },
     "e3sm_timing": {
         "pattern": r"e3sm_timing\..*",
+        "display_pattern": "e3sm_timing..*..*",
         "location": "root",
         "parser": parse_e3sm_timing,
         "required": True,
     },
     "git_describe": {
         "pattern": r"GIT_DESCRIBE\..*\.gz",
+        "display_pattern": "GIT_DESCRIBE..*.gz",
         "location": "root",
         "parser": parse_git_describe,
         "required": True,
     },
     "git_config": {
         "pattern": r"GIT_CONFIG\..*\.gz",
+        "display_pattern": "GIT_CONFIG..*.gz",
         "location": "root",
         "parser": parse_git_config,
         "required": False,
     },
     "git_status": {
         "pattern": r"GIT_STATUS\..*\.gz",
+        "display_pattern": "GIT_STATUS..*.gz",
         "location": "root",
         "parser": parse_git_status,
         "required": False,
@@ -118,7 +136,10 @@ FILE_SPECS: dict[str, FileSpec] = {
 
 
 def main_parser(
-    archive_path: str | Path, output_dir: str | Path
+    archive_path: str | Path,
+    output_dir: str | Path,
+    *,
+    strict_validation: bool = False,
 ) -> tuple[list[ParsedSimulation], int]:
     """Main entrypoint for parser workflow.
 
@@ -172,6 +193,8 @@ def main_parser(
     results: list[ParsedSimulation] = []
     skipped_count = 0
 
+    validation_errors: list[dict[str, str]] = []
+
     for case_dir, exec_dirs in case_to_executions_dirs.items():
         sorted_exec_dirs = sorted(exec_dirs)
         logger.info(
@@ -180,14 +203,17 @@ def main_parser(
         )
 
         for exec_dir in sorted_exec_dirs:
-            try:
-                metadata_files = _locate_metadata_files(exec_dir)
-                results.append(_parse_all_files(exec_dir, metadata_files))
-            except FileNotFoundError as exc:
-                logger.warning(f"Skipping incomplete run in '{exec_dir}': {exc}")
-                skipped_count += 1
+            parsed_simulation, exec_validation_errors, exec_skipped_count = (
+                _process_execution_dir(exec_dir, strict_validation=strict_validation)
+            )
+            skipped_count += exec_skipped_count
+            validation_errors.extend(exec_validation_errors)
 
-                continue
+            if parsed_simulation is not None:
+                results.append(parsed_simulation)
+
+    if validation_errors:
+        raise ArchiveValidationError(validation_errors)
 
     if skipped_count:
         logger.info(
@@ -197,6 +223,27 @@ def main_parser(
     logger.info("Completed parsing all execution directories.")
 
     return results, skipped_count
+
+
+def _process_execution_dir(
+    exec_dir: str, *, strict_validation: bool
+) -> tuple[ParsedSimulation | None, list[dict[str, str]], int]:
+    try:
+        metadata_files = _locate_metadata_files(exec_dir)
+        return _parse_all_files(exec_dir, metadata_files), [], 0
+    except ArchiveValidationError as exc:
+        if strict_validation:
+            return None, exc.errors, 0
+
+        logger.warning(
+            "Skipping incomplete run in '%s': %s",
+            exec_dir,
+            "; ".join(error["message"] for error in exc.errors),
+        )
+        return None, [], 1
+    except FileNotFoundError as exc:
+        logger.warning(f"Skipping incomplete run in '{exec_dir}': {exc}")
+        return None, [], 1
 
 
 def _extract_archive(archive_path: str, output_dir: str) -> None:
@@ -275,6 +322,13 @@ def _is_within_directory(base_dir: Path, target_path: Path) -> bool:
     return True
 
 
+def _location_label(location: str) -> str:
+    if location == "root":
+        return "archive root"
+
+    return "casedocs/"
+
+
 def _map_case_to_execution_dirs(root_dir: str) -> dict[str, list[str]]:
     """Maps case directories to their execution subdirectories.
 
@@ -321,85 +375,90 @@ def _map_case_to_execution_dirs(root_dir: str) -> dict[str, list[str]]:
 def _locate_metadata_files(exp_dir: str) -> SimulationFiles:
     """Locate required and optional files in the execution directory."""
     files: SimulationFiles = {key: None for key in FILE_SPECS}
+    validation_errors: list[dict[str, str]] = []
+    missing_optional: list[str] = []
+    casedocs_dirs = _find_casedocs_dirs(exp_dir)
 
-    files = _find_root_files(exp_dir, files)
-    files = _find_casedocs_files(exp_dir, files)
-
-    _check_missing_files(files, exp_dir)
-
-    return files
-
-
-def _find_file_in_dir(directory: str, pattern: str) -> str | None:
-    """Find a file matching the pattern in the specified directory.
-
-    Raises
-    ------
-    ValueError
-        If multiple files match the pattern.
-    """
-    matches = []
-    for fname in os.listdir(directory):
-        if re.match(pattern, fname):
-            matches.append(os.path.join(directory, fname))
-
-    if len(matches) > 1:
-        raise ValueError(
-            f"Multiple files matching pattern '{pattern}' found in {directory}: {matches}"
-        )
-
-    return matches[0] if matches else None
-
-
-def _find_root_files(exp_dir: str, files: SimulationFiles) -> SimulationFiles:
-    """Find files located in the root of the execution directory."""
     for key, spec in FILE_SPECS.items():
-        if spec["location"] == "root":
-            pattern = str(spec["pattern"])
-            files[key] = _find_file_in_dir(exp_dir, pattern)
+        matches = _find_spec_matches(exp_dir, casedocs_dirs, spec)
 
-    return files
+        if len(matches) > 1:
+            validation_errors.append(
+                {
+                    "code": "multiple_matching_files",
+                    "execution_dir": exp_dir,
+                    "file_spec": spec["display_pattern"],
+                    "location": _location_label(spec["location"]),
+                    "message": (
+                        f"Multiple files matched '{spec['display_pattern']}' in "
+                        f"{_location_label(spec['location'])} for '{exp_dir}'."
+                    ),
+                }
+            )
+            continue
 
+        if matches:
+            files[key] = matches[0]
+            continue
 
-def _find_casedocs_files(exp_dir: str, files: SimulationFiles) -> SimulationFiles:
-    for key, spec in FILE_SPECS.items():
-        if spec["location"] == "casedocs":
-            pattern = str(spec["pattern"])
+        if spec.get("required", False):
+            validation_errors.append(
+                {
+                    "code": "missing_required_file",
+                    "execution_dir": exp_dir,
+                    "file_spec": spec["display_pattern"],
+                    "location": _location_label(spec["location"]),
+                    "message": (
+                        f"Missing required '{spec['display_pattern']}' in "
+                        f"{_location_label(spec['location'])} for '{exp_dir}'."
+                    ),
+                }
+            )
+            continue
 
-            for subdir in os.listdir(exp_dir):
-                subdir_path = os.path.join(exp_dir, subdir)
+        missing_optional.append(key)
 
-                if os.path.isdir(subdir_path) and subdir.startswith("CaseDocs"):
-                    match = _find_file_in_dir(subdir_path, pattern)
+    if validation_errors:
+        raise ArchiveValidationError(validation_errors)
 
-                    if match:
-                        files[key] = match
-                        break
-    return files
-
-
-def _check_missing_files(files: SimulationFiles, exp_dir: str) -> None:
-    missing_required = [
-        key
-        for key, spec in FILE_SPECS.items()
-        if spec.get("required", False) and not files.get(key)
-    ]
-    if missing_required:
-        raise FileNotFoundError(
-            "Required files not found in execution directory "
-            f"'{exp_dir}': {', '.join(missing_required)}"
-        )
-
-    missing_optional = [
-        key
-        for key, spec in FILE_SPECS.items()
-        if not spec.get("required", False) and not files.get(key)
-    ]
     if missing_optional:
         logger.warning(
             "Optional files missing in execution directory "
             f"'{exp_dir}': {', '.join(missing_optional)}"
         )
+
+    return files
+
+
+def _find_casedocs_dirs(exp_dir: str) -> list[str]:
+    casedocs_dirs: list[str] = []
+
+    for subdir in os.listdir(exp_dir):
+        subdir_path = os.path.join(exp_dir, subdir)
+
+        if os.path.isdir(subdir_path) and subdir.lower().startswith("casedocs"):
+            casedocs_dirs.append(subdir_path)
+
+    return casedocs_dirs
+
+
+def _find_spec_matches(
+    exp_dir: str, casedocs_dirs: list[str], spec: FileSpec
+) -> list[str]:
+    if spec["location"] == "root":
+        directories = [exp_dir]
+    else:
+        directories = casedocs_dirs
+
+    matches: list[str] = []
+    pattern = str(spec["pattern"])
+
+    for directory in directories:
+        for fname in os.listdir(directory):
+            if re.match(pattern, fname):
+                matches.append(os.path.join(directory, fname))
+
+    return matches
 
 
 def _parse_all_files(exec_dir: str, files: dict[str, str | None]) -> ParsedSimulation:

--- a/backend/app/features/ingestion/schemas.py
+++ b/backend/app/features/ingestion/schemas.py
@@ -5,7 +5,17 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.features.ingestion.enums import IngestionSourceType, IngestionStatus
-from app.features.simulation.schemas import SimulationCreate
+
+
+class IngestionSimulationSummary(BaseModel):
+    """Lightweight summary of a persisted simulation created by ingestion."""
+
+    id: Annotated[UUID, Field(..., description="ID of the created simulation")]
+    case_id: Annotated[UUID, Field(..., description="ID of the associated case")]
+    case_name: Annotated[str, Field(..., description="Name of the associated case")]
+    execution_id: Annotated[
+        str, Field(..., description="Execution identifier for the created simulation")
+    ]
 
 
 class IngestFromPathRequest(BaseModel):
@@ -38,8 +48,8 @@ class IngestionResponse(BaseModel):
         int, Field(..., description="Number of duplicate simulations detected")
     ]
     simulations: Annotated[
-        list[SimulationCreate],
-        Field(..., description="List of created simulation objects"),
+        list[IngestionSimulationSummary],
+        Field(..., description="List of created simulation summaries"),
     ]
     errors: Annotated[
         list[dict[str, str]],

--- a/backend/app/features/simulation/api.py
+++ b/backend/app/features/simulation/api.py
@@ -47,7 +47,7 @@ def list_cases(db: Session = Depends(get_database_session)) -> list[CaseOut]:
     """
     cases = (
         db.query(Case)
-        .options(selectinload(Case.simulations))
+        .options(selectinload(Case.simulations).selectinload(Simulation.machine))
         .order_by(Case.created_at.desc())
         .all()
     )
@@ -114,7 +114,7 @@ def get_case(case_id: UUID, db: Session = Depends(get_database_session)) -> Case
     """
     case = (
         db.query(Case)
-        .options(selectinload(Case.simulations))
+        .options(selectinload(Case.simulations).selectinload(Simulation.machine))
         .filter(Case.id == case_id)
         .first()
     )
@@ -142,6 +142,18 @@ def _case_to_out(case: Case) -> CaseOut:
         SimulationSummaryOut
     """
     summaries = []
+    machine_names = sorted(
+        {
+            sim.machine.name
+            for sim in case.simulations
+            if sim.machine is not None and sim.machine.name
+        },
+        key=lambda name: name.lower(),
+    )
+    hpc_usernames = sorted(
+        {sim.hpc_username for sim in case.simulations if sim.hpc_username},
+        key=lambda username: username.lower(),
+    )
 
     for sim in case.simulations:
         is_canonical = sim.id == case.canonical_simulation_id
@@ -165,6 +177,8 @@ def _case_to_out(case: Case) -> CaseOut:
         case_group=case.case_group,
         canonical_simulation_id=case.canonical_simulation_id,
         simulations=summaries,
+        machine_names=machine_names,
+        hpc_usernames=hpc_usernames,
         created_at=case.created_at,
         updated_at=case.updated_at,
     )

--- a/backend/app/features/simulation/schemas.py
+++ b/backend/app/features/simulation/schemas.py
@@ -348,6 +348,20 @@ class CaseOut(CamelOutBaseModel):
             description="Simulation executions belonging to this case.",
         ),
     ]
+    machine_names: Annotated[
+        list[str],
+        Field(
+            default_factory=list,
+            description="Unique machine names represented across this case's simulations.",
+        ),
+    ]
+    hpc_usernames: Annotated[
+        list[str],
+        Field(
+            default_factory=list,
+            description="Unique HPC usernames represented across this case's simulations.",
+        ),
+    ]
     created_at: Annotated[
         datetime, Field(..., description="Timestamp when the case was created")
     ]

--- a/backend/tests/features/ingestion/parsers/test_parser.py
+++ b/backend/tests/features/ingestion/parsers/test_parser.py
@@ -194,6 +194,31 @@ class TestMainParser:
         assert isinstance(result[0], ParsedSimulation)
         assert any("1.0-0" in parsed.execution_dir for parsed in result)
 
+    def test_supports_single_execution_archive_at_root(self, tmp_path: Path) -> None:
+        archive_base = tmp_path / "archive_extract"
+        execution_dir = archive_base / "1085209.251220-105556"
+        execution_dir.mkdir(parents=True)
+        self._create_execution_metadata_files(execution_dir, "001.001")
+
+        archive_path = tmp_path / "single_execution.zip"
+        self._create_zip_archive(archive_base, archive_path)
+
+        extract_dir = tmp_path / "extracted"
+        extract_dir.mkdir()
+
+        with self._mock_all_parsers(
+            parse_e3sm_timing={
+                "execution_id": "1085209.251220-105556",
+                "run_start_date": "2025-12-18T20:09:33",
+                "run_end_date": "2025-12-18T20:54:58",
+            }
+        ):
+            result, skipped = parser.main_parser(archive_path, extract_dir)
+
+        assert skipped == 0
+        assert len(result) == 1
+        assert result[0].execution_id == "1085209.251220-105556"
+
     def test_with_tar_gz_archive(self, tmp_path: Path) -> None:
         archive_base = tmp_path / "archive_extract"
         execution_dir = archive_base / "2.5-10"

--- a/backend/tests/features/ingestion/parsers/test_parser.py
+++ b/backend/tests/features/ingestion/parsers/test_parser.py
@@ -297,6 +297,34 @@ class TestMainParser:
         assert result == []
         assert skipped == 1
 
+    def test_missing_required_files_raise_incomplete_archive_error(
+        self, tmp_path: Path
+    ) -> None:
+        execution_dir = tmp_path / "1.0-0"
+        execution_dir.mkdir(parents=True)
+        self._create_execution_metadata_files(
+            execution_dir,
+            "001.001",
+            case_status_content=None,
+        )
+
+        with pytest.raises(parser.IncompleteArchiveError) as exc_info:
+            parser._locate_metadata_files(str(execution_dir))
+
+        assert issubclass(parser.IncompleteArchiveError, FileNotFoundError)
+        assert exc_info.value.errors == [
+            {
+                "code": "missing_required_file",
+                "execution_dir": str(execution_dir),
+                "file_spec": "CaseStatus..*.gz",
+                "location": "archive root",
+                "message": (
+                    f"Missing required 'CaseStatus..*.gz' in archive root for "
+                    f"'{execution_dir}'."
+                ),
+            }
+        ]
+
     def test_multiple_matching_timing_files_raises_error(self, tmp_path: Path) -> None:
         archive_base = tmp_path / "archive_extract"
         execution_dir = archive_base / "1.0-0"
@@ -330,6 +358,7 @@ class TestMainParser:
         with pytest.raises(parser.ArchiveValidationError) as exc_info:
             parser.main_parser(archive_path, extract_dir, strict_validation=True)
 
+        assert not isinstance(exc_info.value, FileNotFoundError)
         assert exc_info.value.errors == [
             {
                 "code": "multiple_matching_files",
@@ -342,6 +371,116 @@ class TestMainParser:
                 ),
             }
         ]
+
+    def test_process_execution_dir_skips_invalid_archive_when_not_strict(
+        self,
+    ) -> None:
+        exec_dir = "/tmp/execution"
+        validation_errors = [{"message": "duplicate metadata"}]
+
+        with (
+            patch(
+                "app.features.ingestion.parsers.parser._locate_metadata_files",
+                side_effect=parser.ArchiveValidationError(validation_errors),
+            ),
+            patch(
+                "app.features.ingestion.parsers.parser.logger.warning"
+            ) as mock_warning,
+        ):
+            parsed_simulation, errors, skipped = parser._process_execution_dir(
+                exec_dir, strict_validation=False
+            )
+
+        assert parsed_simulation is None
+        assert errors == []
+        assert skipped == 1
+        mock_warning.assert_called_once_with(
+            "Skipping invalid run in '%s': %s",
+            exec_dir,
+            "duplicate metadata",
+        )
+
+    def test_process_execution_dir_reports_generic_file_not_found_when_strict(
+        self,
+    ) -> None:
+        exec_dir = "/tmp/execution"
+
+        with (
+            patch(
+                "app.features.ingestion.parsers.parser._locate_metadata_files",
+                return_value={},
+            ),
+            patch(
+                "app.features.ingestion.parsers.parser._parse_all_files",
+                side_effect=FileNotFoundError("metadata file disappeared"),
+            ),
+        ):
+            parsed_simulation, errors, skipped = parser._process_execution_dir(
+                exec_dir, strict_validation=True
+            )
+
+        assert parsed_simulation is None
+        assert errors == [
+            {
+                "code": "file_not_found",
+                "execution_dir": exec_dir,
+                "message": "metadata file disappeared",
+            }
+        ]
+        assert skipped == 0
+
+    def test_build_file_not_found_validation_error_for_missing_timing_lid(
+        self,
+    ) -> None:
+        exec_dir = "/tmp/execution"
+        error = parser._build_file_not_found_validation_error(
+            exec_dir,
+            FileNotFoundError(
+                f"Required timing-file LID missing for execution directory '{exec_dir}'"
+            ),
+        )
+
+        assert error == {
+            "code": "missing_required_value",
+            "execution_dir": exec_dir,
+            "file_spec": "e3sm_timing..*..*",
+            "location": "archive root",
+            "message": (
+                f"Required timing-file LID missing for execution directory '{exec_dir}'"
+            ),
+        }
+
+    def test_process_execution_dir_skips_generic_file_not_found_when_not_strict(
+        self,
+    ) -> None:
+        exec_dir = "/tmp/execution"
+        missing_file = FileNotFoundError("metadata file disappeared")
+
+        with (
+            patch(
+                "app.features.ingestion.parsers.parser._locate_metadata_files",
+                return_value={},
+            ),
+            patch(
+                "app.features.ingestion.parsers.parser._parse_all_files",
+                side_effect=missing_file,
+            ),
+            patch(
+                "app.features.ingestion.parsers.parser.logger.warning"
+            ) as mock_warning,
+        ):
+            parsed_simulation, errors, skipped = parser._process_execution_dir(
+                exec_dir, strict_validation=False
+            )
+
+        assert parsed_simulation is None
+        assert errors == []
+        assert skipped == 1
+        mock_warning.assert_called_once_with(
+            "Skipping incomplete run in '%s': %s",
+            exec_dir,
+            missing_file,
+        )
 
     def test_unsupported_archive_format_raises_error(self, tmp_path: Path) -> None:
         archive_path = tmp_path / "archive.rar"

--- a/backend/tests/features/ingestion/parsers/test_parser.py
+++ b/backend/tests/features/ingestion/parsers/test_parser.py
@@ -533,6 +533,38 @@ class TestMainParser:
         assert result == []
         assert skipped == 1
 
+    def test_strict_validation_reports_missing_timing_lid(self, tmp_path: Path) -> None:
+        execution_dir = tmp_path / "1.0-0"
+        execution_dir.mkdir(parents=True)
+        self._create_execution_metadata_files(execution_dir, "001.001")
+
+        with self._mock_all_parsers(
+            parse_e3sm_timing={
+                "execution_id": None,
+                "run_start_date": "2025-12-18T20:09:33",
+                "run_end_date": "2025-12-18T20:54:58",
+            }
+        ):
+            with pytest.raises(parser.ArchiveValidationError) as exc_info:
+                parser.main_parser(
+                    tmp_path,
+                    tmp_path / "unused_output",
+                    strict_validation=True,
+                )
+
+        assert exc_info.value.errors == [
+            {
+                "code": "missing_required_value",
+                "execution_dir": str(execution_dir),
+                "file_spec": "e3sm_timing..*..*",
+                "location": "archive root",
+                "message": (
+                    "Required timing-file LID missing for execution directory "
+                    f"'{execution_dir}'"
+                ),
+            }
+        ]
+
     def test_mismatched_timing_lid_falls_back_to_directory_basename(
         self, tmp_path: Path
     ) -> None:

--- a/backend/tests/features/ingestion/parsers/test_parser.py
+++ b/backend/tests/features/ingestion/parsers/test_parser.py
@@ -25,7 +25,7 @@ class TestMainParser:
         *,
         include_env_run: bool = True,
         include_timing: bool = True,
-        case_status_content: str | None = None,
+        case_status_content: str | None = "2025-01-01 00:00:00: case.run success",
     ) -> None:
         """Create standard execution files for testing."""
         version_base = version.split(".")[0]
@@ -163,7 +163,7 @@ class TestMainParser:
         assert "case_status" in parser.FILE_SPECS
         assert "case_docs_env_run" in parser.FILE_SPECS
         assert "e3sm_timing" in parser.FILE_SPECS
-        assert parser.FILE_SPECS["case_status"]["required"] is False
+        assert parser.FILE_SPECS["case_status"]["required"] is True
         assert parser.FILE_SPECS["case_docs_env_run"]["required"] is True
         assert parser.FILE_SPECS["e3sm_timing"]["required"] is True
 
@@ -288,6 +288,10 @@ class TestMainParser:
             f.write('<config><entry id="CASE" value="test_case" /></config>')
         with gzip.open(casedocs / "env_build.xml.001.gz", "wt") as f:
             f.write('<config><entry id="COMPILER" value="gnu" /></config>')
+        with gzip.open(casedocs / "env_run.xml.001.gz", "wt") as f:
+            f.write('<config><entry id="RUN_TYPE" value="startup" /></config>')
+        with gzip.open(execution_dir / "CaseStatus.001.gz", "wt") as f:
+            f.write("2025-01-01 00:00:00: case.run success")
         with gzip.open(execution_dir / "GIT_DESCRIBE.001.gz", "wt") as f:
             f.write("describe")
 
@@ -296,9 +300,23 @@ class TestMainParser:
 
         extract_dir = tmp_path / "extracted"
         extract_dir.mkdir()
+        extracted_execution_dir = extract_dir / "1.0-0"
 
-        with pytest.raises(ValueError, match="Multiple files matching pattern"):
-            parser.main_parser(archive_path, extract_dir)
+        with pytest.raises(parser.ArchiveValidationError) as exc_info:
+            parser.main_parser(archive_path, extract_dir, strict_validation=True)
+
+        assert exc_info.value.errors == [
+            {
+                "code": "multiple_matching_files",
+                "execution_dir": str(extracted_execution_dir),
+                "file_spec": "e3sm_timing..*..*",
+                "location": "archive root",
+                "message": (
+                    f"Multiple files matched 'e3sm_timing..*..*' in archive root for "
+                    f"'{extracted_execution_dir}'."
+                ),
+            }
+        ]
 
     def test_unsupported_archive_format_raises_error(self, tmp_path: Path) -> None:
         archive_path = tmp_path / "archive.rar"
@@ -370,6 +388,51 @@ class TestMainParser:
         assert result == []
         assert skipped == 1
 
+    def test_missing_case_status_skips_incomplete_run(self, tmp_path: Path) -> None:
+        execution_dir = tmp_path / "1.0-0"
+        execution_dir.mkdir(parents=True)
+        self._create_execution_metadata_files(
+            execution_dir,
+            "001.001",
+            case_status_content=None,
+        )
+
+        result, skipped = parser.main_parser(tmp_path, tmp_path / "unused_output")
+
+        assert result == []
+        assert skipped == 1
+
+    def test_strict_validation_reports_missing_required_spec(
+        self, tmp_path: Path
+    ) -> None:
+        execution_dir = tmp_path / "1.0-0"
+        execution_dir.mkdir(parents=True)
+        self._create_execution_metadata_files(
+            execution_dir,
+            "001.001",
+            case_status_content=None,
+        )
+
+        with pytest.raises(parser.ArchiveValidationError) as exc_info:
+            parser.main_parser(
+                tmp_path,
+                tmp_path / "unused_output",
+                strict_validation=True,
+            )
+
+        assert exc_info.value.errors == [
+            {
+                "code": "missing_required_file",
+                "execution_dir": str(execution_dir),
+                "file_spec": "CaseStatus..*.gz",
+                "location": "archive root",
+                "message": (
+                    f"Missing required 'CaseStatus..*.gz' in archive root for "
+                    f"'{execution_dir}'."
+                ),
+            }
+        ]
+
     def test_case_status_is_merged(self, tmp_path: Path) -> None:
         execution_dir = tmp_path / "1.0-0"
         execution_dir.mkdir(parents=True)
@@ -413,14 +476,16 @@ class TestMainParser:
         assert result[0].run_start_date == "2025-01-01 00:00:00"
         assert result[0].run_end_date is None
 
-    def test_missing_case_status_defaults_status_to_unknown(
-        self, tmp_path: Path
-    ) -> None:
+    def test_empty_case_status_defaults_status_to_unknown(self, tmp_path: Path) -> None:
         execution_dir = tmp_path / "1.0-0"
         execution_dir.mkdir(parents=True)
-        self._create_execution_metadata_files(execution_dir, "001.001")
+        self._create_execution_metadata_files(
+            execution_dir,
+            "001.001",
+            case_status_content="2025-01-01 00:00:00: case.run",
+        )
 
-        with self._mock_all_parsers():
+        with self._mock_all_parsers(parse_case_status={}):
             result, skipped = parser.main_parser(tmp_path, tmp_path / "unused_output")
 
         assert skipped == 0

--- a/backend/tests/features/ingestion/test_api.py
+++ b/backend/tests/features/ingestion/test_api.py
@@ -230,6 +230,14 @@ class TestIngestFromPathEndpoint:
         assert data["errors"] == mock_errors
 
         assert len(data["simulations"]) == 2
+        assert {simulation["execution_id"] for simulation in data["simulations"]} == {
+            "exec-errors-1",
+            "exec-errors-2",
+        }
+        assert {simulation["case_name"] for simulation in data["simulations"]} == {
+            "test_case_errors",
+            "case2_errors",
+        }
 
     def test_endpoint_creates_audit_record(self, client, db: Session, tmp_path):
         """Test that ingestion creates an audit record in the database."""
@@ -455,6 +463,9 @@ class TestIngestFromUploadEndpoint:
         data = res.json()
         assert data["created_count"] == 1
         assert data["duplicate_count"] == 0
+        assert len(data["simulations"]) == 1
+        assert data["simulations"][0]["execution_id"] == "exec-zip-1"
+        assert data["simulations"][0]["case_name"] == "test_case_zip"
 
     def test_upload_valid_tar_gz_file(self, client, db: Session):
         """Test uploading a valid .tar.gz archive."""
@@ -504,6 +515,7 @@ class TestIngestFromUploadEndpoint:
             )
 
         assert res.status_code == 201
+        assert res.json()["simulations"][0]["execution_id"] == "exec-targz-1"
 
     def test_upload_invalid_file_extension(self, client, db: Session):
         """Test that invalid file extensions are rejected."""
@@ -592,7 +604,7 @@ class TestIngestFromUploadEndpoint:
         )
 
         assert ingestion is not None
-        assert str(ingestion.source_type) == "hpc_upload"
+        assert str(ingestion.source_type) == "browser_upload"
         assert ingestion.status == "success"
         assert ingestion.archive_sha256 is not None
         assert len(ingestion.archive_sha256) == 64  # SHA256 hex length

--- a/backend/tests/features/ingestion/test_api.py
+++ b/backend/tests/features/ingestion/test_api.py
@@ -1082,6 +1082,61 @@ class TestIngestFromUploadEndpoint:
             simulation.git_repository_url == "https://github.com/E3SM-Project/E3SM.git"
         )
 
+    def test_persist_simulations_with_hpc_username(self, client, db: Session, tmp_path):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        archive_path = self._create_archive_file(
+            tmp_path, "archive_with_hpc_username.tar.gz"
+        )
+        payload = {
+            "archive_path": str(archive_path),
+            "machine_name": machine.name,
+            "hpc_username": "nersc-user",
+        }
+
+        case = Case(name="test_case_hpc_username")
+        db.add(case)
+        db.flush()
+
+        mock_simulations = [
+            SimulationCreate.model_validate(
+                {
+                    "caseId": str(case.id),
+                    "executionId": "exec-hpc-username-1",
+                    "compset": "AQUAPLANET",
+                    "compsetAlias": "QPC4",
+                    "gridName": "f19_f19",
+                    "gridResolution": "1.9x2.5",
+                    "initializationType": "startup",
+                    "simulationType": "experimental",
+                    "status": "created",
+                    "machineId": str(machine.id),
+                    "simulationStartDate": "2023-01-01T00:00:00Z",
+                    "gitTag": "v1.0",
+                    "gitCommitHash": "abc123",
+                }
+            )
+        ]
+
+        with patch(
+            "app.features.ingestion.api.ingest_archive",
+            return_value=IngestArchiveResult(
+                simulations=mock_simulations,
+                created_count=1,
+                duplicate_count=0,
+                errors=[],
+            ),
+        ):
+            res = client.post(f"{API_BASE}/ingestions/from-path", json=payload)
+
+        assert res.status_code == 201
+
+        simulation = db.query(Simulation).filter(Simulation.case_id == case.id).first()
+
+        assert simulation is not None
+        assert simulation.hpc_username == "nersc-user"
+
 
 class TestIngestionApiCoverage:
     def test_set_canonical_simulations_skips_non_uuid_case_id(self):
@@ -1166,6 +1221,56 @@ class TestIngestionApiCoverage:
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.detail == "Filename is required"
+
+    def test_ingest_from_upload_ignores_file_close_errors(
+        self, db: Session, normal_user_sync: dict
+    ):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        user = User(
+            id=normal_user_sync["id"],
+            email=normal_user_sync["email"],
+            is_active=True,
+            is_verified=True,
+            role=UserRole.USER,
+        )
+        raw_file = MagicMock()
+        raw_file.close.side_effect = RuntimeError("close failed")
+        upload_file = UploadFile(file=raw_file, filename="archive.zip")
+        response = MagicMock()
+
+        with (
+            patch(
+                "app.features.ingestion.api._validate_upload_file", return_value=None
+            ),
+            patch(
+                "app.features.ingestion.api._save_uploaded_file_and_hash",
+                return_value="deadbeef",
+            ),
+            patch(
+                "app.features.ingestion.api._run_ingest_archive",
+                return_value=IngestArchiveResult(
+                    simulations=[],
+                    created_count=0,
+                    duplicate_count=0,
+                    errors=[],
+                ),
+            ),
+            patch(
+                "app.features.ingestion.api._process_ingestion",
+                return_value=response,
+            ),
+        ):
+            result = ingest_from_upload(
+                file=upload_file,
+                machine_name=machine.name,
+                db=db,
+                user=user,
+            )
+
+        assert result is response
+        raw_file.close.assert_called_once_with()
 
     def test_validate_archive_path_not_file_or_dir(self, tmp_path):
         """Covers the branch where path exists but is neither file nor dir."""

--- a/backend/tests/features/ingestion/test_api.py
+++ b/backend/tests/features/ingestion/test_api.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from app.api.version import API_BASE
 from app.features.ingestion.api import (
     _run_ingest_archive,
+    _save_uploaded_file_and_hash,
     _set_canonical_simulations,
     _validate_archive_path,
     _validate_upload_file,
@@ -24,6 +25,7 @@ from app.features.ingestion.api import (
 )
 from app.features.ingestion.ingest import IngestArchiveResult
 from app.features.ingestion.models import Ingestion
+from app.features.ingestion.parsers.parser import ArchiveValidationError
 from app.features.machine.models import Machine
 from app.features.simulation.models import Case, Simulation
 from app.features.simulation.schemas import SimulationCreate
@@ -595,8 +597,8 @@ class TestIngestFromUploadEndpoint:
         assert ingestion.archive_sha256 is not None
         assert len(ingestion.archive_sha256) == 64  # SHA256 hex length
 
-    def test_upload_partial_success_status(self, client, db: Session):
-        """Test that partial success is recorded correctly."""
+    def test_upload_rejects_partial_ingestion_results(self, client, db: Session):
+        """Upload endpoint should fail instead of persisting partial ingestion results."""
         machine = db.query(Machine).first()
         assert machine is not None
 
@@ -643,22 +645,21 @@ class TestIngestFromUploadEndpoint:
                 files={"file": ("test_partial.zip", file, "application/zip")},
             )
 
-        assert res.status_code == 201
+        assert res.status_code == 400
+        assert res.json()["detail"] == {
+            "message": "Archive validation failed.",
+            "errors": mock_errors,
+        }
 
-        # Verify partial status
         ingestion = (
             db.query(Ingestion)
             .filter(Ingestion.source_reference == "test_partial.zip")
             .first()
         )
+        assert ingestion is None
 
-        assert ingestion is not None
-        assert ingestion.status == "partial"
-        assert ingestion.created_count == 1
-        assert ingestion.error_count == 1
-
-    def test_upload_failed_status(self, client, db: Session):
-        """Test that failed ingestion is recorded correctly."""
+    def test_upload_rejects_failed_ingestion_results(self, client, db: Session):
+        """Upload endpoint should fail instead of persisting failed ingestion results."""
         machine = db.query(Machine).first()
         assert machine is not None
 
@@ -682,19 +683,18 @@ class TestIngestFromUploadEndpoint:
                 files={"file": ("test_failed.zip", file, "application/zip")},
             )
 
-        assert res.status_code == 201
+        assert res.status_code == 400
+        assert res.json()["detail"] == {
+            "message": "Archive validation failed.",
+            "errors": mock_errors,
+        }
 
-        # Verify failed status
         ingestion = (
             db.query(Ingestion)
             .filter(Ingestion.source_reference == "test_failed.zip")
             .first()
         )
-
-        assert ingestion is not None
-        assert ingestion.status == "failed"
-        assert ingestion.created_count == 0
-        assert ingestion.error_count == 2
+        assert ingestion is None
 
     def test_upload_without_filename(self, client, db: Session):
         """Test that upload without filename is rejected."""
@@ -791,27 +791,46 @@ class TestIngestFromUploadEndpoint:
         assert ingestion.created_count == 0
         assert ingestion.error_count == 2
 
-    def test_upload_file_size_too_large(self, client, db: Session):
-        """Test that files exceeding size limit are rejected."""
+    def test_save_uploaded_file_rejects_large_files(self, tmp_path: Path):
+        file_content = b"x" * (51 * 1024 * 1024)  # 51MB
+        upload_file = UploadFile(file=BytesIO(file_content), filename="large_file.zip")
+
+        with pytest.raises(HTTPException) as exc_info:
+            _save_uploaded_file_and_hash(upload_file, tmp_path / "large_file.zip")
+
+        assert exc_info.value.status_code == 413
+        assert exc_info.value.detail == "File too large"
+
+    def test_upload_returns_structured_validation_errors(self, client, db: Session):
         machine = db.query(Machine).first()
         assert machine is not None
 
-        # Create a large file to test the size limit
-        file_content = b"x" * (21 * 1024 * 1024)  # 21MB
-        file = BytesIO(file_content)
+        file = BytesIO(b"PK\x03\x04")
+        validation_errors = [
+            {
+                "code": "missing_required_file",
+                "execution_dir": "/tmp/archive/1.0-0",
+                "file_spec": "env_case.xml..*.gz",
+                "location": "casedocs/",
+                "message": "Missing required 'env_case.xml..*.gz' in casedocs/ for '/tmp/archive/1.0-0'.",
+            }
+        ]
 
-        # Note: TestClient doesn't set the size attribute on UploadFile,
-        # so this test may not fully exercise the size check in production.
-        # The size check would need to be tested with real HTTP multipart uploads.
-        res = client.post(
-            f"{API_BASE}/ingestions/from-upload",
-            data={"machine_name": machine.name},
-            files={"file": ("large_file.zip", file, "application/zip")},
-        )
+        with patch(
+            "app.features.ingestion.api.ingest_archive",
+            side_effect=ArchiveValidationError(validation_errors),
+        ):
+            res = client.post(
+                f"{API_BASE}/ingestions/from-upload",
+                data={"machine_name": machine.name},
+                files={"file": ("invalid.zip", file, "application/zip")},
+            )
 
-        # Since TestClient doesn't expose file.size, this may succeed
-        # In production with real uploads, this would return 413
-        assert res.status_code in [201, 413]
+        assert res.status_code == 400
+        assert res.json()["detail"] == {
+            "message": "Archive validation failed.",
+            "errors": validation_errors,
+        }
 
     def test_upload_handles_lookup_error(self, client, db: Session):
         """Test that LookupError in upload is handled with 400 response."""
@@ -1081,6 +1100,30 @@ class TestIngestionApiCoverage:
                 _run_ingest_archive("/tmp/archive.tar.gz", "/tmp", db)
 
         assert exc_info.value.status_code == 400
+
+    def test_run_ingest_archive_handles_archive_validation_error(self, db: Session):
+        validation_errors = [
+            {
+                "code": "missing_required_file",
+                "execution_dir": "/tmp/archive/1.0-0",
+                "file_spec": "CaseStatus..*.gz",
+                "location": "archive root",
+                "message": "Missing required 'CaseStatus..*.gz' in archive root for '/tmp/archive/1.0-0'.",
+            }
+        ]
+
+        with patch(
+            "app.features.ingestion.api.ingest_archive",
+            side_effect=ArchiveValidationError(validation_errors),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                _run_ingest_archive("/tmp/archive.tar.gz", "/tmp", db)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == {
+            "message": "Archive validation failed.",
+            "errors": validation_errors,
+        }
 
     def test_ingest_from_upload_defensive_filename_none_branch(
         self, db: Session, normal_user_sync: dict

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -2213,3 +2213,39 @@ class TestIngestHelpers:
         assert draft.git_repository_url == "https://github.com/E3SM-Project/E3SM.git"
         assert draft.simulation_start_date is not None
         assert draft.run_start_date is not None
+
+    def test_build_simulation_create_draft_falls_back_without_env_run(self) -> None:
+        parsed = ParsedSimulation(
+            execution_dir="/path/to/1082006.260305-120006",
+            execution_id="1082006.260305-120006",
+            case_name="case1",
+            case_group=None,
+            machine="machine",
+            hpc_username="test-user",
+            compset="FHIST",
+            compset_alias="test_alias",
+            grid_name="grid1",
+            grid_resolution="0.9x1.25",
+            campaign="campaign",
+            experiment_type="historical",
+            initialization_type=None,
+            simulation_start_date=None,
+            simulation_end_date=None,
+            run_start_date="2020-01-02T03:04:05Z",
+            run_end_date=None,
+            compiler="gcc",
+            git_repository_url="https://github.com/E3SM-Project/E3SM.git",
+            git_branch="main",
+            git_tag="v1.0.0",
+            git_commit_hash="abc123",
+            status="completed",
+        )
+
+        draft = _build_simulation_create_draft(
+            parsed_simulation=parsed,
+            machine_id=uuid4(),
+            case_id=uuid4(),
+        )
+
+        assert draft.initialization_type == "unknown"
+        assert draft.simulation_start_date == draft.run_start_date

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -2213,39 +2213,3 @@ class TestIngestHelpers:
         assert draft.git_repository_url == "https://github.com/E3SM-Project/E3SM.git"
         assert draft.simulation_start_date is not None
         assert draft.run_start_date is not None
-
-    def test_build_simulation_create_draft_falls_back_without_env_run(self) -> None:
-        parsed = ParsedSimulation(
-            execution_dir="/path/to/1082006.260305-120006",
-            execution_id="1082006.260305-120006",
-            case_name="case1",
-            case_group=None,
-            machine="machine",
-            hpc_username="test-user",
-            compset="FHIST",
-            compset_alias="test_alias",
-            grid_name="grid1",
-            grid_resolution="0.9x1.25",
-            campaign="campaign",
-            experiment_type="historical",
-            initialization_type=None,
-            simulation_start_date=None,
-            simulation_end_date=None,
-            run_start_date="2020-01-02T03:04:05Z",
-            run_end_date=None,
-            compiler="gcc",
-            git_repository_url="https://github.com/E3SM-Project/E3SM.git",
-            git_branch="main",
-            git_tag="v1.0.0",
-            git_commit_hash="abc123",
-            status="completed",
-        )
-
-        draft = _build_simulation_create_draft(
-            parsed_simulation=parsed,
-            machine_id=uuid4(),
-            case_id=uuid4(),
-        )
-
-        assert draft.initialization_type == "unknown"
-        assert draft.simulation_start_date == draft.run_start_date

--- a/backend/tests/features/simulation/test_api.py
+++ b/backend/tests/features/simulation/test_api.py
@@ -126,6 +126,8 @@ class TestListCases:
         case_data = data[0]
         assert case_data["name"] == "test_case_nested"
         assert case_data["canonicalSimulationId"] == str(sim1.id)
+        assert case_data["machineNames"] == [machine.name]
+        assert case_data["hpcUsernames"] == []
 
         # Verify nested simulations are SimulationSummaryOut (lightweight)
         sims = case_data["simulations"]
@@ -224,6 +226,8 @@ class TestGetCase:
         data = res.json()
         assert data["name"] == "test_case_detail"
         assert len(data["simulations"]) == 1
+        assert data["machineNames"] == [machine.name]
+        assert data["hpcUsernames"] == []
         assert data["simulations"][0]["executionId"] == "case-detail-exec-1"
         assert data["simulations"][0]["isCanonical"] is True
 

--- a/backend/tests/features/simulation/test_schemas.py
+++ b/backend/tests/features/simulation/test_schemas.py
@@ -474,12 +474,16 @@ class TestCaseOutSchema:
                     simulation_end_date=None,
                 ),
             ],
+            machine_names=["chrysalis"],
+            hpc_usernames=["ac.tvo"],
             created_at=datetime(2023, 1, 1, 0, 0, 0),
             updated_at=datetime(2023, 1, 2, 0, 0, 0),
         )
         assert case_out.name == "v3.LR.historical_0121"
         assert case_out.case_group == "ensemble_v3"
         assert len(case_out.simulations) == 2
+        assert case_out.machine_names == ["chrysalis"]
+        assert case_out.hpc_usernames == ["ac.tvo"]
         assert case_out.simulations[0].is_canonical is True
         assert case_out.simulations[1].change_count == 2
 
@@ -490,8 +494,12 @@ class TestCaseOutSchema:
             case_group=None,
             canonical_simulation_id=None,
             simulations=[],
+            machine_names=[],
+            hpc_usernames=[],
             created_at=datetime(2023, 1, 1, 0, 0, 0),
             updated_at=datetime(2023, 1, 2, 0, 0, 0),
         )
         assert case_out.canonical_simulation_id is None
         assert case_out.simulations == []
+        assert case_out.machine_names == []
+        assert case_out.hpc_usernames == []

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -129,34 +129,14 @@ export const CaseDetailsPage = ({
     summary: simulation,
     details: simulationDetailsById.get(simulation.id),
   }));
-  const machineSummary = (() => {
-    const names = [
-      ...new Set(
-        simulations
-          .map(({ details }) => details?.machine?.name)
-          .filter((name): name is string => Boolean(name)),
-      ),
-    ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' }));
+  const summarizeValues = (values: string[]) => {
+    if (values.length === 0) return '—';
+    if (values.length === 1) return values[0];
 
-    if (names.length === 0) return '—';
-    if (names.length === 1) return names[0];
-
-    return `${names[0]} +${names.length - 1}`;
-  })();
-  const hpcUsernameSummary = (() => {
-    const usernames = [
-      ...new Set(
-        simulations
-          .map(({ details }) => details?.hpcUsername)
-          .filter((username): username is string => Boolean(username)),
-      ),
-    ].sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' }));
-
-    if (usernames.length === 0) return '—';
-    if (usernames.length === 1) return usernames[0];
-
-    return `${usernames[0]} +${usernames.length - 1}`;
-  })();
+    return `${values[0]} +${values.length - 1}`;
+  };
+  const machineSummary = summarizeValues(caseRecord.machineNames);
+  const hpcUsernameSummary = summarizeValues(caseRecord.hpcUsernames);
   const isCompareButtonDisabled = selectedSimulationIds.length < 2;
 
   const toggleSimulationSelection = (simulationId: string) => {

--- a/frontend/src/features/upload/UploadPage.tsx
+++ b/frontend/src/features/upload/UploadPage.tsx
@@ -1,1187 +1,328 @@
 import axios from 'axios';
 import { AlertTriangle, CheckCircle, Info } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { ChangeEvent, useMemo, useState } from 'react';
 
-import { createSimulation } from '@/features/simulations/api/api';
-import { ConfirmResetDialog } from '@/features/upload/components/ConfirmResetDialog';
-import { FormSection } from '@/features/upload/components/FormSection';
-import { LinkField } from '@/features/upload/components/LinkField';
-import { ReviewFieldList } from '@/features/upload/components/Review/ReviewFieldList';
-import { ReviewLinkList } from '@/features/upload/components/Review/ReviewLinkList';
-import { ReviewSection } from '@/features/upload/components/Review/ReviewSection';
-import type { RenderableField } from '@/features/upload/types/field';
+import {
+  ArchiveUploadValidationDetail,
+  ArchiveUploadValidationError,
+  uploadSimulationArchive,
+} from '@/features/upload/api/api';
 import { toast } from '@/hooks/use-toast';
-import { Machine, SimulationCreate, SimulationCreateForm } from '@/types';
-import { ARTIFACT_KIND_MAP, ArtifactIn } from '@/types/artifact';
-import { ExternalLinkIn } from '@/types/link';
+import type { Machine } from '@/types';
 
-// -------------------- Types & Interfaces --------------------
 interface UploadPageProps {
   machines: Machine[];
 }
 
-type OpenKey =
-  | 'configuration'
-  | 'modelSetup'
-  | 'versionControl'
-  | 'timeline'
-  | 'paths'
-  | 'docs'
-  | null;
+const MAX_ARCHIVE_SIZE_BYTES = 50 * 1024 * 1024;
+const SUPPORTED_ARCHIVE_EXTENSIONS = ['.tar.gz', '.tgz', '.zip'];
+const FILE_INPUT_ACCEPT = '.tar.gz,.tgz,.zip,application/gzip,application/zip';
 
-// -------------------- Initial Form State --------------------
-const initialState: SimulationCreateForm = {
-  // --- Configuration ---
-  caseId: '', // required (UUID of the Case)
-  executionId: '', // required
-  description: null,
-  compset: '', // required
-  compsetAlias: '', // required
-  gridName: '', // required
-  gridResolution: '', // required
-  initializationType: '',
-  compiler: null,
+const hasSupportedArchiveExtension = (filename: string): boolean => {
+  const normalized = filename.toLowerCase();
 
-  // --- Model Setup ---
-  simulationType: '', // required
-  status: 'created', // required
-  campaign: null,
-  experimentType: null,
-  machineId: '', // required
-
-  // --- Version Control ---
-  gitRepositoryUrl: null,
-  gitBranch: null,
-  gitTag: null,
-  gitCommitHash: null,
-
-  // --- Timeline ---
-  simulationStartDate: '', // required
-  simulationEndDate: null,
-  runStartDate: null,
-  runEndDate: null,
-
-  // --- Documentation ---
-  keyFeatures: null,
-  knownIssues: null,
-  notesMarkdown: null,
-
-  // --- Metadata ---
-  extra: {},
-
-  // --- Artifacts & Links ---
-  artifacts: [],
-  links: [],
-
-  // --- UI-only fields ---
-  outputPath: '',
-  archivePaths: [],
-  runScriptPaths: [],
-  postprocessingScriptPaths: [],
+  return SUPPORTED_ARCHIVE_EXTENSIONS.some((extension) => normalized.endsWith(extension));
 };
 
-// -------------------- Component --------------------
+const validateArchiveFile = (file: File | null): string | null => {
+  if (!file) {
+    return 'Select a performance archive to upload.';
+  }
+
+  if (!hasSupportedArchiveExtension(file.name)) {
+    return 'File must be a .tar.gz, .tgz, or .zip archive.';
+  }
+
+  if (file.size > MAX_ARCHIVE_SIZE_BYTES) {
+    return 'File must be 50 MB or smaller.';
+  }
+
+  return null;
+};
+
+const isArchiveUploadValidationDetail = (detail: unknown): detail is ArchiveUploadValidationDetail => {
+  if (!detail || typeof detail !== 'object') {
+    return false;
+  }
+
+  const candidate = detail as Partial<ArchiveUploadValidationDetail>;
+
+  return (
+    typeof candidate.message === 'string' &&
+    Array.isArray(candidate.errors) &&
+    candidate.errors.every(
+      (error) =>
+        error &&
+        typeof error === 'object' &&
+        typeof (error as Partial<ArchiveUploadValidationError>).message === 'string',
+    )
+  );
+};
+
 export const UploadPage = ({ machines }: UploadPageProps) => {
-  const navigate = useNavigate();
+  const [selectedMachineId, setSelectedMachineId] = useState('');
+  const [hpcUsername, setHpcUsername] = useState('');
+  const [archiveFile, setArchiveFile] = useState<File | null>(null);
+  const [archiveFileError, setArchiveFileError] = useState<string | null>(null);
+  const [validationErrors, setValidationErrors] = useState<ArchiveUploadValidationError[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+  const [fileInputKey, setFileInputKey] = useState(0);
 
-  const [form, setForm] = useState<SimulationCreateForm>(initialState);
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [diagLinks, setDiagLinks] = useState<{ label: string; url: string }[]>([]);
-  const [paceLinks, setPaceLinks] = useState<{ label: string; url: string }[]>([]);
-
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [openSection, setOpenSection] = useState<OpenKey>('configuration');
-  const [reviewOpen, setReviewOpen] = useState(false);
-
-  // -------------------- Derived Data --------------------
-  // --- Configuration fields (matches initialState order)
-  const configFields = useMemo(
-    (): RenderableField[] => [
-      {
-        label: 'Case ID',
-        name: 'caseId',
-        required: true,
-        type: 'text',
-        placeholder: 'UUID of the Case this simulation belongs to',
-      },
-      {
-        label: 'Execution ID',
-        name: 'executionId',
-        required: true,
-        type: 'text',
-        placeholder: 'e.g., 1125772.260116-181605',
-      },
-      {
-        label: 'Description',
-        name: 'description',
-        required: false,
-        type: 'textarea',
-        placeholder: 'Short description (optional)',
-      },
-      {
-        label: 'Compset',
-        name: 'compset',
-        required: true,
-        type: 'text',
-        placeholder: 'e.g., A_WCYCL1850S_CMIP6',
-      },
-      {
-        label: 'Compset Alias',
-        name: 'compsetAlias',
-        required: true,
-        type: 'text',
-        placeholder: 'e.g., WCYCL1850S',
-      },
-      {
-        label: 'Grid Name',
-        name: 'gridName',
-        required: true,
-        type: 'text',
-        placeholder: 'e.g., ne30_oECv3_ICG',
-      },
-      {
-        label: 'Grid Resolution',
-        name: 'gridResolution',
-        required: true,
-        type: 'text',
-        placeholder: 'e.g., 1deg',
-      },
-      {
-        label: 'Initialization Type',
-        name: 'initializationType',
-        required: true,
-        type: 'text',
-        placeholder: 'e.g., hybrid, branch, startup',
-      },
-      {
-        label: 'Compiler',
-        name: 'compiler',
-        required: false,
-        type: 'text',
-        placeholder: 'e.g., intel/2021.4',
-      },
-    ],
-    [],
+  const selectedMachine = useMemo(
+    () => machines.find((machine) => machine.id === selectedMachineId) ?? null,
+    [machines, selectedMachineId],
   );
 
-  // --- Model Setup fields (matches initialState order)
-  const modelFields = useMemo(
-    (): RenderableField[] => [
-      {
-        label: 'Simulation Type',
-        name: 'simulationType',
-        required: true,
-        type: 'select',
-        options: [
-          { value: 'production', label: 'Production' },
-          { value: 'test', label: 'Test' },
-          { value: 'spinup', label: 'Spinup' },
-        ],
-      },
-      {
-        label: 'Status',
-        name: 'status',
-        required: true,
-        type: 'select',
-        options: [
-          { value: 'created', label: 'Created' },
-          { value: 'queued', label: 'Queued' },
-          { value: 'running', label: 'Running' },
-          { value: 'failed', label: 'Failed' },
-          { value: 'completed', label: 'Completed' },
-        ],
-      },
-      {
-        label: 'Campaign',
-        name: 'campaign',
-        required: false,
-        type: 'text',
-        placeholder: 'e.g., v3.LR',
-      },
-      {
-        label: 'Experiment Type',
-        name: 'experimentType',
-        required: false,
-        type: 'text',
-        placeholder: 'e.g., piControl',
-      },
-      {
-        label: 'Machine',
-        name: 'machineId',
-        required: true,
-        type: 'select',
-        options: machines.map((m) => ({ value: m.id, label: m.name })),
-        renderValue: (value: string) => {
-          const machine = machines.find((m) => m.id === value);
+  const handleArchiveChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextFile = event.target.files?.[0] ?? null;
+    const nextError = validateArchiveFile(nextFile);
 
-          return machine ? machine.name : value;
-        },
-      },
-    ],
-    [machines],
-  );
-
-  // --- Version Control fields (matches initialState order)
-  const versionFields = useMemo(
-    (): RenderableField[] => [
-      {
-        label: 'Repository URL',
-        name: 'gitRepositoryUrl',
-        required: false,
-        type: 'url',
-        placeholder: 'https://github.com/org/repo',
-      },
-      {
-        label: 'Branch',
-        name: 'gitBranch',
-        required: false,
-        type: 'text',
-        placeholder: 'e.g., e3sm-v3',
-      },
-      { label: 'Tag', name: 'gitTag', required: false, type: 'text', placeholder: 'e.g., v1.0.0' },
-      {
-        label: 'Commit Hash',
-        name: 'gitCommitHash',
-        required: false,
-        type: 'text',
-        placeholder: 'e.g., a1b2c3d',
-      },
-    ],
-    [],
-  );
-
-  // --- Timeline fields (matches initialState order)
-  const timelineFields = useMemo(
-    (): RenderableField[] => [
-      {
-        label: 'Simulation Start Date',
-        name: 'simulationStartDate',
-        required: true,
-        type: 'date',
-        placeholder: '',
-      },
-      {
-        label: 'Simulation End Date',
-        name: 'simulationEndDate',
-        required: false,
-        type: 'date',
-        placeholder: '',
-      },
-      {
-        label: 'Run Start Date',
-        name: 'runStartDate',
-        required: false,
-        type: 'date',
-        placeholder: '',
-      },
-      { label: 'Run End Date', name: 'runEndDate', required: false, type: 'date', placeholder: '' },
-    ],
-    [],
-  );
-
-  // --- Documentation fields (matches initialState order)
-  const docFields = useMemo(
-    (): RenderableField[] => [
-      {
-        label: 'Key Features',
-        name: 'keyFeatures',
-        required: false,
-        type: 'textarea',
-        placeholder: 'Key features (optional)',
-      },
-      {
-        label: 'Known Issues',
-        name: 'knownIssues',
-        required: false,
-        type: 'textarea',
-        placeholder: 'Known issues (optional)',
-      },
-      {
-        label: 'Notes (Markdown)',
-        name: 'notesMarkdown',
-        required: false,
-        type: 'textarea',
-        placeholder: 'Notes (optional)',
-      },
-    ],
-    [],
-  );
-
-  // --- Metadata fields (matches initialState order)
-  const metaFields = useMemo(
-    (): RenderableField[] => [
-      {
-        label: 'Extra Metadata (JSON)',
-        name: 'extra',
-        required: false,
-        type: 'textarea',
-        placeholder: '{"foo": "bar"}',
-      },
-    ],
-    [],
-  );
-
-  // --- Data Paths & Scripts fields (matches initialState order)
-  const pathFields = useMemo(
-    (): RenderableField[] => [
-      {
-        label: 'Output Path',
-        name: 'outputPath',
-        required: true,
-        type: 'text',
-        placeholder: '/global/archive/sim-output/...',
-      },
-      {
-        label: 'Archive Paths',
-        name: 'archivePaths',
-        required: false,
-        type: 'text',
-        placeholder: '/global/archive/sim-state/..., /other/path/...',
-      },
-      {
-        label: 'Run Script Paths',
-        name: 'runScriptPaths',
-        required: false,
-        type: 'text',
-        placeholder: '/home/user/run.sh, /home/user/run2.sh',
-      },
-      {
-        label: 'Postprocessing Script Paths',
-        name: 'postprocessingScriptPaths',
-        required: false,
-        type: 'text',
-        placeholder: '/home/user/post.sh',
-      },
-    ],
-    [],
-  );
-
-  // Calculate required fields based on field definitions.
-  const requiredFields = useMemo(
-    () => ({
-      configuration: configFields.filter((field) => field.required).length,
-      modelSetup: modelFields.filter((field) => field.required).length,
-      timeline: timelineFields.filter((field) => field.required).length,
-      versionControl: versionFields.filter((field) => field.required).length,
-      paths: pathFields.filter((field) => field.required).length,
-      docs: docFields.filter((field) => field.required).length,
-      meta: metaFields.filter((field) => field.required).length,
-      review: 0,
-    }),
-    [configFields, modelFields, timelineFields, versionFields, pathFields, docFields, metaFields],
-  );
-
-  const validateField = (name: string, value: unknown) => {
-    let error: string | null = null;
-
-    // 1. Required fields
-    const ALL_FIELDS = [
-      ...configFields,
-      ...modelFields,
-      ...timelineFields,
-      ...versionFields,
-      ...pathFields,
-      ...docFields,
-      ...metaFields,
-    ];
-
-    const fieldDef = ALL_FIELDS.find((f) => f.name === name);
-
-    if (fieldDef?.required) {
-      if (
-        value === undefined ||
-        value === null ||
-        value === '' ||
-        (Array.isArray(value) && value.length === 0)
-      ) {
-        error = `${fieldDef.label} is required`;
-      }
-    }
-
-    // 2. Special-case validation by name.
-    // NOTE: These fields are empty on the initial form state but require user input.
-    if (!error) {
-      if (name === 'machineId') {
-        if (value === undefined || value === null || value === '') {
-          error = 'Machine ID is required';
-        } else {
-          const isUuid = /^[0-9a-fA-F-]{36}$/.test(String(value));
-          if (!isUuid) error = 'Machine ID must be a valid UUID';
-        }
-      }
-
-      if (name === 'simulationStartDate' && value !== undefined && value !== null && value !== '') {
-        const date = Date.parse(String(value));
-
-        if (isNaN(date)) error = 'Invalid start date';
-      }
-    }
-
-    setErrors((prev) => ({ ...prev, [name]: error ?? '' }));
+    setArchiveFile(nextFile);
+    setArchiveFileError(nextError);
+    setValidationErrors([]);
   };
 
-  // -------------------- Derived Data for Required Counts --------------------
-  // Count non-empty values
-  const isFilled = (v: unknown) => v !== null && v !== undefined && v !== '';
+  const resetFileSelection = () => {
+    setArchiveFile(null);
+    setArchiveFileError(null);
+    setFileInputKey((current) => current + 1);
+  };
 
-  // Generic satisfied count calculator for required fields
-  const getSatisfiedCount = useCallback(
-    (fields: RenderableField[]) =>
-      fields.reduce((count, f) => {
-        if (!f.required) return count;
+  const handleUpload = async () => {
+    const fileToUpload = archiveFile;
+    const nextFileError = validateArchiveFile(fileToUpload);
+    if (nextFileError || !fileToUpload) {
+      setArchiveFileError(nextFileError);
+      return;
+    }
 
-        const v = form[f.name as keyof SimulationCreateForm];
-
-        return isFilled(v) ? count + 1 : count;
-      }, 0),
-    [form],
-  );
-
-  // Memoized section counts
-  const fieldsSatisfied = useMemo(
-    () => ({
-      configuration: getSatisfiedCount(configFields),
-      modelSetup: getSatisfiedCount(modelFields),
-      timeline: getSatisfiedCount(timelineFields),
-      paths: getSatisfiedCount(pathFields),
-    }),
-    [getSatisfiedCount, configFields, modelFields, timelineFields, pathFields],
-  );
-
-  const allFieldsValid = useMemo(
-    () =>
-      fieldsSatisfied.configuration >= requiredFields.configuration &&
-      fieldsSatisfied.modelSetup >= requiredFields.modelSetup &&
-      fieldsSatisfied.timeline >= requiredFields.timeline &&
-      fieldsSatisfied.paths >= requiredFields.paths,
-    [requiredFields, fieldsSatisfied],
-  );
-
-  // -------------------- Builders --------------------
-  const buildArtifacts = (form: SimulationCreateForm): ArtifactIn[] => {
-    const artifacts: ArtifactIn[] = [];
-
-    if (form.outputPath) {
-      artifacts.push({
-        kind: ARTIFACT_KIND_MAP.outputPath,
-        uri: form.outputPath,
+    if (!selectedMachine) {
+      toast({
+        title: 'Machine required',
+        description: 'Select the machine that produced this performance archive.',
+        variant: 'destructive',
       });
+      return;
     }
 
-    form.archivePaths?.forEach((path) => {
-      artifacts.push({
-        kind: ARTIFACT_KIND_MAP.archivePaths,
-        uri: path,
-      });
-    });
-
-    form.runScriptPaths?.forEach((path) => {
-      artifacts.push({
-        kind: ARTIFACT_KIND_MAP.runScriptPaths,
-        uri: path,
-      });
-    });
-
-    form.postprocessingScriptPaths?.forEach((path) => {
-      artifacts.push({
-        kind: ARTIFACT_KIND_MAP.postprocessingScriptPaths,
-        uri: path,
-      });
-    });
-
-    return artifacts;
-  };
-
-  const buildLinks = (
-    diagLinks: { label: string; url: string }[],
-    paceLinks: { label: string; url: string }[],
-  ): ExternalLinkIn[] => {
-    const links: ExternalLinkIn[] = [];
-    diagLinks.forEach((l) => {
-      if (l.label?.trim() && l.url?.trim()) {
-        links.push({ kind: 'diagnostic', url: l.url, label: l.label || null });
-      }
-    });
-    paceLinks.forEach((l) => {
-      if (l.label?.trim() && l.url?.trim()) {
-        links.push({ kind: 'performance', url: l.url, label: l.label || null });
-      }
-    });
-
-    return links;
-  };
-
-  // -------------------- Handlers --------------------
-
-  const ARRAY_FIELDS = new Set(['archivePaths', 'runScriptPaths', 'postprocessingScriptPaths']);
-  const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
-
-    if (!ARRAY_FIELDS.has(name)) return;
-
-    setForm((prev) => ({
-      ...prev,
-      [name]: value
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean),
-    }));
-  };
-
-  const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-  ) => {
-    const { name, value } = e.target;
-
-    let normalizedValue: unknown = value;
-
-    // Dates → empty string becomes null
-    if (name === 'simulationEndDate' || name === 'runStartDate' || name === 'runEndDate') {
-      normalizedValue = value || null;
-    }
-
-    // JSON field
-    else if (name === 'extra') {
-      try {
-        normalizedValue = value ? JSON.parse(value) : {};
-
-        setErrors((prev) => ({ ...prev, [name]: '' }));
-      } catch {
-        normalizedValue = {};
-
-        setErrors((prev) => ({
-          ...prev,
-          [name]: 'Invalid JSON format',
-        }));
-      }
-    }
-
-    setForm((prev) => ({
-      ...prev,
-      [name]: normalizedValue,
-    }));
-
-    if (name !== 'extra') {
-      validateField(name, normalizedValue);
-    }
-  };
-
-  const toggle = (k: OpenKey) => setOpenSection((prev) => (prev === k ? null : k));
-
-  const addDiag = () => setDiagLinks([...diagLinks, { label: '', url: '' }]);
-  const setDiag = (i: number, field: 'label' | 'url', v: string) => {
-    const next = diagLinks.slice();
-    next[i][field] = v;
-    setDiagLinks(next);
-  };
-
-  const addPace = () => setPaceLinks([...paceLinks, { label: '', url: '' }]);
-  const setPace = (i: number, field: 'label' | 'url', v: string) => {
-    const next = paceLinks.slice();
-    next[i][field] = v;
-    setPaceLinks(next);
-  };
-
-  // -------------------- Handlers --------------------
-  const handleSubmit = async () => {
-    setIsSubmitting(true);
-
-    const artifacts = buildArtifacts(form);
-    const links = buildLinks(diagLinks, paceLinks);
-    const normalizedForm = normalizeOptionalFields(form);
-
-    const payload: SimulationCreate = {
-      ...normalizedForm,
-      artifacts,
-      links,
-    };
+    setIsUploading(true);
+    setValidationErrors([]);
 
     try {
-      const simulation = await createSimulation(payload);
+      const response = await uploadSimulationArchive({
+        file: fileToUpload,
+        machineName: selectedMachine.name,
+        hpcUsername: hpcUsername.trim() || undefined,
+      });
+
+      resetFileSelection();
 
       toast({
-        title: 'Simulation Created',
-        description: (
-          <div className="flex items-center gap-2">
-            <CheckCircle className="h-5 w-5 text-green-600" />
-            Your simulation has been successfully created.
-          </div>
-        ),
-      });
-
-      navigate(`/simulations/${simulation.id}`, {
-        state: { justCreated: true },
+        title: 'Archive ingested',
+        description:
+          response.created_count > 0
+            ? `${response.created_count} simulation(s) created and ${response.duplicate_count} duplicate(s) skipped.`
+            : `No new simulations were created. ${response.duplicate_count} duplicate(s) were skipped.`,
       });
     } catch (error) {
-      console.error('Failed to create simulation:', error);
-
       if (axios.isAxiosError(error)) {
-        const status = error.response?.status;
-        const data = error.response?.data;
+        const detail = error.response?.data?.detail;
 
-        // TODO: Handle errors more gracefully by having the form detect them first.
-        if (status === 422 && Array.isArray(data?.detail)) {
+        if (isArchiveUploadValidationDetail(detail)) {
+          setValidationErrors(detail.errors);
           toast({
-            title: 'Invalid form data',
-            description: 'Some fields are missing or invalid. Please review the form and try again',
+            title: 'Archive validation failed',
+            description: detail.message,
             variant: 'destructive',
           });
-
           return;
         }
 
-        if (status === 400) {
+        if (typeof detail === 'string') {
           toast({
-            title: 'Cannot create simulation',
-            description:
-              typeof data?.detail === 'string'
-                ? data.detail
-                : 'The simulation request is valid but cannot be accepted.',
+            title: 'Upload failed',
+            description: detail,
             variant: 'destructive',
           });
-
-          return;
-        }
-
-        if (status === 409) {
-          toast({
-            title: 'Simulation already exists',
-            description:
-              typeof data?.detail === 'string'
-                ? data.detail
-                : 'A simulation with the same execution ID already exists.',
-            variant: 'destructive',
-          });
-
           return;
         }
       }
 
       toast({
         title: 'Upload failed',
-        description: 'We could not create the simulation. Please review the form and try again.',
+        description: 'We could not ingest the archive. Please review the archive and try again.',
         variant: 'destructive',
       });
     } finally {
-      setIsSubmitting(false);
+      setIsUploading(false);
     }
   };
-
-  const normalizeOptionalFields = (form: SimulationCreateForm): SimulationCreateForm => {
-    return {
-      ...form,
-
-      // nullable strings / IDs
-      description: form.description?.trim() || null,
-      compiler: form.compiler?.trim() || null,
-      campaign: form.campaign || null,
-      experimentType: form.experimentType || null,
-      gitRepositoryUrl: form.gitRepositoryUrl?.trim() || null,
-      gitBranch: form.gitBranch?.trim() || null,
-      gitTag: form.gitTag?.trim() || null,
-      gitCommitHash: form.gitCommitHash?.trim() || null,
-      simulationEndDate: form.simulationEndDate || null,
-      runStartDate: form.runStartDate || null,
-      runEndDate: form.runEndDate || null,
-      keyFeatures: form.keyFeatures?.trim() || null,
-      knownIssues: form.knownIssues?.trim() || null,
-      notesMarkdown: form.notesMarkdown?.trim() || null,
-
-      // arrays
-      archivePaths: form.archivePaths ?? [],
-      runScriptPaths: form.runScriptPaths ?? [],
-      postprocessingScriptPaths: form.postprocessingScriptPaths ?? [],
-
-      // object
-      extra: form.extra ?? {},
-    };
-  };
-
-  // -------------------- Development Checks --------------------
-  useEffect(() => {
-    if (!import.meta.env.DEV) return;
-
-    const ignore = new Set(['artifacts', 'links']);
-
-    const uiFieldSet = new Set(
-      [
-        ...configFields,
-        ...modelFields,
-        ...versionFields,
-        ...timelineFields,
-        ...docFields,
-        ...metaFields,
-        ...pathFields,
-      ].map((f) => f.name),
-    );
-
-    const stateKeys = Object.keys(initialState).filter(
-      (k) => !ignore.has(k),
-    ) as (keyof SimulationCreateForm)[];
-
-    const missingInUI = stateKeys.filter((k) => !uiFieldSet.has(k));
-    const missingInState = [...uiFieldSet].filter((k) => !stateKeys.includes(k));
-
-    if (missingInUI.length || missingInState.length) {
-      console.group('⚠️ Field mismatch detected');
-
-      if (missingInUI.length) console.warn('State fields missing UI:', missingInUI);
-      if (missingInState.length) console.warn('UI fields missing state:', missingInState);
-
-      console.groupEnd();
-    }
-  }, [configFields, modelFields, versionFields, timelineFields, docFields, metaFields, pathFields]);
-
-  // -------------------- Render --------------------
-  const renderErrorList = (
-    errors: Record<string, string>,
-    fields: { name: string; label: string }[],
-  ): React.ReactNode => {
-    return Object.entries(errors)
-      .filter(([, msg]) => !!msg)
-      .map(([field, msg]) => {
-        const fieldDef = fields.find((f) => f.name === field);
-        const label = fieldDef ? fieldDef.label : field;
-
-        return (
-          <li key={field}>
-            <span className="font-semibold">{label}:</span> {String(msg)}
-          </li>
-        );
-      });
-  };
-
-  const completed =
-    fieldsSatisfied.configuration +
-    fieldsSatisfied.modelSetup +
-    fieldsSatisfied.timeline +
-    fieldsSatisfied.paths;
-
-  const required =
-    requiredFields.configuration +
-    requiredFields.modelSetup +
-    requiredFields.timeline +
-    requiredFields.paths;
 
   return (
     <div className="w-full min-h-[calc(100vh-64px)] bg-gray-50">
-      <div className="max-w-6xl mx-auto px-4 md:px-6 py-8">
+      <div className="max-w-4xl mx-auto px-4 md:px-6 py-8">
         <header className="mb-6">
-          <h1 className="text-2xl font-bold">Upload a New Simulation</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Provide configuration and context. You can save a draft at any time.
+          <h1 className="text-2xl font-bold">Upload an E3SM Performance Archive</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Submit a packaged performance archive instead of entering simulation metadata manually.
           </p>
-          <div className="mt-3 flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
-            <Info className="h-4 w-4 mt-0.5 shrink-0" />
-            <p>
-              Archive uploads require <code className="font-mono text-xs bg-blue-100 px-1 rounded">env_case.xml</code> for
-              case metadata extraction (e.g. <code className="font-mono text-xs bg-blue-100 px-1 rounded">CASE_GROUP</code>).
-              Simulations missing required metadata files will be skipped during ingestion.
-            </p>
-          </div>
         </header>
 
-        <FormSection
-          title="Configuration"
-          isOpen={openSection === 'configuration'}
-          onToggle={() => toggle('configuration')}
-          requiredCount={requiredFields.configuration}
-          satisfiedCount={fieldsSatisfied.configuration}
-        >
-          {configFields.map((field) => (
-            <div key={field.name}>
+        <div className="space-y-6">
+          <section className="rounded-xl border bg-white p-6 shadow-sm">
+            <div className="flex items-start gap-3 rounded-md border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
+              <Info className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="space-y-2">
+                <p>
+                  Supported archive types: <code className="rounded bg-blue-100 px-1 py-0.5 text-xs">.tar.gz</code>,{' '}
+                  <code className="rounded bg-blue-100 px-1 py-0.5 text-xs">.tgz</code>, and{' '}
+                  <code className="rounded bg-blue-100 px-1 py-0.5 text-xs">.zip</code>.
+                </p>
+                <p>
+                  Maximum upload size: <span className="font-medium">50 MB</span>. The backend validates archive layout
+                  against the required E3SM performance-file specs before ingestion.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-6 grid gap-5 md:grid-cols-2">
+              <div>
+                <label className="text-sm font-medium">
+                  Machine <span className="text-red-500">*</span>
+                </label>
+                <select
+                  className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3"
+                  value={selectedMachineId}
+                  onChange={(event) => setSelectedMachineId(event.target.value)}
+                >
+                  <option value="">Select a machine...</option>
+                  {machines.map((machine) => (
+                    <option key={machine.id} value={machine.id}>
+                      {machine.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium">HPC Username</label>
+                <input
+                  className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3"
+                  value={hpcUsername}
+                  onChange={(event) => setHpcUsername(event.target.value)}
+                  placeholder="Optional provenance username"
+                  type="text"
+                />
+              </div>
+            </div>
+
+            <div className="mt-5">
               <label className="text-sm font-medium">
-                {field.label}
-                {field.required && <span className="text-red-500">*</span>}
+                Performance Archive <span className="text-red-500">*</span>
               </label>
+              <input
+                key={fileInputKey}
+                accept={FILE_INPUT_ACCEPT}
+                className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm file:mr-4 file:rounded-md file:border-0 file:bg-gray-900 file:px-4 file:py-2 file:text-sm file:font-medium file:text-white"
+                onChange={handleArchiveChange}
+                type="file"
+              />
 
-              {field.type === 'textarea' ? (
-                <textarea
-                  className={`mt-1 w-full rounded-md border px-3 py-2 ${
-                    errors[field.name] ? 'border-red-500' : 'border-gray-300'
-                  }`}
-                  name={field.name}
-                  value={(form[field.name] as string | null) ?? ''}
-                  onChange={handleChange}
-                  placeholder={field.placeholder}
-                  rows={field.name === 'description' ? 2 : 4}
-                />
-              ) : (
-                <input
-                  className={`mt-1 w-full rounded-md border px-3 h-10 ${
-                    errors[field.name] ? 'border-red-500' : 'border-gray-300'
-                  }`}
-                  name={field.name}
-                  value={(form[field.name] as string | null) ?? ''}
-                  onChange={handleChange}
-                  placeholder={field.placeholder}
-                />
-              )}
+              <p className="mt-2 text-xs text-gray-500">
+                Required root files: <code>e3sm_timing..*..*</code>, <code>CaseStatus..*.gz</code>,{' '}
+                <code>GIT_DESCRIBE..*.gz</code>. Required <code>casedocs/</code> files: <code>README.case..*.gz</code>,{' '}
+                <code>env_case.xml..*.gz</code>, <code>env_build.xml..*.gz</code>, and <code>env_run.xml..*</code>.
+              </p>
 
-              {/* 🔥 Inline validation message */}
-              {errors[field.name] && (
-                <p className="text-red-500 text-xs mt-1">{errors[field.name]}</p>
-              )}
-            </div>
-          ))}
-        </FormSection>
-
-        <FormSection
-          title="Timeline"
-          isOpen={openSection === 'timeline'}
-          onToggle={() => toggle('timeline')}
-          requiredCount={requiredFields.timeline}
-          satisfiedCount={fieldsSatisfied.timeline}
-        >
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-            {timelineFields.map((field) => (
-              <div key={field.name}>
-                <label className="text-sm font-medium">
-                  {field.label}
-                  {field.required && <span className="text-red-500">*</span>}
-                </label>
-
-                <input
-                  className={`mt-1 w-full h-10 rounded-md border px-3 ${
-                    errors[field.name] ? 'border-red-500' : 'border-gray-300'
-                  }`}
-                  type={field.type}
-                  name={field.name}
-                  value={(form[field.name] as string | null) ?? ''}
-                  onChange={handleChange}
-                  placeholder={field.placeholder}
-                />
-
-                {errors[field.name] && (
-                  <p className="text-red-500 text-xs mt-1">{errors[field.name]}</p>
-                )}
-              </div>
-            ))}
-          </div>
-        </FormSection>
-        <FormSection
-          title="Model Setup"
-          isOpen={openSection === 'modelSetup'}
-          onToggle={() => toggle('modelSetup')}
-          requiredCount={requiredFields.modelSetup}
-          satisfiedCount={fieldsSatisfied.modelSetup}
-        >
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-            {modelFields.map((field) => (
-              <div key={field.name}>
-                <label className="text-sm font-medium">
-                  {field.label}
-                  {field.required && <span className="text-red-500">*</span>}
-                </label>
-
-                {field.type === 'select' ? (
-                  <select
-                    className={`mt-1 w-full h-10 rounded-md border px-3 ${
-                      errors[field.name] ? 'border-red-500' : 'border-gray-300'
-                    }`}
-                    name={field.name}
-                    value={(form[field.name] as string | null) ?? ''}
-                    onChange={handleChange}
-                  >
-                    <option value="">Select...</option>
-                    {field.options?.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <input
-                    className={`mt-1 w-full h-10 rounded-md border px-3 ${
-                      errors[field.name] ? 'border-red-500' : 'border-gray-300'
-                    }`}
-                    name={field.name}
-                    value={(form[field.name] as string | null) ?? ''}
-                    onChange={handleChange}
-                    placeholder={field.placeholder}
-                  />
-                )}
-
-                {errors[field.name] && (
-                  <p className="text-red-500 text-xs mt-1">{errors[field.name]}</p>
-                )}
-              </div>
-            ))}
-          </div>
-        </FormSection>
-        <FormSection
-          title="Version Control"
-          isOpen={openSection === 'versionControl'}
-          onToggle={() => toggle('versionControl')}
-          requiredCount={requiredFields.versionControl}
-          satisfiedCount={getSatisfiedCount(versionFields)}
-        >
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-            {versionFields.map((field) => (
-              <div key={field.name}>
-                <label className="text-sm font-medium">{field.label}</label>
-
-                <input
-                  className={`mt-1 w-full h-10 rounded-md border px-3 ${
-                    errors[field.name] ? 'border-red-500' : 'border-gray-300'
-                  }`}
-                  name={field.name}
-                  value={(form[field.name] as string | null) ?? ''}
-                  onChange={handleChange}
-                  placeholder={field.placeholder}
-                />
-
-                {errors[field.name] && (
-                  <p className="text-red-500 text-xs mt-1">{errors[field.name]}</p>
-                )}
-              </div>
-            ))}
-          </div>
-        </FormSection>
-
-        <FormSection
-          title="Data Paths & Scripts"
-          isOpen={openSection === 'paths'}
-          onToggle={() => toggle('paths')}
-          requiredCount={requiredFields.paths}
-          satisfiedCount={fieldsSatisfied.paths}
-        >
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-            {pathFields.map((field) => {
-              const rawValue = form[field.name] as string | string[] | null | undefined;
-
-              return (
-                <div key={field.name}>
-                  <label className="text-sm font-medium">
-                    {field.label}
-                    {field.required && <span className="text-red-500">*</span>}
-                  </label>
-
-                  <input
-                    className={`mt-1 w-full h-10 rounded-md border px-3 ${
-                      errors[field.name] ? 'border-red-500' : 'border-gray-300'
-                    }`}
-                    name={field.name}
-                    value={Array.isArray(rawValue) ? rawValue.join(', ') : (rawValue ?? '')}
-                    onChange={handleChange}
-                    onBlur={handleBlur}
-                    placeholder={field.placeholder}
-                  />
-
-                  {field.name === 'outputPath' ? (
-                    <p className="text-xs text-gray-500 mt-1">
-                      Enter a single path (for example: <code>/path</code>)
-                    </p>
-                  ) : (
-                    <p className="text-xs text-gray-500 mt-1">
-                      Enter a comma-separated list of paths (for example: <code>/path1,/path2</code>{' '}
-                      or <code>/path1, /path2</code>).
-                    </p>
-                  )}
-
-                  {errors[field.name] && (
-                    <p className="text-red-500 text-xs mt-1">{errors[field.name]}</p>
-                  )}
+              {archiveFile ? (
+                <div className="mt-3 flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-800">
+                  <CheckCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    Selected <span className="font-medium">{archiveFile.name}</span> ({(archiveFile.size / (1024 * 1024)).toFixed(2)} MB)
+                  </span>
                 </div>
-              );
-            })}
+              ) : null}
 
-            <LinkField
-              title="Diagnostic Links"
-              links={diagLinks}
-              onAdd={addDiag}
-              onChange={setDiag}
-            />
+              {archiveFileError ? <p className="mt-2 text-sm text-red-600">{archiveFileError}</p> : null}
+            </div>
 
-            <LinkField title="PACE Links" links={paceLinks} onAdd={addPace} onChange={setPace} />
-          </div>
-        </FormSection>
-
-        {/* Documentation & Notes Section */}
-        <FormSection
-          title="Documentation & Notes"
-          isOpen={openSection === 'docs'}
-          onToggle={() => toggle('docs')}
-        >
-          <div className="space-y-6">
-            {/* Documentation Fields */}
-            {docFields.map((field) => (
-              <div key={field.name}>
-                <label className="text-sm font-medium">
-                  {field.label}
-                  {!field.required && (
-                    <span className="text-xs text-muted-foreground ml-1">(optional)</span>
-                  )}
-                </label>
-                <textarea
-                  className="mt-1 w-full rounded-md border px-3 py-2"
-                  name={field.name}
-                  value={(form[field.name] as string | null) ?? ''}
-                  onChange={handleChange}
-                  placeholder={field.placeholder}
-                  rows={field.name === 'notesMarkdown' ? 4 : 2}
-                />
-              </div>
-            ))}
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-              {metaFields.map((field) => {
-                const rawValue = form[field.name] as string | null | undefined;
-
-                return (
-                  <div key={field.name}>
-                    <label className="text-sm font-medium">{field.label}</label>
-
-                    <textarea
-                      className={`mt-1 w-full rounded-md border px-3 py-2 ${
-                        errors[field.name] ? 'border-red-500' : 'border-gray-300'
-                      }`}
-                      name={field.name}
-                      value={
-                        field.name === 'extra'
-                          ? JSON.stringify(form.extra ?? {}, null, 2)
-                          : (rawValue ?? '')
-                      }
-                      onChange={handleChange}
-                      placeholder={field.placeholder}
-                      rows={4}
-                    />
-
-                    {errors[field.name] && (
-                      <p className="text-red-500 text-xs mt-1">{errors[field.name]}</p>
-                    )}
+            {validationErrors.length > 0 ? (
+              <div className="mt-5 rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <div>
+                    <p className="font-medium">Archive validation failed.</p>
+                    <ul className="mt-2 list-disc space-y-1 pl-5">
+                      {validationErrors.map((error) => (
+                        <li key={`${error.execution_dir}-${error.file_spec}-${error.location}`}>{error.message}</li>
+                      ))}
+                    </ul>
                   </div>
-                );
-              })}
-            </div>
-          </div>
-        </FormSection>
-
-        <FormSection
-          title="Review & Submit"
-          isOpen={reviewOpen}
-          onToggle={() => setReviewOpen((v) => !v)}
-        >
-          <div
-            className="mb-4 max-h-[60vh] md:max-h-[600px] overflow-y-auto pr-2"
-            style={{ scrollbarGutter: 'stable' }}
-            tabIndex={0}
-          >
-            <div className="sticky top-0 z-10 mb-3">
-              <div className="flex items-center gap-2 p-3 bg-blue-50 border border-blue-200 rounded">
-                <svg
-                  className="w-5 h-5 text-blue-500 flex-shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                  viewBox="0 0 24 24"
-                >
-                  <circle cx="12" cy="12" r="10" fill="white" />
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4m0 4h.01" />
-                </svg>
-
-                <span className="text-sm text-slate-700">
-                  <span className="font-medium">Review your entries below.</span> Required fields
-                  are marked with <span className="text-red-500">*</span> and must be filled before
-                  submitting.
-                </span>
-
-                <span
-                  className={`ml-auto inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold ${
-                    allFieldsValid ? 'bg-green-100 text-green-700' : 'bg-yellow-100 text-yellow-700'
-                  }`}
-                >
-                  {allFieldsValid ? (
-                    <CheckCircle className="h-3.5 w-3.5" />
-                  ) : (
-                    <AlertTriangle className="h-3.5 w-3.5" />
-                  )}
-                  {completed} / {required} required
-                </span>
+                </div>
               </div>
-            </div>
+            ) : null}
 
-            {Object.values(errors).some(Boolean) && (
-              <div className="mt-2 text-red-600 text-sm">
-                Please fix the errors above before submitting.
-                <ul className="list-disc ml-6 mt-1">
-                  {renderErrorList(errors, [
-                    ...configFields,
-                    ...modelFields,
-                    ...versionFields,
-                    ...timelineFields,
-                    ...docFields,
-                    ...metaFields,
-                    ...pathFields,
-                  ])}
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700"
+                onClick={resetFileSelection}
+                type="button"
+              >
+                Clear file
+              </button>
+              <button
+                className="rounded-md bg-gray-900 px-5 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isUploading}
+                onClick={handleUpload}
+                type="button"
+              >
+                {isUploading ? 'Uploading archive...' : 'Upload archive'}
+              </button>
+            </div>
+          </section>
+
+          <section className="rounded-xl border bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold">Archive Layout</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              The uploader is intended for packaged E3SM performance archives from systems such as Chrysalis and NERSC.
+              Files must live either at the archive root or under <code>casedocs/</code> in the expected locations.
+            </p>
+
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <div>
+                <h3 className="text-sm font-medium">Required root files</h3>
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-gray-700">
+                  <li>
+                    <code>e3sm_timing..*..*</code>
+                  </li>
+                  <li>
+                    <code>CaseStatus..*.gz</code>
+                  </li>
+                  <li>
+                    <code>GIT_DESCRIBE..*.gz</code>
+                  </li>
                 </ul>
               </div>
-            )}
-            <div className="space-y-4">
-              <ReviewSection title="Configuration">
-                <ReviewFieldList form={form} fields={configFields} />
-              </ReviewSection>
 
-              <ReviewSection title="Model Setup">
-                <ReviewFieldList form={form} fields={modelFields} />
-              </ReviewSection>
-
-              <ReviewSection title="Version Control">
-                <ReviewFieldList form={form} fields={versionFields} />
-              </ReviewSection>
-
-              <ReviewSection title="Timeline">
-                <ReviewFieldList form={form} fields={timelineFields} />
-              </ReviewSection>
-
-              <ReviewSection title="Data Paths & Scripts">
-                <ReviewFieldList form={form} fields={pathFields} />
-              </ReviewSection>
-              <ReviewSection title="Diagnostic Links">
-                <ReviewLinkList links={diagLinks} />
-              </ReviewSection>
-              <ReviewSection title="PACE Links">
-                <ReviewLinkList links={paceLinks} />
-              </ReviewSection>
-              <ReviewSection title="Documentation & Notes">
-                <ReviewFieldList form={form} fields={[...docFields, ...metaFields]} />
-              </ReviewSection>
-            </div>
-          </div>
-        </FormSection>
-
-        <div className="sticky bottom-0 inset-x-0 border-t bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60">
-          <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between gap-3">
-            <p className="text-sm text-muted-foreground">
-              Tip: You can collapse completed sections to stay focused.
-            </p>
-            <div className="flex gap-2">
-              <div className="mt-4 flex gap-2">
-                <ConfirmResetDialog
-                  onConfirm={() => {
-                    setForm(initialState);
-                    setDiagLinks([]);
-                    setPaceLinks([]);
-                    setErrors({});
-                  }}
-                />
-
-                <button
-                  type="button"
-                  className="bg-gray-900 text-white px-5 py-2 rounded-md disabled:opacity-50"
-                  disabled={
-                    Object.values(errors).filter((msg) => msg !== '').length > 0 ||
-                    !allFieldsValid ||
-                    isSubmitting
-                  }
-                  onClick={handleSubmit}
-                >
-                  Submit simulation
-                </button>
+              <div>
+                <h3 className="text-sm font-medium">Required casedocs files</h3>
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-gray-700">
+                  <li>
+                    <code>README.case..*.gz</code>
+                  </li>
+                  <li>
+                    <code>env_case.xml..*.gz</code>
+                  </li>
+                  <li>
+                    <code>env_build.xml..*.gz</code>
+                  </li>
+                  <li>
+                    <code>env_run.xml..*</code>
+                  </li>
+                </ul>
               </div>
             </div>
-          </div>
+          </section>
         </div>
       </div>
     </div>

--- a/frontend/src/features/upload/UploadPage.tsx
+++ b/frontend/src/features/upload/UploadPage.tsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { AlertTriangle, CheckCircle, Info } from 'lucide-react';
-import { ChangeEvent, useMemo, useState } from 'react';
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import {
@@ -25,6 +25,8 @@ interface UploadStatus {
 const MAX_ARCHIVE_SIZE_BYTES = 50 * 1024 * 1024;
 const SUPPORTED_ARCHIVE_EXTENSIONS = ['.tar.gz', '.tgz', '.zip'];
 const FILE_INPUT_ACCEPT = '.tar.gz,.tgz,.zip,application/gzip,application/zip';
+const EXECUTION_ID_PATTERN = /^\d+\.\d+-\d+$/;
+const ARCHIVE_LEVEL_VALIDATION_LABEL = 'Archive-level validation';
 
 const hasSupportedArchiveExtension = (filename: string): boolean => {
   const normalized = filename.toLowerCase();
@@ -48,7 +50,83 @@ const validateArchiveFile = (file: File | null): string | null => {
   return null;
 };
 
-const isArchiveUploadValidationDetail = (detail: unknown): detail is ArchiveUploadValidationDetail => {
+const stripArchiveExtension = (filename: string): string => {
+  const normalized = filename.toLowerCase();
+  const matchingExtension = SUPPORTED_ARCHIVE_EXTENSIONS.find((extension) =>
+    normalized.endsWith(extension),
+  );
+
+  return matchingExtension ? filename.slice(0, -matchingExtension.length) : filename;
+};
+
+const formatExecutionDirLabel = (executionDir: string, archiveFilename?: string | null): string => {
+  if (!executionDir) {
+    return ARCHIVE_LEVEL_VALIDATION_LABEL;
+  }
+
+  const segments = executionDir.replace(/\\/g, '/').replace(/\/+$/, '').split('/').filter(Boolean);
+
+  if (segments.length === 0) {
+    return ARCHIVE_LEVEL_VALIDATION_LABEL;
+  }
+
+  const archiveRootName = archiveFilename ? stripArchiveExtension(archiveFilename) : null;
+  const archiveRootIndex = archiveRootName ? segments.lastIndexOf(archiveRootName) : -1;
+
+  if (archiveRootIndex >= 0) {
+    return segments.slice(archiveRootIndex).join('/');
+  }
+
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    if (!EXECUTION_ID_PATTERN.test(segments[index])) {
+      continue;
+    }
+
+    const previousSegment = segments[index - 1];
+
+    if (previousSegment && !previousSegment.toLowerCase().startsWith('tmp')) {
+      return `${previousSegment}/${segments[index]}`;
+    }
+
+    return segments[index];
+  }
+
+  return segments.length > 1 ? segments.slice(-2).join('/') : segments[0];
+};
+
+const formatValidationLocation = (location: string): string => {
+  if (location === 'archive root') {
+    return 'Execution root';
+  }
+
+  if (location === 'casedocs/') {
+    return 'casedocs/';
+  }
+
+  return location;
+};
+
+const formatValidationIssueTitle = (error: ArchiveUploadValidationError): string => {
+  switch (error.code) {
+    case 'missing_required_file':
+      return `Missing required file: ${error.file_spec}`;
+    case 'multiple_matching_files':
+      return `Multiple files matched: ${error.file_spec}`;
+    case 'missing_required_value':
+      return `Missing required value in: ${error.file_spec}`;
+    case 'file_not_found':
+      return 'Referenced metadata file was not found';
+    default:
+      return error.file_spec ? `Validation error: ${error.file_spec}` : 'Validation error';
+  }
+};
+
+const shouldShowValidationMessage = (error: ArchiveUploadValidationError): boolean =>
+  error.code === 'missing_required_value' || error.code === 'file_not_found';
+
+const isArchiveUploadValidationDetail = (
+  detail: unknown,
+): detail is ArchiveUploadValidationDetail => {
   if (!detail || typeof detail !== 'object') {
     return false;
   }
@@ -73,10 +151,13 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
   const [archiveFile, setArchiveFile] = useState<File | null>(null);
   const [archiveFileError, setArchiveFileError] = useState<string | null>(null);
   const [uploadStatus, setUploadStatus] = useState<UploadStatus | null>(null);
-  const [createdSimulations, setCreatedSimulations] = useState<IngestionUploadSimulationSummary[]>([]);
+  const [createdSimulations, setCreatedSimulations] = useState<IngestionUploadSimulationSummary[]>(
+    [],
+  );
   const [validationErrors, setValidationErrors] = useState<ArchiveUploadValidationError[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   const [fileInputKey, setFileInputKey] = useState(0);
+  const validationPanelRef = useRef<HTMLDivElement | null>(null);
 
   const selectedMachine = useMemo(
     () => machines.find((machine) => machine.id === selectedMachineId) ?? null,
@@ -101,6 +182,38 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
       name: firstSimulation.case_name,
     };
   }, [createdSimulations]);
+  const validationErrorGroups = useMemo(() => {
+    const groups = new Map<string, ArchiveUploadValidationError[]>();
+
+    for (const error of validationErrors) {
+      const executionDir = error.execution_dir || 'Archive-level validation';
+      const group = groups.get(executionDir);
+
+      if (group) {
+        group.push(error);
+        continue;
+      }
+
+      groups.set(executionDir, [error]);
+    }
+
+    return Array.from(groups, ([executionDir, errors]) => ({
+      executionDir,
+      displayExecutionDir: formatExecutionDirLabel(executionDir, archiveFile?.name),
+      errors,
+    }));
+  }, [archiveFile?.name, validationErrors]);
+  const validationExecutionCount = validationErrorGroups.length;
+  const validationIssueCount = validationErrors.length;
+
+  useEffect(() => {
+    if (validationErrors.length === 0) {
+      return;
+    }
+
+    validationPanelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    validationPanelRef.current?.focus({ preventScroll: true });
+  }, [validationErrors.length]);
 
   const handleArchiveChange = (event: ChangeEvent<HTMLInputElement>) => {
     const nextFile = event.target.files?.[0] ?? null;
@@ -141,7 +254,8 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
     setUploadStatus({
       tone: 'info',
       title: 'Uploading and validating archive',
-      description: 'The archive is being uploaded, extracted, and checked against the required file specs.',
+      description:
+        'The archive is being uploaded, extracted, and checked against the required file specs.',
     });
     setCreatedSimulations([]);
     setValidationErrors([]);
@@ -171,11 +285,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
         if (isArchiveUploadValidationDetail(detail)) {
           setCreatedSimulations([]);
           setValidationErrors(detail.errors);
-          setUploadStatus({
-            tone: 'error',
-            title: 'Archive validation failed',
-            description: detail.message,
-          });
+          setUploadStatus(null);
           return;
         }
 
@@ -212,8 +322,12 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
         <header className="mb-6">
           <h1 className="text-2xl font-bold">Upload a Case or Run</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Upload either a full E3SM performance case archive or a single execution directory packaged as
-            <code className="ml-1 rounded bg-gray-100 px-1 py-0.5 text-xs">&lt;execution_id&gt;/...</code>.
+            Upload either a full E3SM performance case archive or a single execution directory
+            packaged as
+            <code className="ml-1 rounded bg-gray-100 px-1 py-0.5 text-xs">
+              &lt;execution_id&gt;/...
+            </code>
+            .
           </p>
         </header>
 
@@ -223,17 +337,27 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
               <Info className="mt-0.5 h-4 w-4 shrink-0" />
               <div className="space-y-2">
                 <p>
-                  Supported archive types: <code className="rounded bg-blue-100 px-1 py-0.5 text-xs">.tar.gz</code>,{' '}
+                  Supported archive types:{' '}
+                  <code className="rounded bg-blue-100 px-1 py-0.5 text-xs">.tar.gz</code>,{' '}
                   <code className="rounded bg-blue-100 px-1 py-0.5 text-xs">.tgz</code>, and{' '}
                   <code className="rounded bg-blue-100 px-1 py-0.5 text-xs">.zip</code>.
                 </p>
                 <p>
-                  Maximum upload size: <span className="font-medium">50 MB</span>. The backend validates archive layout
-                  against the required E3SM performance-file specs before ingestion.
+                  Maximum upload size: <span className="font-medium">50 MB</span>. The backend
+                  validates archive layout against the required E3SM performance-file specs before
+                  ingestion.
                 </p>
                 <p>
-                  You can upload either a case archive containing one or more execution directories, or a single
-                  execution packaged directly as <code className="rounded bg-blue-100 px-1 py-0.5 text-xs">&lt;execution_id&gt;/...</code>.
+                  Browser uploads use strict validation. If any execution directory is incomplete or
+                  invalid, the entire archive is rejected and no executions are ingested.
+                </p>
+                <p>
+                  You can upload either a case archive containing one or more execution directories,
+                  or a single execution packaged directly as{' '}
+                  <code className="rounded bg-blue-100 px-1 py-0.5 text-xs">
+                    &lt;execution_id&gt;/...
+                  </code>
+                  .
                 </p>
               </div>
             </div>
@@ -286,7 +410,8 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
                   <div>
                     <p className="font-medium text-gray-700">Required root files</p>
                     <p className="mt-1">
-                      <code>e3sm_timing..*..*</code>, <code>CaseStatus..*.gz</code>, <code>GIT_DESCRIBE..*.gz</code>
+                      <code>e3sm_timing..*..*</code>, <code>CaseStatus..*.gz</code>,{' '}
+                      <code>GIT_DESCRIBE..*.gz</code>
                     </p>
                   </div>
                   <div>
@@ -294,8 +419,8 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
                       Required <code>casedocs/</code> files
                     </p>
                     <p className="mt-1">
-                      <code>README.case..*.gz</code>, <code>env_case.xml..*.gz</code>, <code>env_build.xml..*.gz</code>,{' '}
-                      <code>env_run.xml..*</code>
+                      <code>README.case..*.gz</code>, <code>env_case.xml..*.gz</code>,{' '}
+                      <code>env_build.xml..*.gz</code>, <code>env_run.xml..*</code>
                     </p>
                   </div>
                 </div>
@@ -305,25 +430,75 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
                 <div className="mt-3 flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-800">
                   <CheckCircle className="mt-0.5 h-4 w-4 shrink-0" />
                   <span>
-                    Selected <span className="font-medium">{archiveFile.name}</span> ({(archiveFile.size / (1024 * 1024)).toFixed(2)} MB)
+                    Selected <span className="font-medium">{archiveFile.name}</span> (
+                    {(archiveFile.size / (1024 * 1024)).toFixed(2)} MB)
                   </span>
                 </div>
               ) : null}
 
-              {archiveFileError ? <p className="mt-2 text-sm text-red-600">{archiveFileError}</p> : null}
+              {archiveFileError ? (
+                <p className="mt-2 text-sm text-red-600">{archiveFileError}</p>
+              ) : null}
             </div>
 
             {validationErrors.length > 0 ? (
-              <div className="mt-5 rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+              <div
+                className="mt-5 rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+                ref={validationPanelRef}
+                tabIndex={-1}
+              >
                 <div className="flex items-start gap-2">
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
                   <div>
-                    <p className="font-medium">Archive validation failed.</p>
-                    <ul className="mt-2 list-disc space-y-1 pl-5">
-                      {validationErrors.map((error) => (
-                        <li key={`${error.execution_dir}-${error.file_spec}-${error.location}`}>{error.message}</li>
-                      ))}
-                    </ul>
+                    <p className="font-medium">
+                      {validationExecutionCount} execution
+                      {validationExecutionCount === 1 ? '' : 's'} failed validation. No executions
+                      were ingested.
+                    </p>
+                    <p className="mt-1 text-red-700">
+                      Review the {validationIssueCount} reported issue
+                      {validationIssueCount === 1 ? '' : 's'} below, fix the metadata gaps, and
+                      upload the archive again.
+                    </p>
+                    <div className="mt-3 space-y-3">
+                      {validationErrorGroups.map(
+                        ({ executionDir, displayExecutionDir, errors }) => (
+                          <div
+                            key={executionDir}
+                            className="rounded-md border border-red-200 bg-white/70 p-3"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <p className="font-medium text-red-900">{displayExecutionDir}</p>
+                              <span className="shrink-0 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800">
+                                {errors.length} issue{errors.length === 1 ? '' : 's'}
+                              </span>
+                            </div>
+                            <ul className="mt-2 space-y-2">
+                              {errors.map((error) => (
+                                <li
+                                  key={`${executionDir}-${error.file_spec}-${error.location}-${error.code}`}
+                                  className="rounded-md border border-red-100 bg-red-50/70 px-3 py-2"
+                                >
+                                  <p className="font-medium text-red-900">
+                                    {formatValidationIssueTitle(error)}
+                                  </p>
+                                  <div className="mt-1 flex flex-wrap gap-2 text-xs text-red-700">
+                                    {error.location ? (
+                                      <span className="rounded bg-red-100 px-2 py-0.5">
+                                        Location: {formatValidationLocation(error.location)}
+                                      </span>
+                                    ) : null}
+                                    {shouldShowValidationMessage(error) ? (
+                                      <span>{error.message}</span>
+                                    ) : null}
+                                  </div>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        ),
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>
@@ -347,7 +522,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
               </button>
             </div>
 
-            {uploadStatus ? (
+            {uploadStatus && validationErrors.length === 0 ? (
               <div
                 className={`mt-5 rounded-md border p-4 text-sm ${
                   uploadStatus.tone === 'success'
@@ -418,11 +593,17 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
                           </td>
                           <td className="px-4 py-4 text-right text-sm">
                             <div className="flex justify-end gap-3">
-                              <Link className="text-blue-700 hover:underline" to={`/simulations/${simulation.id}`}>
+                              <Link
+                                className="text-blue-700 hover:underline"
+                                to={`/simulations/${simulation.id}`}
+                              >
                                 Open
                               </Link>
                               {!createdCaseSummary ? (
-                                <Link className="text-blue-700 hover:underline" to={`/cases/${simulation.case_id}`}>
+                                <Link
+                                  className="text-blue-700 hover:underline"
+                                  to={`/cases/${simulation.case_id}`}
+                                >
                                   View case
                                 </Link>
                               ) : null}
@@ -440,15 +621,16 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
           <section className="rounded-xl border bg-white p-6 shadow-sm">
             <h2 className="text-lg font-semibold">Archive Layout</h2>
             <p className="mt-2 text-sm text-muted-foreground">
-              The uploader is intended for packaged E3SM performance archives from systems such as Chrysalis and NERSC.
-              You can upload a full case archive or a single execution directory at archive root. Files must live either
-              at the execution-directory root or under <code>casedocs/</code> in the expected locations.
+              The uploader is intended for packaged E3SM performance archives from systems such as
+              Chrysalis and NERSC. You can upload a full case archive or a single execution
+              directory at archive root. Files must live either at the execution-directory root or
+              under <code>casedocs/</code> in the expected locations.
             </p>
 
             <div className="mt-4 rounded-md border border-gray-200 bg-gray-50 p-4">
               <h3 className="text-sm font-medium">Example</h3>
               <pre className="mt-2 overflow-x-auto text-xs text-gray-700">
-{`qa/
+                {`qa/
 └── performance_archive/
     └── v3.LR.historical_0121/
         └── 1081156.251218-200923/
@@ -464,8 +646,10 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
                 └── env_run.xml.001.gz`}
               </pre>
               <p className="mt-2 text-xs text-gray-500">
-                A full case archive includes the case directory above. A single-run archive can start directly at
-                <code className="mx-1 rounded bg-gray-100 px-1 py-0.5">1081156.251218-200923/</code>.
+                A full case archive includes the case directory above. A single-run archive can
+                start directly at
+                <code className="mx-1 rounded bg-gray-100 px-1 py-0.5">1081156.251218-200923/</code>
+                .
               </p>
             </div>
 

--- a/frontend/src/features/upload/UploadPage.tsx
+++ b/frontend/src/features/upload/UploadPage.tsx
@@ -1,10 +1,12 @@
 import axios from 'axios';
 import { AlertTriangle, CheckCircle, Info } from 'lucide-react';
 import { ChangeEvent, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import {
   ArchiveUploadValidationDetail,
   ArchiveUploadValidationError,
+  IngestionUploadSimulationSummary,
   uploadSimulationArchive,
 } from '@/features/upload/api/api';
 import { toast } from '@/hooks/use-toast';
@@ -71,6 +73,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
   const [archiveFile, setArchiveFile] = useState<File | null>(null);
   const [archiveFileError, setArchiveFileError] = useState<string | null>(null);
   const [uploadStatus, setUploadStatus] = useState<UploadStatus | null>(null);
+  const [createdSimulations, setCreatedSimulations] = useState<IngestionUploadSimulationSummary[]>([]);
   const [validationErrors, setValidationErrors] = useState<ArchiveUploadValidationError[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   const [fileInputKey, setFileInputKey] = useState(0);
@@ -87,6 +90,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
     setArchiveFile(nextFile);
     setArchiveFileError(nextError);
     setUploadStatus(null);
+    setCreatedSimulations([]);
     setValidationErrors([]);
   };
 
@@ -105,6 +109,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
     }
 
     if (!selectedMachine) {
+      setCreatedSimulations([]);
       setUploadStatus({
         tone: 'error',
         title: 'Machine required',
@@ -119,6 +124,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
       title: 'Uploading and validating archive',
       description: 'The archive is being uploaded, extracted, and checked against the required file specs.',
     });
+    setCreatedSimulations([]);
     setValidationErrors([]);
 
     try {
@@ -129,6 +135,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
       });
 
       resetFileSelection();
+      setCreatedSimulations(response.simulations);
 
       setUploadStatus({
         tone: 'success',
@@ -143,6 +150,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
         const detail = error.response?.data?.detail;
 
         if (isArchiveUploadValidationDetail(detail)) {
+          setCreatedSimulations([]);
           setValidationErrors(detail.errors);
           setUploadStatus({
             tone: 'error',
@@ -153,6 +161,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
         }
 
         if (typeof detail === 'string') {
+          setCreatedSimulations([]);
           setUploadStatus({
             tone: 'error',
             title: 'Upload failed',
@@ -162,6 +171,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
         }
       }
 
+      setCreatedSimulations([]);
       setUploadStatus({
         tone: 'error',
         title: 'Upload failed',
@@ -341,6 +351,35 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
                     <p className="mt-1">{uploadStatus.description}</p>
                   </div>
                 </div>
+              </div>
+            ) : null}
+
+            {createdSimulations.length > 0 ? (
+              <div className="mt-5 rounded-md border border-green-200 bg-white p-4 text-sm">
+                <p className="font-medium text-gray-900">Created simulations</p>
+                <ul className="mt-3 space-y-2">
+                  {createdSimulations.map((simulation) => (
+                    <li
+                      key={simulation.id}
+                      className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2"
+                    >
+                      <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                        <div>
+                          <p className="font-medium text-gray-900">{simulation.execution_id}</p>
+                          <p className="text-xs text-gray-600">Case: {simulation.case_name}</p>
+                        </div>
+                        <div className="flex gap-3 text-xs">
+                          <Link className="text-blue-700 hover:underline" to={`/simulations/${simulation.id}`}>
+                            View simulation
+                          </Link>
+                          <Link className="text-blue-700 hover:underline" to={`/cases/${simulation.case_id}`}>
+                            View case
+                          </Link>
+                        </div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
               </div>
             ) : null}
           </section>

--- a/frontend/src/features/upload/UploadPage.tsx
+++ b/frontend/src/features/upload/UploadPage.tsx
@@ -14,6 +14,12 @@ interface UploadPageProps {
   machines: Machine[];
 }
 
+interface UploadStatus {
+  tone: 'info' | 'success' | 'error';
+  title: string;
+  description: string;
+}
+
 const MAX_ARCHIVE_SIZE_BYTES = 50 * 1024 * 1024;
 const SUPPORTED_ARCHIVE_EXTENSIONS = ['.tar.gz', '.tgz', '.zip'];
 const FILE_INPUT_ACCEPT = '.tar.gz,.tgz,.zip,application/gzip,application/zip';
@@ -64,6 +70,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
   const [hpcUsername, setHpcUsername] = useState('');
   const [archiveFile, setArchiveFile] = useState<File | null>(null);
   const [archiveFileError, setArchiveFileError] = useState<string | null>(null);
+  const [uploadStatus, setUploadStatus] = useState<UploadStatus | null>(null);
   const [validationErrors, setValidationErrors] = useState<ArchiveUploadValidationError[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   const [fileInputKey, setFileInputKey] = useState(0);
@@ -79,6 +86,7 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
 
     setArchiveFile(nextFile);
     setArchiveFileError(nextError);
+    setUploadStatus(null);
     setValidationErrors([]);
   };
 
@@ -97,15 +105,20 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
     }
 
     if (!selectedMachine) {
-      toast({
+      setUploadStatus({
+        tone: 'error',
         title: 'Machine required',
-        description: 'Select the machine that produced this performance archive.',
-        variant: 'destructive',
+        description: 'Select the machine that produced this performance archive before uploading.',
       });
       return;
     }
 
     setIsUploading(true);
+    setUploadStatus({
+      tone: 'info',
+      title: 'Uploading and validating archive',
+      description: 'The archive is being uploaded, extracted, and checked against the required file specs.',
+    });
     setValidationErrors([]);
 
     try {
@@ -117,7 +130,8 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
 
       resetFileSelection();
 
-      toast({
+      setUploadStatus({
+        tone: 'success',
         title: 'Archive ingested',
         description:
           response.created_count > 0
@@ -130,27 +144,32 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
 
         if (isArchiveUploadValidationDetail(detail)) {
           setValidationErrors(detail.errors);
-          toast({
+          setUploadStatus({
+            tone: 'error',
             title: 'Archive validation failed',
             description: detail.message,
-            variant: 'destructive',
           });
           return;
         }
 
         if (typeof detail === 'string') {
-          toast({
+          setUploadStatus({
+            tone: 'error',
             title: 'Upload failed',
             description: detail,
-            variant: 'destructive',
           });
           return;
         }
       }
 
-      toast({
+      setUploadStatus({
+        tone: 'error',
         title: 'Upload failed',
         description: 'We could not ingest the archive. Please review the archive and try again.',
+      });
+      toast({
+        title: 'Upload failed',
+        description: 'An unexpected server or network error occurred while uploading the archive.',
         variant: 'destructive',
       });
     } finally {
@@ -298,6 +317,32 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
                 {isUploading ? 'Uploading archive...' : 'Upload archive'}
               </button>
             </div>
+
+            {uploadStatus ? (
+              <div
+                className={`mt-5 rounded-md border p-4 text-sm ${
+                  uploadStatus.tone === 'success'
+                    ? 'border-green-200 bg-green-50 text-green-800'
+                    : uploadStatus.tone === 'error'
+                      ? 'border-red-200 bg-red-50 text-red-800'
+                      : 'border-blue-200 bg-blue-50 text-blue-900'
+                }`}
+              >
+                <div className="flex items-start gap-2">
+                  {uploadStatus.tone === 'success' ? (
+                    <CheckCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  ) : uploadStatus.tone === 'error' ? (
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  ) : (
+                    <Info className="mt-0.5 h-4 w-4 shrink-0" />
+                  )}
+                  <div>
+                    <p className="font-medium">{uploadStatus.title}</p>
+                    <p className="mt-1">{uploadStatus.description}</p>
+                  </div>
+                </div>
+              </div>
+            ) : null}
           </section>
 
           <section className="rounded-xl border bg-white p-6 shadow-sm">

--- a/frontend/src/features/upload/UploadPage.tsx
+++ b/frontend/src/features/upload/UploadPage.tsx
@@ -182,6 +182,10 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
                   Maximum upload size: <span className="font-medium">50 MB</span>. The backend validates archive layout
                   against the required E3SM performance-file specs before ingestion.
                 </p>
+                <p>
+                  You can upload either a case archive containing one or more execution directories, or a single
+                  execution packaged directly as <code className="rounded bg-blue-100 px-1 py-0.5 text-xs">&lt;execution_id&gt;/...</code>.
+                </p>
               </div>
             </div>
 
@@ -285,7 +289,8 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
             <h2 className="text-lg font-semibold">Archive Layout</h2>
             <p className="mt-2 text-sm text-muted-foreground">
               The uploader is intended for packaged E3SM performance archives from systems such as Chrysalis and NERSC.
-              Files must live either at the archive root or under <code>casedocs/</code> in the expected locations.
+              You can upload a full case archive or a single execution directory at archive root. Files must live either
+              at the execution-directory root or under <code>casedocs/</code> in the expected locations.
             </p>
 
             <div className="mt-4 grid gap-4 md:grid-cols-2">

--- a/frontend/src/features/upload/UploadPage.tsx
+++ b/frontend/src/features/upload/UploadPage.tsx
@@ -162,9 +162,10 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
     <div className="w-full min-h-[calc(100vh-64px)] bg-gray-50">
       <div className="max-w-4xl mx-auto px-4 md:px-6 py-8">
         <header className="mb-6">
-          <h1 className="text-2xl font-bold">Upload an E3SM Performance Archive</h1>
+          <h1 className="text-2xl font-bold">Upload a Case or Run</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Submit a packaged performance archive instead of entering simulation metadata manually.
+            Upload either a full E3SM performance case archive or a single execution directory packaged as
+            <code className="ml-1 rounded bg-gray-100 px-1 py-0.5 text-xs">&lt;execution_id&gt;/...</code>.
           </p>
         </header>
 
@@ -292,6 +293,30 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
               You can upload a full case archive or a single execution directory at archive root. Files must live either
               at the execution-directory root or under <code>casedocs/</code> in the expected locations.
             </p>
+
+            <div className="mt-4 rounded-md border border-gray-200 bg-gray-50 p-4">
+              <h3 className="text-sm font-medium">Example</h3>
+              <pre className="mt-2 overflow-x-auto text-xs text-gray-700">
+{`qa/
+└── performance_archive/
+    └── v3.LR.historical_0121/
+        └── 1081156.251218-200923/
+            ├── e3sm_timing.001.001
+            ├── CaseStatus.001.gz
+            ├── GIT_DESCRIBE.001.gz
+            ├── GIT_CONFIG.001.gz
+            ├── GIT_STATUS.001.gz
+            └── CaseDocs/
+                ├── README.case.001.gz
+                ├── env_case.xml.001.gz
+                ├── env_build.xml.001.gz
+                └── env_run.xml.001.gz`}
+              </pre>
+              <p className="mt-2 text-xs text-gray-500">
+                A full case archive includes the case directory above. A single-run archive can start directly at
+                <code className="mx-1 rounded bg-gray-100 px-1 py-0.5">1081156.251218-200923/</code>.
+              </p>
+            </div>
 
             <div className="mt-4 grid gap-4 md:grid-cols-2">
               <div>

--- a/frontend/src/features/upload/UploadPage.tsx
+++ b/frontend/src/features/upload/UploadPage.tsx
@@ -82,6 +82,25 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
     () => machines.find((machine) => machine.id === selectedMachineId) ?? null,
     [machines, selectedMachineId],
   );
+  const createdCaseSummary = useMemo(() => {
+    if (createdSimulations.length === 0) {
+      return null;
+    }
+
+    const firstSimulation = createdSimulations[0];
+    const allSameCase = createdSimulations.every(
+      (simulation) => simulation.case_id === firstSimulation.case_id,
+    );
+
+    if (!allSameCase) {
+      return null;
+    }
+
+    return {
+      id: firstSimulation.case_id,
+      name: firstSimulation.case_name,
+    };
+  }, [createdSimulations]);
 
   const handleArchiveChange = (event: ChangeEvent<HTMLInputElement>) => {
     const nextFile = event.target.files?.[0] ?? null;
@@ -355,31 +374,65 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
             ) : null}
 
             {createdSimulations.length > 0 ? (
-              <div className="mt-5 rounded-md border border-green-200 bg-white p-4 text-sm">
-                <p className="font-medium text-gray-900">Created simulations</p>
-                <ul className="mt-3 space-y-2">
-                  {createdSimulations.map((simulation) => (
-                    <li
-                      key={simulation.id}
-                      className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2"
+              <div className="mt-5 rounded-md border border-gray-200 bg-white text-sm">
+                <div className="flex items-center justify-between gap-4 border-b border-gray-200 bg-gray-50/60 px-4 py-3">
+                  <div>
+                    <p className="font-medium text-gray-900">
+                      Created simulations ({createdSimulations.length})
+                    </p>
+                    {createdCaseSummary ? (
+                      <p className="mt-1 text-sm text-gray-700" title={createdCaseSummary.name}>
+                        Case: {createdCaseSummary.name}
+                      </p>
+                    ) : null}
+                  </div>
+                  {createdCaseSummary ? (
+                    <Link
+                      className="shrink-0 text-sm font-medium text-blue-700 hover:underline"
+                      to={`/cases/${createdCaseSummary.id}`}
                     >
-                      <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
-                        <div>
-                          <p className="font-medium text-gray-900">{simulation.execution_id}</p>
-                          <p className="text-xs text-gray-600">Case: {simulation.case_name}</p>
-                        </div>
-                        <div className="flex gap-3 text-xs">
-                          <Link className="text-blue-700 hover:underline" to={`/simulations/${simulation.id}`}>
-                            View simulation
-                          </Link>
-                          <Link className="text-blue-700 hover:underline" to={`/cases/${simulation.case_id}`}>
-                            View case
-                          </Link>
-                        </div>
-                      </div>
-                    </li>
-                  ))}
-                </ul>
+                      View case
+                    </Link>
+                  ) : null}
+                </div>
+
+                <div className="max-h-96 overflow-auto">
+                  <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-gray-50 text-xs text-gray-600">
+                      <tr>
+                        <th className="px-4 py-3 text-left font-medium">Execution ID</th>
+                        <th className="px-4 py-3 text-right font-medium">Action</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 bg-white">
+                      {createdSimulations.map((simulation) => (
+                        <tr className="hover:bg-gray-50" key={simulation.id}>
+                          <td className="px-4 py-4">
+                            <Link
+                              className="block truncate font-medium text-blue-700 hover:underline"
+                              title={simulation.execution_id}
+                              to={`/simulations/${simulation.id}`}
+                            >
+                              {simulation.execution_id}
+                            </Link>
+                          </td>
+                          <td className="px-4 py-4 text-right text-sm">
+                            <div className="flex justify-end gap-3">
+                              <Link className="text-blue-700 hover:underline" to={`/simulations/${simulation.id}`}>
+                                Open
+                              </Link>
+                              {!createdCaseSummary ? (
+                                <Link className="text-blue-700 hover:underline" to={`/cases/${simulation.case_id}`}>
+                                  View case
+                                </Link>
+                              ) : null}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               </div>
             ) : null}
           </section>

--- a/frontend/src/features/upload/UploadPage.tsx
+++ b/frontend/src/features/upload/UploadPage.tsx
@@ -233,11 +233,25 @@ export const UploadPage = ({ machines }: UploadPageProps) => {
                 type="file"
               />
 
-              <p className="mt-2 text-xs text-gray-500">
-                Required root files: <code>e3sm_timing..*..*</code>, <code>CaseStatus..*.gz</code>,{' '}
-                <code>GIT_DESCRIBE..*.gz</code>. Required <code>casedocs/</code> files: <code>README.case..*.gz</code>,{' '}
-                <code>env_case.xml..*.gz</code>, <code>env_build.xml..*.gz</code>, and <code>env_run.xml..*</code>.
-              </p>
+              <div className="mt-3 rounded-md border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600">
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div>
+                    <p className="font-medium text-gray-700">Required root files</p>
+                    <p className="mt-1">
+                      <code>e3sm_timing..*..*</code>, <code>CaseStatus..*.gz</code>, <code>GIT_DESCRIBE..*.gz</code>
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-medium text-gray-700">
+                      Required <code>casedocs/</code> files
+                    </p>
+                    <p className="mt-1">
+                      <code>README.case..*.gz</code>, <code>env_case.xml..*.gz</code>, <code>env_build.xml..*.gz</code>,{' '}
+                      <code>env_run.xml..*</code>
+                    </p>
+                  </div>
+                </div>
+              </div>
 
               {archiveFile ? (
                 <div className="mt-3 flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-800">

--- a/frontend/src/features/upload/api/api.ts
+++ b/frontend/src/features/upload/api/api.ts
@@ -16,8 +16,15 @@ export interface ArchiveUploadValidationDetail {
 export interface IngestionUploadResponse {
   created_count: number;
   duplicate_count: number;
-  simulations: unknown[];
+  simulations: IngestionUploadSimulationSummary[];
   errors: Record<string, string>[];
+}
+
+export interface IngestionUploadSimulationSummary {
+  id: string;
+  case_id: string;
+  case_name: string;
+  execution_id: string;
 }
 
 interface UploadSimulationArchiveParams {

--- a/frontend/src/features/upload/api/api.ts
+++ b/frontend/src/features/upload/api/api.ts
@@ -1,0 +1,49 @@
+import { api } from '@/api/api';
+
+export interface ArchiveUploadValidationError {
+  code: string;
+  execution_dir: string;
+  file_spec: string;
+  location: string;
+  message: string;
+}
+
+export interface ArchiveUploadValidationDetail {
+  message: string;
+  errors: ArchiveUploadValidationError[];
+}
+
+export interface IngestionUploadResponse {
+  created_count: number;
+  duplicate_count: number;
+  simulations: unknown[];
+  errors: Record<string, string>[];
+}
+
+interface UploadSimulationArchiveParams {
+  file: File;
+  machineName: string;
+  hpcUsername?: string;
+}
+
+export const uploadSimulationArchive = async ({
+  file,
+  machineName,
+  hpcUsername,
+}: UploadSimulationArchiveParams): Promise<IngestionUploadResponse> => {
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('machine_name', machineName);
+
+  if (hpcUsername) {
+    formData.append('hpc_username', hpcUsername);
+  }
+
+  const response = await api.post<IngestionUploadResponse>('/ingestions/from-upload', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  return response.data;
+};

--- a/frontend/src/features/upload/api/api.ts
+++ b/frontend/src/features/upload/api/api.ts
@@ -46,11 +46,7 @@ export const uploadSimulationArchive = async ({
     formData.append('hpc_username', hpcUsername);
   }
 
-  const response = await api.post<IngestionUploadResponse>('/ingestions/from-upload', formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-    },
-  });
+  const response = await api.post<IngestionUploadResponse>('/ingestions/from-upload', formData);
 
   return response.data;
 };

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -18,6 +18,8 @@ export interface CaseOut {
   caseGroup: string | null;
   canonicalSimulationId: string | null;
   simulations: SimulationSummaryOut[];
+  machineNames: string[];
+  hpcUsernames: string[];
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Description

- Replaces the manual simulation submission page with an archive-only browser upload workflow for E3SM performance archives.
- Validates uploaded archives against the required archive layout and required file specs, with structured inline error reporting on the form.
- Supports both full case archives and single-execution archives packaged as `<execution_id>/...`, while keeping `env_run` required.
- Shows upload progress and created simulation results directly on the form, with links back into the created case and simulations.
- Fixes case details so uploaded cases correctly show aggregated machine names and HPC usernames from the case API response.

Closes #119

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [x] Tests added or updated (if needed)
- [x] All tests pass (locally and CI/CD)
- [x] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)

- No database migration or special deployment step is required.
