### PR TITLE
Fix browse filter URL state and simulations detail back navigation

### DIFF
--- a/frontend/src/features/browse/BrowsePage.tsx
+++ b/frontend/src/features/browse/BrowsePage.tsx
@@ -131,6 +131,23 @@ const parsePageSize = (params: URLSearchParams): number => {
   return PAGE_SIZE_OPTIONS.includes(ps) ? ps : 25;
 };
 
+const decodeFilterValue = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const deserializeArrayFilter = (value: string): string[] =>
+  value
+    .split(',')
+    .filter(Boolean)
+    .map(decodeFilterValue);
+
+const serializeArrayFilter = (values: string[]): string =>
+  values.map((value) => encodeURIComponent(value)).join(',');
+
 export const BrowsePage = ({
   selectedSimulationIds,
   setSelectedSimulationIds,
@@ -338,7 +355,7 @@ export const BrowsePage = ({
     MULTI_SELECT_FILTER_KEYS.forEach((key) => {
       const value = searchParams.get(key);
       if (value !== null) {
-        next[key] = value.split(',').filter(Boolean) as FilterState[typeof key];
+        next[key] = deserializeArrayFilter(value) as FilterState[typeof key];
       }
     });
 
@@ -398,7 +415,7 @@ export const BrowsePage = ({
         for (const key of FILTER_KEYS) {
           const value = appliedFilters[key];
           if (Array.isArray(value) && value.length) {
-            next.set(key, value.join(','));
+            next.set(key, serializeArrayFilter(value));
           } else if (typeof value === 'string' && value) {
             next.set(key, value);
           } else {

--- a/frontend/src/features/simulations/SimulationsPage.tsx
+++ b/frontend/src/features/simulations/SimulationsPage.tsx
@@ -99,6 +99,9 @@ export const SimulationsPage = ({ simulations }: SimulationsPageProps) => {
   const navigate = useNavigate();
   const location = useLocation();
   const currentPath = `${location.pathname}${location.search}`;
+  const navigateToSimulationDetails = (simulationId: string) => {
+    navigate(`/simulations/${simulationId}`, { state: { from: currentPath } });
+  };
 
   // Derive unique case names and case groups for filter dropdowns.
   const caseNames = useMemo(
@@ -498,7 +501,7 @@ export const SimulationsPage = ({ simulations }: SimulationsPageProps) => {
                 <TableRow
                   key={row.id}
                   className="hover:bg-muted/40 cursor-pointer"
-                  onClick={() => navigate(`/simulations/${row.original.id}`)}
+                  onClick={() => navigateToSimulationDetails(row.original.id)}
                 >
                   {/* Sticky checkbox cell */}
                   <TableCell


### PR DESCRIPTION
## Description

- Fixes browse filter URL serialization and hydration for multi-select values that contain commas, such as `caseName`.
- Ensures bookmarked URLs, refresh, and back/forward navigation restore the correct filter state.
- Preserves `/simulations` origin state for all simulation-details entry paths, including row clicks, so the details page returns users to the simulations table instead of falling back to `/browse`.

Related to: https://github.com/E3SM-Project/simboard/pull/158#pullrequestreview-4039142951

## Root Cause

- Array filters in `BrowsePage.tsx` were serialized with `join(',')` and restored with `split(',')`, which corrupted any single filter value containing a comma.
- In `SimulationsPage.tsx`, the execution-ID link passed `state.from`, but row-click navigation did not, which caused inconsistent back-navigation behavior from the same table.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [ ] Tests added or updated (if needed)
- [x] All tests pass (locally and CI/CD)
- [ ] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)

- No special deployment or migration steps required.

## Validation

- `pnpm run lint`
- `pnpm run type-check`
