### PR TITLE
Prevent empty case creation during path ingestion

### DIFF
--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -18,13 +18,13 @@ Caching for reference lookup:
     keyed by case.id, to avoid repeated DB queries.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import UUID
 
 from dateutil import parser as dateutil_parser
-from pydantic import ValidationError
+from pydantic import BaseModel, ConfigDict, HttpUrl, ValidationError
 from sqlalchemy.orm import Session
 
 from app.core.logger import _setup_custom_logger
@@ -37,8 +37,6 @@ from app.features.simulation.models import Case, Simulation
 from app.features.simulation.schemas import SimulationCreate
 
 logger = _setup_custom_logger(__name__)
-
-PLACEHOLDER_CASE_ID = UUID(int=0)
 
 
 @dataclass
@@ -72,7 +70,7 @@ class IngestArchiveResult:
 class SimulationCreateDraft:
     """Normalized internal payload validated into ``SimulationCreate``."""
 
-    case_id: UUID
+    case_id: UUID | None
     execution_id: str
     compset: str | None
     compset_alias: str | None
@@ -90,6 +88,37 @@ class SimulationCreateDraft:
     run_end_date: datetime | None
     compiler: str | None
     git_repository_url: str | None
+    git_branch: str | None
+    git_tag: str | None
+    git_commit_hash: str | None
+    created_by: UUID | None
+    last_updated_by: UUID | None
+    hpc_username: str | None
+    run_config_deltas: dict[str, dict[str, str | None]] | None = None
+
+
+class SimulationCreateDraftPreCaseValidation(BaseModel):
+    """Pydantic validation model for draft fields available before case lookup."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    execution_id: str
+    compset: str
+    compset_alias: str
+    grid_name: str
+    grid_resolution: str
+    simulation_type: SimulationType
+    status: SimulationStatus
+    campaign: str | None
+    experiment_type: str | None
+    initialization_type: str
+    machine_id: UUID
+    simulation_start_date: datetime
+    simulation_end_date: datetime | None
+    run_start_date: datetime | None
+    run_end_date: datetime | None
+    compiler: str | None
+    git_repository_url: HttpUrl | None
     git_branch: str | None
     git_tag: str | None
     git_commit_hash: str | None
@@ -250,12 +279,12 @@ def _process_simulation_for_ingest(
         )
         return None, True
 
-    _prevalidate_simulation_create(parsed_simulation, machine_id)
+    prevalidated_draft = _prevalidate_simulation_create(parsed_simulation, machine_id)
     case = _resolve_case(parsed_simulation, case_name, db)
 
     simulation = _build_simulation_create(
         parsed_simulation=parsed_simulation,
-        machine_id=machine_id,
+        prevalidated_draft=prevalidated_draft,
         case=case,
         reference_cache=reference_cache,
         persisted_reference_cache=persisted_reference_cache,
@@ -317,7 +346,7 @@ def _seed_reference_cache_from_duplicate(
 
 def _build_simulation_create(
     parsed_simulation: ParsedSimulation,
-    machine_id: UUID,
+    prevalidated_draft: SimulationCreateDraft,
     case: Case,
     reference_cache: dict[str, SimulationConfigSnapshot],
     persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
@@ -329,8 +358,8 @@ def _build_simulation_create(
     ----------
     parsed_simulation : ParsedSimulation
         Parsed archive-derived metadata for the simulation.
-    machine_id : UUID
-        Resolved machine ID from the database.
+    prevalidated_draft : SimulationCreateDraft
+        Draft with normalized fields already parsed and prevalidated.
     case : Case
         Resolved Case object for this simulation.
     reference_cache : dict[str, SimulationConfigSnapshot]
@@ -353,11 +382,7 @@ def _build_simulation_create(
         reference_cache[case_name] = _build_config_snapshot(parsed_simulation)
 
         simulation = _validate_simulation_create(
-            _build_simulation_create_draft(
-                parsed_simulation=parsed_simulation,
-                machine_id=machine_id,
-                case_id=case.id,
-            )
+            replace(prevalidated_draft, case_id=case.id)
         )
         logger.info(
             "Mapped reference simulation from %s: %s",
@@ -368,12 +393,10 @@ def _build_simulation_create(
         return simulation
 
     delta = reference_snapshot.diff(_build_config_snapshot(parsed_simulation))
-    run_config_deltas = delta if delta else None
-    simulation_draft = _build_simulation_create_draft(
-        parsed_simulation=parsed_simulation,
-        machine_id=machine_id,
+    simulation_draft = replace(
+        prevalidated_draft,
         case_id=case.id,
-        run_config_deltas=run_config_deltas,
+        run_config_deltas=delta if delta else None,
     )
     simulation = _validate_simulation_create(simulation_draft)
 
@@ -395,15 +418,20 @@ def _build_simulation_create(
 def _prevalidate_simulation_create(
     parsed_simulation: ParsedSimulation,
     machine_id: UUID,
-) -> None:
-    """Validate non-case simulation fields before creating a new case."""
-    _validate_simulation_create(
-        _build_simulation_create_draft(
-            parsed_simulation=parsed_simulation,
-            machine_id=machine_id,
-            case_id=PLACEHOLDER_CASE_ID,
-        )
+) -> SimulationCreateDraft:
+    """Build and validate non-case simulation fields before creating a new case."""
+    draft = _build_simulation_create_draft(
+        parsed_simulation=parsed_simulation,
+        machine_id=machine_id,
+        case_id=None,
     )
+
+    SimulationCreateDraftPreCaseValidation.model_validate(
+        draft,
+        from_attributes=True,
+    )
+
+    return draft
 
 
 def _get_reference_metadata_for_case(
@@ -643,7 +671,7 @@ def _normalize_git_url(url: str | None) -> str | None:
 def _build_simulation_create_draft(
     parsed_simulation: ParsedSimulation,
     machine_id: UUID,
-    case_id: UUID,
+    case_id: UUID | None,
     run_config_deltas: dict[str, dict[str, str | None]] | None = None,
 ) -> SimulationCreateDraft:
     """Build a normalized internal draft for ``SimulationCreate`` validation.

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -38,6 +38,8 @@ from app.features.simulation.schemas import SimulationCreate
 
 logger = _setup_custom_logger(__name__)
 
+PLACEHOLDER_CASE_ID = UUID(int=0)
+
 
 @dataclass
 class IngestArchiveResult:
@@ -241,13 +243,15 @@ def _process_simulation_for_ingest(
     execution_id = parsed_simulation.execution_id
     case_name = _require_case_name(parsed_simulation)
     machine_id = _resolve_machine_id(parsed_simulation, db)
-    case = _resolve_case(parsed_simulation, case_name, db)
 
     if _is_duplicate_simulation(execution_id, parsed_simulation.execution_dir, db):
         _seed_reference_cache_from_duplicate(
             case_name, parsed_simulation, reference_cache
         )
         return None, True
+
+    _prevalidate_simulation_create(parsed_simulation, machine_id)
+    case = _resolve_case(parsed_simulation, case_name, db)
 
     simulation = _build_simulation_create(
         parsed_simulation=parsed_simulation,
@@ -386,6 +390,20 @@ def _build_simulation_create(
         )
 
     return simulation
+
+
+def _prevalidate_simulation_create(
+    parsed_simulation: ParsedSimulation,
+    machine_id: UUID,
+) -> None:
+    """Validate non-case simulation fields before creating a new case."""
+    _validate_simulation_create(
+        _build_simulation_create_draft(
+            parsed_simulation=parsed_simulation,
+            machine_id=machine_id,
+            case_id=PLACEHOLDER_CASE_ID,
+        )
+    )
 
 
 def _get_reference_metadata_for_case(

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from uuid import UUID
 
 from dateutil import parser as dateutil_parser
-from pydantic import BaseModel, ConfigDict, HttpUrl, ValidationError
+from pydantic import HttpUrl, TypeAdapter, ValidationError
 from sqlalchemy.orm import Session
 
 from app.core.logger import _setup_custom_logger
@@ -37,6 +37,10 @@ from app.features.simulation.models import Case, Simulation
 from app.features.simulation.schemas import SimulationCreate
 
 logger = _setup_custom_logger(__name__)
+
+_STRING_ADAPTER = TypeAdapter(str)
+_DATETIME_ADAPTER = TypeAdapter(datetime)
+_HTTP_URL_ADAPTER = TypeAdapter(HttpUrl)
 
 
 @dataclass
@@ -88,37 +92,6 @@ class SimulationCreateDraft:
     run_end_date: datetime | None
     compiler: str | None
     git_repository_url: str | None
-    git_branch: str | None
-    git_tag: str | None
-    git_commit_hash: str | None
-    created_by: UUID | None
-    last_updated_by: UUID | None
-    hpc_username: str | None
-    run_config_deltas: dict[str, dict[str, str | None]] | None = None
-
-
-class SimulationCreateDraftPreCaseValidation(BaseModel):
-    """Pydantic validation model for draft fields available before case lookup."""
-
-    model_config = ConfigDict(from_attributes=True)
-
-    execution_id: str
-    compset: str
-    compset_alias: str
-    grid_name: str
-    grid_resolution: str
-    simulation_type: SimulationType
-    status: SimulationStatus
-    campaign: str | None
-    experiment_type: str | None
-    initialization_type: str
-    machine_id: UUID
-    simulation_start_date: datetime
-    simulation_end_date: datetime | None
-    run_start_date: datetime | None
-    run_end_date: datetime | None
-    compiler: str | None
-    git_repository_url: HttpUrl | None
     git_branch: str | None
     git_tag: str | None
     git_commit_hash: str | None
@@ -426,12 +399,27 @@ def _prevalidate_simulation_create(
         case_id=None,
     )
 
-    SimulationCreateDraftPreCaseValidation.model_validate(
-        draft,
-        from_attributes=True,
-    )
+    _validate_pre_case_draft(draft)
 
     return draft
+
+
+def _validate_pre_case_draft(draft: SimulationCreateDraft) -> None:
+    """Validate the draft fields that must succeed before case creation."""
+    for field_name in (
+        "execution_id",
+        "compset",
+        "compset_alias",
+        "grid_name",
+        "grid_resolution",
+        "initialization_type",
+    ):
+        _STRING_ADAPTER.validate_python(getattr(draft, field_name))
+
+    _DATETIME_ADAPTER.validate_python(draft.simulation_start_date)
+
+    if draft.git_repository_url is not None:
+        _HTTP_URL_ADAPTER.validate_python(draft.git_repository_url)
 
 
 def _get_reference_metadata_for_case(

--- a/backend/tests/features/ingestion/test_api.py
+++ b/backend/tests/features/ingestion/test_api.py
@@ -26,6 +26,7 @@ from app.features.ingestion.api import (
 from app.features.ingestion.ingest import IngestArchiveResult
 from app.features.ingestion.models import Ingestion
 from app.features.ingestion.parsers.parser import ArchiveValidationError
+from app.features.ingestion.parsers.types import ParsedSimulation
 from app.features.machine.models import Machine
 from app.features.simulation.models import Case, Simulation
 from app.features.simulation.schemas import SimulationCreate
@@ -802,6 +803,62 @@ class TestIngestFromUploadEndpoint:
         assert ingestion.status == "failed"
         assert ingestion.created_count == 0
         assert ingestion.error_count == 2
+
+    def test_path_endpoint_does_not_persist_empty_case_on_ingest_error(
+        self, client, db: Session, tmp_path
+    ):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        archive_path = self._create_archive_file(tmp_path, "orphan_case.tar.gz")
+        payload = {"archive_path": str(archive_path), "machine_name": machine.name}
+
+        parsed_simulation = ParsedSimulation(
+            execution_dir="/path/to/1081175.251218-200942",
+            execution_id="1081175.251218-200942",
+            case_name="orphan_case_endpoint",
+            case_group=None,
+            machine=machine.name,
+            hpc_username=None,
+            compset="FHIST",
+            compset_alias="test_alias",
+            grid_name="grid",
+            grid_resolution="0.9x1.25",
+            campaign=None,
+            experiment_type=None,
+            initialization_type="test",
+            simulation_start_date=None,
+            simulation_end_date=None,
+            run_start_date=None,
+            run_end_date=None,
+            compiler=None,
+            git_repository_url=None,
+            git_branch=None,
+            git_tag=None,
+            git_commit_hash=None,
+            status=None,
+        )
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=([parsed_simulation], 0),
+        ):
+            res = client.post(f"{API_BASE}/ingestions/from-path", json=payload)
+
+        assert res.status_code == 201
+        assert res.json()["created_count"] == 0
+        assert len(res.json()["errors"]) == 1
+
+        ingestion = (
+            db.query(Ingestion)
+            .filter(Ingestion.source_reference == str(archive_path))
+            .first()
+        )
+        assert ingestion is not None
+        assert ingestion.status == "failed"
+        assert (
+            db.query(Case).filter(Case.name == "orphan_case_endpoint").first() is None
+        )
 
     def test_save_uploaded_file_rejects_large_files(self, tmp_path: Path):
         file_content = b"x" * (51 * 1024 * 1024)  # 51MB

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -790,6 +790,138 @@ class TestIngestArchiveContinued(TestIngestArchive):
             # Duplicate should be skipped, result should be empty
             assert len(ingest_result.simulations) == 0
 
+    def test_validation_error_does_not_persist_empty_case(self, db: Session) -> None:
+        machine = self._create_machine(db, "test-machine")
+
+        mock_simulations = {
+            "/path/to/1081175.251218-200940": {
+                "execution_id": "1081175.251218-200940",
+                "case_name": "orphan_case_validation",
+                "compset": "FHIST",
+                "compset_alias": "test_alias",
+                "grid_name": "grid",
+                "grid_resolution": "0.9x1.25",
+                "machine": machine.name,
+                "simulation_start_date": None,
+                "initialization_type": "test",
+                "simulation_type": "test",
+                "status": None,
+                "experiment_type": None,
+                "campaign": None,
+                "run_start_date": None,
+                "run_end_date": None,
+                "compiler": None,
+                "git_repository_url": None,
+                "git_branch": None,
+                "git_tag": None,
+                "git_commit_hash": None,
+                "created_by": None,
+                "last_updated_by": None,
+            }
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            ingest_result = ingest_archive(
+                Path("/tmp/archive.zip"), Path("/tmp/out"), db
+            )
+
+        assert ingest_result.simulations == []
+        assert len(ingest_result.errors) == 1
+        assert ingest_result.errors[0]["error_type"] == "ValidationError"
+        assert (
+            db.query(Case).filter(Case.name == "orphan_case_validation").first() is None
+        )
+
+    def test_duplicate_does_not_persist_new_empty_case(self, db: Session) -> None:
+        machine = self._create_machine(db, "test-machine")
+
+        user = User(
+            id=uuid4(), email="test@example.com", is_active=True, is_superuser=False
+        )
+        db.add(user)
+        db.commit()
+
+        ingestion = Ingestion(
+            source_type=IngestionSourceType.HPC_PATH,
+            source_reference="test_duplicate_does_not_persist_new_empty_case",
+            machine_id=machine.id,
+            triggered_by=user.id,
+            status=IngestionStatus.SUCCESS,
+            created_count=1,
+            duplicate_count=0,
+            error_count=0,
+        )
+        db.add(ingestion)
+        db.flush()
+
+        case = Case(name="existing_case")
+        db.add(case)
+        db.flush()
+
+        existing_sim = Simulation(
+            case_id=case.id,
+            execution_id="1081175.251218-200941",
+            compset="FHIST",
+            compset_alias="FHIST_f09_fe",
+            grid_name="grid",
+            grid_resolution="0.9x1.25",
+            machine_id=machine.id,
+            simulation_start_date=datetime(2020, 1, 1),
+            initialization_type="test",
+            simulation_type="test",
+            status=SimulationStatus.CREATED,
+            created_by=user.id,
+            last_updated_by=user.id,
+            ingestion_id=ingestion.id,
+        )
+        db.add(existing_sim)
+        db.commit()
+
+        mock_simulations = {
+            "/path/to/1081175.251218-200941": {
+                "execution_id": "1081175.251218-200941",
+                "case_name": "orphan_case_duplicate",
+                "compset": "FHIST",
+                "compset_alias": "test_alias",
+                "grid_name": "grid",
+                "grid_resolution": "0.9x1.25",
+                "machine": machine.name,
+                "simulation_start_date": "2020-01-01",
+                "initialization_type": "test",
+                "simulation_type": "test",
+                "status": None,
+                "experiment_type": None,
+                "campaign": None,
+                "run_start_date": None,
+                "run_end_date": None,
+                "compiler": None,
+                "git_repository_url": None,
+                "git_branch": None,
+                "git_tag": None,
+                "git_commit_hash": None,
+                "created_by": None,
+                "last_updated_by": None,
+            }
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            ingest_result = ingest_archive(
+                Path("/tmp/archive.zip"), Path("/tmp/out"), db
+            )
+
+        assert ingest_result.created_count == 0
+        assert ingest_result.duplicate_count == 1
+        assert ingest_result.simulations == []
+        assert (
+            db.query(Case).filter(Case.name == "orphan_case_duplicate").first() is None
+        )
+
     def test_ingest_archive_counts(self, db: Session) -> None:
         """Test that summary counts reflect created and duplicate simulations."""
         machine = self._create_machine(db, "test-machine")


### PR DESCRIPTION
## Description
- prevent orphan `Case` rows from being persisted when path ingestion fails to create a simulation
- move duplicate detection ahead of any case persistence side effect in backend ingestion orchestration
- pre-validate simulation fields before `_resolve_case()` and add regressions for invalid-run, duplicate-run, and `/ingestions/from-path` commit-path behavior
- Closes #165

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [x] Tests added or updated (if needed)
- [x] All tests pass (locally and CI/CD)
- [ ] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)
- None.
