### PR TITLE
Extract and preserve path artifacts during ingestion

### DIFF
--- a/backend/app/features/ingestion/api.py
+++ b/backend/app/features/ingestion/api.py
@@ -65,6 +65,8 @@ def ingest_from_path(
     NOTE: Arbitrary filesystem paths are currently permitted to support HPC
     ingestion workflows (e.g., NERSC). This endpoint is restricted to users with
     the ADMIN or SERVICE_ACCOUNT role.
+    Path artifacts parsed from the archive are treated as opaque provenance
+    metadata and stored exactly as they appear in the archive metadata.
 
     TODO: Consider enforcing that archive_path must reside within a configured
     base directory (e.g., a designated HPC storage or ingestion directory)
@@ -100,7 +102,9 @@ def ingest_from_path(
 
     with tempfile.TemporaryDirectory() as tmpdir:
         ingest_result = _run_ingest_archive(
-            archive_path=str(archive_path), output_dir=tmpdir, db=db
+            archive_path=str(archive_path),
+            output_dir=tmpdir,
+            db=db,
         )
 
     response = _process_ingestion(
@@ -138,6 +142,10 @@ def ingest_from_upload(
     user: User = Depends(current_active_user),
 ) -> IngestionResponse:
     """Ingest an archive via file upload and persist simulations.
+
+    Path artifacts parsed from uploaded archives are treated as opaque remote
+    provenance metadata. SimBoard stores the filesystem paths exactly as
+    reported in the archive metadata without validating them on the API host.
 
     Parameters
     ----------

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -18,6 +18,7 @@ Caching for reference lookup:
     keyed by case.id, to avoid repeated DB queries.
 """
 
+import shlex
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,9 +33,9 @@ from app.features.ingestion.parsers.parser import main_parser
 from app.features.ingestion.parsers.types import ParsedSimulation
 from app.features.machine.utils import resolve_machine_by_name
 from app.features.simulation.config_delta import SimulationConfigSnapshot
-from app.features.simulation.enums import SimulationStatus, SimulationType
+from app.features.simulation.enums import ArtifactKind, SimulationStatus, SimulationType
 from app.features.simulation.models import Case, Simulation
-from app.features.simulation.schemas import SimulationCreate
+from app.features.simulation.schemas import ArtifactCreate, SimulationCreate
 
 logger = _setup_custom_logger(__name__)
 
@@ -357,6 +358,7 @@ def _build_simulation_create(
         simulation = _validate_simulation_create(
             replace(prevalidated_draft, case_id=case.id)
         )
+        simulation = _attach_path_artifacts(simulation, parsed_simulation)
         logger.info(
             "Mapped reference simulation from %s: %s",
             parsed_simulation.execution_dir,
@@ -372,6 +374,7 @@ def _build_simulation_create(
         run_config_deltas=delta if delta else None,
     )
     simulation = _validate_simulation_create(simulation_draft)
+    simulation = _attach_path_artifacts(simulation, parsed_simulation)
 
     if delta:
         logger.info(
@@ -386,6 +389,134 @@ def _build_simulation_create(
         )
 
     return simulation
+
+
+def _attach_path_artifacts(
+    simulation: SimulationCreate,
+    parsed_simulation: ParsedSimulation,
+) -> SimulationCreate:
+    path_artifacts = _build_path_artifacts(parsed_simulation)
+    if not path_artifacts:
+        return simulation
+
+    return simulation.model_copy(update={"artifacts": path_artifacts})
+
+
+def _build_path_artifacts(parsed_simulation: ParsedSimulation) -> list[ArtifactCreate]:
+    execution_dir = parsed_simulation.execution_dir
+    path_artifacts: list[ArtifactCreate] = []
+
+    output_path = _validate_existing_path(
+        parsed_simulation.output_path,
+        source_name="RUNDIR",
+        execution_dir=execution_dir,
+    )
+    archive_path = _validate_existing_path(
+        parsed_simulation.archive_path,
+        source_name="DOUT_S_ROOT",
+        execution_dir=execution_dir,
+    )
+    run_script_path = _derive_case_run_script_path(parsed_simulation.case_root)
+    run_script_path = _validate_existing_path(
+        run_script_path,
+        source_name="CASEROOT/.case.run",
+        execution_dir=execution_dir,
+    )
+    postprocessing_path = _extract_postprocessing_script_path(
+        parsed_simulation.postprocessing_script,
+        execution_dir=execution_dir,
+    )
+    postprocessing_path = _validate_existing_path(
+        postprocessing_path,
+        source_name="POSTRUN_SCRIPT",
+        execution_dir=execution_dir,
+    )
+
+    _append_path_artifact(path_artifacts, ArtifactKind.OUTPUT, output_path)
+    _append_path_artifact(path_artifacts, ArtifactKind.ARCHIVE, archive_path)
+    _append_path_artifact(path_artifacts, ArtifactKind.RUN_SCRIPT, run_script_path)
+    _append_path_artifact(
+        path_artifacts,
+        ArtifactKind.POSTPROCESS_SCRIPT,
+        postprocessing_path,
+    )
+
+    return path_artifacts
+
+
+def _append_path_artifact(
+    artifacts: list[ArtifactCreate], kind: ArtifactKind, uri: str | None
+) -> None:
+    if uri is None:
+        return
+
+    artifacts.append(ArtifactCreate(kind=kind, uri=uri))
+
+
+def _derive_case_run_script_path(case_root: str | None) -> str | None:
+    normalized_case_root = _normalize_path_candidate(case_root)
+    if normalized_case_root is None:
+        return None
+
+    return str(Path(normalized_case_root) / ".case.run")
+
+
+def _extract_postprocessing_script_path(
+    postprocessing_script: str | None,
+    execution_dir: str,
+) -> str | None:
+    normalized_script = _normalize_path_candidate(postprocessing_script)
+    if normalized_script is None:
+        return None
+
+    try:
+        tokens = shlex.split(normalized_script)
+    except ValueError:
+        logger.warning(
+            "Skipping POSTRUN_SCRIPT artifact for '%s': could not parse value '%s'.",
+            execution_dir,
+            normalized_script,
+        )
+        return None
+
+    if not tokens:
+        return None
+
+    return tokens[0]
+
+
+def _validate_existing_path(
+    path_value: str | None,
+    *,
+    source_name: str,
+    execution_dir: str,
+) -> str | None:
+    normalized_path = _normalize_path_candidate(path_value)
+    if normalized_path is None:
+        return None
+
+    candidate_path = Path(normalized_path).expanduser()
+    if not candidate_path.exists():
+        logger.warning(
+            "Skipping %s artifact for '%s': path does not exist on ingest host: %s",
+            source_name,
+            execution_dir,
+            normalized_path,
+        )
+        return None
+
+    return str(candidate_path)
+
+
+def _normalize_path_candidate(path_value: str | None) -> str | None:
+    if path_value is None:
+        return None
+
+    normalized = path_value.strip()
+    if not normalized:
+        return None
+
+    return normalized
 
 
 def _prevalidate_simulation_create(

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -138,7 +138,6 @@ def ingest_archive(
         Directory where extracted files will be stored.
     db : Session
         SQLAlchemy database session for machine and simulation lookups.
-
     Returns
     -------
     IngestArchiveResult
@@ -399,37 +398,20 @@ def _attach_path_artifacts(
     if not path_artifacts:
         return simulation
 
-    return simulation.model_copy(update={"artifacts": path_artifacts})
+    return simulation.model_copy(
+        update={"artifacts": [*simulation.artifacts, *path_artifacts]}
+    )
 
 
 def _build_path_artifacts(parsed_simulation: ParsedSimulation) -> list[ArtifactCreate]:
-    execution_dir = parsed_simulation.execution_dir
     path_artifacts: list[ArtifactCreate] = []
 
-    output_path = _validate_existing_path(
-        parsed_simulation.output_path,
-        source_name="RUNDIR",
-        execution_dir=execution_dir,
-    )
-    archive_path = _validate_existing_path(
-        parsed_simulation.archive_path,
-        source_name="DOUT_S_ROOT",
-        execution_dir=execution_dir,
-    )
+    output_path = _normalize_path_candidate(parsed_simulation.output_path)
+    archive_path = _normalize_path_candidate(parsed_simulation.archive_path)
     run_script_path = _derive_case_run_script_path(parsed_simulation.case_root)
-    run_script_path = _validate_existing_path(
-        run_script_path,
-        source_name="CASEROOT/.case.run",
-        execution_dir=execution_dir,
-    )
     postprocessing_path = _extract_postprocessing_script_path(
         parsed_simulation.postprocessing_script,
-        execution_dir=execution_dir,
-    )
-    postprocessing_path = _validate_existing_path(
-        postprocessing_path,
-        source_name="POSTRUN_SCRIPT",
-        execution_dir=execution_dir,
+        execution_dir=parsed_simulation.execution_dir,
     )
 
     _append_path_artifact(path_artifacts, ArtifactKind.OUTPUT, output_path)
@@ -483,29 +465,6 @@ def _extract_postprocessing_script_path(
         return None
 
     return tokens[0]
-
-
-def _validate_existing_path(
-    path_value: str | None,
-    *,
-    source_name: str,
-    execution_dir: str,
-) -> str | None:
-    normalized_path = _normalize_path_candidate(path_value)
-    if normalized_path is None:
-        return None
-
-    candidate_path = Path(normalized_path).expanduser()
-    if not candidate_path.exists():
-        logger.warning(
-            "Skipping %s artifact for '%s': path does not exist on ingest host: %s",
-            source_name,
-            execution_dir,
-            normalized_path,
-        )
-        return None
-
-    return str(candidate_path)
 
 
 def _normalize_path_candidate(path_value: str | None) -> str | None:

--- a/backend/app/features/ingestion/parsers/case_docs.py
+++ b/backend/app/features/ingestion/parsers/case_docs.py
@@ -38,6 +38,7 @@ def parse_env_case(env_case_path: str | Path) -> dict[str, str | None]:
     machine = _extract_value_from_file(env_case_path, "MACH")
     user = _extract_value_from_file(env_case_path, "REALUSER")
     compset_alias = _extract_value_from_file(env_case_path, "COMPSET")
+    case_root = _extract_value_from_file(env_case_path, "CASEROOT")
 
     # Extract metadata that requires special handling
     campaign, experiment_type = _extract_campaign_and_experiment_type(case_name)
@@ -50,6 +51,7 @@ def parse_env_case(env_case_path: str | Path) -> dict[str, str | None]:
         "campaign": campaign,
         "experiment_type": experiment_type,
         "compset_alias": compset_alias,
+        "case_root": case_root,
     }
 
 
@@ -95,6 +97,9 @@ def parse_env_run(env_run_path: str | Path) -> dict[str, str | None]:
     stop_option = _extract_value_from_file(env_run_path, "STOP_OPTION")
     stop_n = _extract_value_from_file(env_run_path, "STOP_N")
     stop_date = _extract_value_from_file(env_run_path, "STOP_DATE")
+    output_path = _extract_value_from_file(env_run_path, "RUNDIR")
+    archive_path = _extract_value_from_file(env_run_path, "DOUT_S_ROOT")
+    postprocessing_script = _extract_value_from_file(env_run_path, "POSTRUN_SCRIPT")
 
     simulation_start_date = (
         run_ref_date if initialization_type == "branch" else run_start_date
@@ -110,6 +115,9 @@ def parse_env_run(env_run_path: str | Path) -> dict[str, str | None]:
         "initialization_type": initialization_type,
         "simulation_start_date": simulation_start_date,
         "simulation_end_date": simulation_end_date,
+        "output_path": output_path,
+        "archive_path": archive_path,
+        "postprocessing_script": postprocessing_script,
     }
 
 

--- a/backend/app/features/ingestion/parsers/case_docs.py
+++ b/backend/app/features/ingestion/parsers/case_docs.py
@@ -30,6 +30,7 @@ def parse_env_case(env_case_path: str | Path) -> dict[str, str | None]:
         - ``experiment_type``: Derived experiment type, constrained to
           KNOWN_EXPERIMENT_TYPES when possible
         - ``compset_alias``: Compset alias (``COMPSET``)
+        - ``case_root``: Case root directory (``CASEROOT``)
     """
     env_case_path = Path(env_case_path)
 
@@ -88,7 +89,15 @@ def parse_env_run(env_run_path: str | Path) -> dict[str, str | None]:
     Returns
     -------
     dict
-        Dictionary with runtime initialization and simulation date metadata.
+        Dictionary with runtime initialization, simulation date metadata,
+        and path-based artifact metadata, including:
+
+        - ``initialization_type``: Run type (``RUN_TYPE``)
+        - ``simulation_start_date``: Effective start date for the run
+        - ``simulation_end_date``: Derived end date for the run
+        - ``output_path``: Run directory path (``RUNDIR``)
+        - ``archive_path``: Short-term archive root (``DOUT_S_ROOT``)
+        - ``postprocessing_script``: Post-run script command (``POSTRUN_SCRIPT``)
     """
     env_run_path = Path(env_run_path)
     initialization_type = _extract_value_from_file(env_run_path, "RUN_TYPE")

--- a/backend/app/features/ingestion/parsers/parser.py
+++ b/backend/app/features/ingestion/parsers/parser.py
@@ -571,6 +571,10 @@ def _parse_all_files(exec_dir: str, files: dict[str, str | None]) -> ParsedSimul
         git_tag=metadata.get("git_tag"),
         git_commit_hash=metadata.get("git_commit_hash"),
         status=metadata.get("status") or SimulationStatus.UNKNOWN.value,
+        output_path=metadata.get("output_path"),
+        archive_path=metadata.get("archive_path"),
+        case_root=metadata.get("case_root"),
+        postprocessing_script=metadata.get("postprocessing_script"),
     )
 
 

--- a/backend/app/features/ingestion/parsers/types.py
+++ b/backend/app/features/ingestion/parsers/types.py
@@ -28,3 +28,7 @@ class ParsedSimulation:
     git_tag: str | None
     git_commit_hash: str | None
     status: str | None
+    output_path: str | None = None
+    archive_path: str | None = None
+    case_root: str | None = None
+    postprocessing_script: str | None = None

--- a/backend/tests/features/ingestion/parsers/test_case_docs.py
+++ b/backend/tests/features/ingestion/parsers/test_case_docs.py
@@ -9,6 +9,19 @@ from app.features.ingestion.parsers.case_docs import (
 
 
 class TestParseEnvCase:
+    def test_extracts_case_root(self, tmp_path):
+        xml_case = """
+        <config>
+            <entry id="CASEROOT" value="/tmp/case_root" />
+        </config>
+        """
+        tmp_case = tmp_path / "env_case_caseroot.xml"
+        tmp_case.write_text(xml_case)
+
+        result = parse_env_case(tmp_case)
+
+        assert result["case_root"] == "/tmp/case_root"
+
     def test_value(self, tmp_path):
         xml_case = """
         <config>
@@ -139,6 +152,41 @@ class TestParseEnvBuild:
 
 
 class TestParseEnvRun:
+    def test_extracts_path_artifact_values(self, tmp_path):
+        xml_run = """
+        <config>
+            <entry id="RUN_TYPE" value="startup" />
+            <entry id="RUN_STARTDATE" value="2020-01-01" />
+            <entry id="RUNDIR" value="/tmp/run" />
+            <entry id="DOUT_S_ROOT" value="/tmp/archive" />
+            <entry id="POSTRUN_SCRIPT">/tmp/post.sh --flag value</entry>
+        </config>
+        """
+        tmp_run = tmp_path / "env_run_paths.xml"
+        tmp_run.write_text(xml_run)
+
+        result = parse_env_run(tmp_run)
+
+        assert result["output_path"] == "/tmp/run"
+        assert result["archive_path"] == "/tmp/archive"
+        assert result["postprocessing_script"] == "/tmp/post.sh --flag value"
+
+    def test_missing_path_entries_return_none(self, tmp_path):
+        xml_run = """
+        <config>
+            <entry id="RUN_TYPE" value="startup" />
+            <entry id="RUN_STARTDATE" value="2020-01-01" />
+        </config>
+        """
+        tmp_run = tmp_path / "env_run_missing_paths.xml"
+        tmp_run.write_text(xml_run)
+
+        result = parse_env_run(tmp_run)
+
+        assert result["output_path"] is None
+        assert result["archive_path"] is None
+        assert result["postprocessing_script"] is None
+
     def test_branch_uses_run_refdate(self, tmp_path):
         xml_run = """
         <config>

--- a/backend/tests/features/ingestion/test_api.py
+++ b/backend/tests/features/ingestion/test_api.py
@@ -28,6 +28,7 @@ from app.features.ingestion.models import Ingestion
 from app.features.ingestion.parsers.parser import ArchiveValidationError
 from app.features.ingestion.parsers.types import ParsedSimulation
 from app.features.machine.models import Machine
+from app.features.simulation.enums import ArtifactKind
 from app.features.simulation.models import Case, Simulation
 from app.features.simulation.schemas import SimulationCreate
 from app.features.user.manager import current_active_user
@@ -731,6 +732,73 @@ class TestIngestFromUploadEndpoint:
         # Should either reject or handle gracefully
         assert res.status_code in [400, 422]
 
+    def test_upload_persists_remote_hpc_path_artifacts_as_metadata(
+        self, client, db: Session
+    ):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        file = BytesIO(b"PK\x03\x04")
+        execution_id = "1083010.260305-120010"
+        parsed_simulations = [
+            ParsedSimulation(
+                execution_dir="/tmp/uploaded/archive/case/1083010.260305-120010",
+                execution_id=execution_id,
+                case_name="v3.LR.historical_0121",
+                case_group=None,
+                machine=machine.name,
+                hpc_username="ac.golaz",
+                compset="FHIST",
+                compset_alias="test_alias",
+                grid_name="grid1",
+                grid_resolution="0.9x1.25",
+                campaign="v3.LR.historical",
+                experiment_type="historical",
+                initialization_type="branch",
+                simulation_start_date="2020-01-01",
+                simulation_end_date=None,
+                run_start_date=None,
+                run_end_date=None,
+                compiler="gnu",
+                git_repository_url="https://github.com/E3SM-Project/E3SM.git",
+                git_branch="main",
+                git_tag="v3",
+                git_commit_hash="abc123",
+                status="completed",
+                output_path="/lcrc/group/e3sm/run",
+                archive_path="/lcrc/group/e3sm/archive",
+                case_root="/lcrc/group/e3sm/case_scripts",
+                postprocessing_script="/global/homes/a/ac.golaz/post.sh --flag value",
+            )
+        ]
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(parsed_simulations, 0),
+        ):
+            res = client.post(
+                f"{API_BASE}/ingestions/from-upload",
+                data={"machine_name": machine.name},
+                files={"file": ("remote-paths.zip", file, "application/zip")},
+            )
+
+        assert res.status_code == 201
+        simulation = (
+            db.query(Simulation).filter(Simulation.execution_id == execution_id).first()
+        )
+        assert simulation is not None
+        by_kind = {artifact.kind: artifact.uri for artifact in simulation.artifacts}
+        assert by_kind[ArtifactKind.OUTPUT] == "/lcrc/group/e3sm/run"
+        assert by_kind[ArtifactKind.ARCHIVE] == "/lcrc/group/e3sm/archive"
+        assert (
+            by_kind[ArtifactKind.RUN_SCRIPT]
+            == "/lcrc/group/e3sm/case_scripts/.case.run"
+        )
+        assert (
+            by_kind[ArtifactKind.POSTPROCESS_SCRIPT]
+            == "/global/homes/a/ac.golaz/post.sh"
+        )
+
     def test_path_endpoint_handles_lookup_error(self, client, db: Session, tmp_path):
         """Test that LookupError is handled with 400 response."""
         machine = db.query(Machine).first()
@@ -747,6 +815,70 @@ class TestIngestFromUploadEndpoint:
 
         assert res.status_code == 400
         assert res.json()["detail"] == "Machine not found"
+
+    def test_path_endpoint_persists_remote_hpc_path_artifacts_as_metadata(
+        self, client, db: Session, tmp_path
+    ):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        archive_path = self._create_archive_file(tmp_path, "remote-paths.tar.gz")
+        payload = {"archive_path": str(archive_path), "machine_name": machine.name}
+        execution_id = "1083011.260305-120011"
+        parsed_simulations = [
+            ParsedSimulation(
+                execution_dir=str(tmp_path / "archive" / "case" / execution_id),
+                execution_id=execution_id,
+                case_name="v3.LR.historical_0121",
+                case_group=None,
+                machine=machine.name,
+                hpc_username="ac.golaz",
+                compset="FHIST",
+                compset_alias="test_alias",
+                grid_name="grid1",
+                grid_resolution="0.9x1.25",
+                campaign="v3.LR.historical",
+                experiment_type="historical",
+                initialization_type="branch",
+                simulation_start_date="2020-01-01",
+                simulation_end_date=None,
+                run_start_date=None,
+                run_end_date=None,
+                compiler="gnu",
+                git_repository_url="https://github.com/E3SM-Project/E3SM.git",
+                git_branch="main",
+                git_tag="v3",
+                git_commit_hash="abc123",
+                status="completed",
+                output_path="/pscratch/sd/a/ac.golaz/run",
+                archive_path="/pscratch/sd/a/ac.golaz/archive",
+                case_root="/pscratch/sd/a/ac.golaz/case_scripts",
+                postprocessing_script="/pscratch/sd/a/ac.golaz/post.sh --flag value",
+            )
+        ]
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(parsed_simulations, 0),
+        ):
+            res = client.post(f"{API_BASE}/ingestions/from-path", json=payload)
+
+        assert res.status_code == 201
+        simulation = (
+            db.query(Simulation).filter(Simulation.execution_id == execution_id).first()
+        )
+        assert simulation is not None
+        by_kind = {artifact.kind: artifact.uri for artifact in simulation.artifacts}
+        assert by_kind[ArtifactKind.OUTPUT] == "/pscratch/sd/a/ac.golaz/run"
+        assert by_kind[ArtifactKind.ARCHIVE] == "/pscratch/sd/a/ac.golaz/archive"
+        assert (
+            by_kind[ArtifactKind.RUN_SCRIPT]
+            == "/pscratch/sd/a/ac.golaz/case_scripts/.case.run"
+        )
+        assert (
+            by_kind[ArtifactKind.POSTPROCESS_SCRIPT]
+            == "/pscratch/sd/a/ac.golaz/post.sh"
+        )
 
     def test_path_endpoint_handles_generic_exception(
         self, client, db: Session, tmp_path
@@ -1224,6 +1356,33 @@ class TestIngestionApiCoverage:
                 _run_ingest_archive("/tmp/archive.tar.gz", "/tmp", db)
 
         assert exc_info.value.status_code == 400
+
+    def test_run_ingest_archive_forwards_strict_validation(self, db: Session):
+        expected_result = IngestArchiveResult(
+            simulations=[],
+            created_count=0,
+            duplicate_count=0,
+            errors=[],
+        )
+
+        with patch(
+            "app.features.ingestion.api.ingest_archive",
+            return_value=expected_result,
+        ) as mock_ingest_archive:
+            result = _run_ingest_archive(
+                "/tmp/archive.tar.gz",
+                "/tmp",
+                db,
+                strict_validation=True,
+            )
+
+        assert result == expected_result
+        mock_ingest_archive.assert_called_once_with(
+            archive_path="/tmp/archive.tar.gz",
+            output_dir="/tmp",
+            db=db,
+            strict_validation=True,
+        )
 
     def test_run_ingest_archive_handles_archive_validation_error(self, db: Session):
         validation_errors = [

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pathlib import Path
+from typing import Mapping
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
@@ -28,14 +29,14 @@ from app.features.ingestion.models import (
 from app.features.ingestion.parsers.types import ParsedSimulation
 from app.features.machine.models import Machine
 from app.features.simulation.config_delta import SimulationConfigSnapshot
-from app.features.simulation.enums import SimulationStatus, SimulationType
+from app.features.simulation.enums import ArtifactKind, SimulationStatus, SimulationType
 from app.features.simulation.models import Case, Simulation
 from app.features.simulation.schemas import SimulationCreate
 from app.features.user.models import User
 
 
 def _parsed_simulations_from_mapping(
-    simulations_by_dir: dict[str, dict[str, str | None]],
+    simulations_by_dir: Mapping[str, Mapping[str, str | None]],
 ) -> list[ParsedSimulation]:
     parsed_simulations: list[ParsedSimulation] = []
 
@@ -65,13 +66,19 @@ def _parsed_simulations_from_mapping(
                 git_tag=metadata.get("git_tag"),
                 git_commit_hash=metadata.get("git_commit_hash"),
                 status=metadata.get("status"),
+                output_path=metadata.get("output_path"),
+                archive_path=metadata.get("archive_path"),
+                case_root=metadata.get("case_root"),
+                postprocessing_script=metadata.get("postprocessing_script"),
             )
         )
 
     return parsed_simulations
 
 
-def _require_execution_id(metadata: dict[str, str | None], execution_dir: str) -> str:
+def _require_execution_id(
+    metadata: Mapping[str, str | None], execution_dir: str
+) -> str:
     execution_id = metadata.get("execution_id")
     if not execution_id:
         raise AssertionError(
@@ -119,7 +126,7 @@ class TestIngestArchive:
         """Test that ingest_archive returns list of SimulationCreate objects."""
         machine = self._create_machine(db, "test-machine")
 
-        mock_simulations = {
+        mock_simulations: dict[str, dict[str, str | None]] = {
             "/path/to/1081156.251218-200923": {
                 "execution_id": "1081156.251218-200923",
                 "case_name": "case1",
@@ -167,7 +174,7 @@ class TestIngestArchive:
         """Test ingesting archive with multiple simulations."""
         machine = self._create_machine(db, "test-machine")
 
-        mock_simulations = {
+        mock_simulations: dict[str, dict[str, str | None]] = {
             "/path/to/1081157.251218-200924": {
                 "execution_id": "1081157.251218-200924",
                 "case_name": "case1",
@@ -2345,3 +2352,117 @@ class TestIngestHelpers:
         assert draft.git_repository_url == "https://github.com/E3SM-Project/E3SM.git"
         assert draft.simulation_start_date is not None
         assert draft.run_start_date is not None
+
+    def test_ingest_maps_path_artifacts_for_existing_paths(
+        self, db: Session, tmp_path: Path
+    ) -> None:
+        machine = Machine(
+            name="artifact-machine",
+            site="Test Site",
+            architecture="x86_64",
+            scheduler="SLURM",
+            gpu=False,
+        )
+        db.add(machine)
+        db.commit()
+        db.refresh(machine)
+
+        output_path = tmp_path / "run"
+        output_path.mkdir()
+        archive_path = tmp_path / "archive"
+        archive_path.mkdir()
+        case_root = tmp_path / "case_root"
+        case_root.mkdir()
+        run_script = case_root / ".case.run"
+        run_script.write_text("#!/bin/sh\n")
+        post_script = tmp_path / "post.sh"
+        post_script.write_text("#!/bin/sh\n")
+
+        mock_simulations = {
+            "/path/to/1082010.260305-120010": {
+                "execution_id": "1082010.260305-120010",
+                "case_name": "case-artifacts",
+                "compset": "FHIST",
+                "compset_alias": "test_alias",
+                "grid_name": "grid1",
+                "grid_resolution": "0.9x1.25",
+                "machine": machine.name,
+                "simulation_start_date": "2020-01-01",
+                "initialization_type": "test",
+                "status": "completed",
+                "output_path": str(output_path),
+                "archive_path": str(archive_path),
+                "case_root": str(case_root),
+                "postprocessing_script": f"{post_script} --flag value",
+            }
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            ingest_result = ingest_archive(
+                Path("/tmp/archive.zip"), Path("/tmp/out"), db
+            )
+
+        assert len(ingest_result.simulations) == 1
+        simulation = ingest_result.simulations[0]
+        assert len(simulation.artifacts) == 4
+
+        by_kind = {artifact.kind: artifact.uri for artifact in simulation.artifacts}
+        assert by_kind[ArtifactKind.OUTPUT] == str(output_path)
+        assert by_kind[ArtifactKind.ARCHIVE] == str(archive_path)
+        assert by_kind[ArtifactKind.RUN_SCRIPT] == str(run_script)
+        assert by_kind[ArtifactKind.POSTPROCESS_SCRIPT] == str(post_script)
+
+    def test_ingest_omits_missing_path_artifacts_and_warns(
+        self, db: Session, tmp_path: Path
+    ) -> None:
+        machine = Machine(
+            name="missing-artifact-machine",
+            site="Test Site",
+            architecture="x86_64",
+            scheduler="SLURM",
+            gpu=False,
+        )
+        db.add(machine)
+        db.commit()
+        db.refresh(machine)
+
+        missing_output = tmp_path / "missing-run"
+        missing_archive = tmp_path / "missing-archive"
+        missing_case_root = tmp_path / "missing-case-root"
+        missing_post_script = tmp_path / "missing-post.sh"
+
+        mock_simulations = {
+            "/path/to/1082011.260305-120011": {
+                "execution_id": "1082011.260305-120011",
+                "case_name": "case-missing-artifacts",
+                "compset": "FHIST",
+                "compset_alias": "test_alias",
+                "grid_name": "grid1",
+                "grid_resolution": "0.9x1.25",
+                "machine": machine.name,
+                "simulation_start_date": "2020-01-01",
+                "initialization_type": "test",
+                "status": "completed",
+                "output_path": str(missing_output),
+                "archive_path": str(missing_archive),
+                "case_root": str(missing_case_root),
+                "postprocessing_script": f"{missing_post_script} --foo",
+            }
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            with patch("app.features.ingestion.ingest.logger.warning") as mock_warning:
+                ingest_result = ingest_archive(
+                    Path("/tmp/archive.zip"), Path("/tmp/out"), db
+                )
+
+        assert len(ingest_result.simulations) == 1
+        simulation = ingest_result.simulations[0]
+        assert simulation.artifacts == []
+        assert mock_warning.call_count >= 4

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -2415,8 +2415,59 @@ class TestIngestHelpers:
         assert by_kind[ArtifactKind.RUN_SCRIPT] == str(run_script)
         assert by_kind[ArtifactKind.POSTPROCESS_SCRIPT] == str(post_script)
 
-    def test_ingest_omits_missing_path_artifacts_and_warns(
-        self, db: Session, tmp_path: Path
+    def test_ingest_metadata_only_preserves_relative_path_artifacts(
+        self, db: Session
+    ) -> None:
+        machine = Machine(
+            name="metadata-only-artifact-machine",
+            site="Test Site",
+            architecture="x86_64",
+            scheduler="SLURM",
+            gpu=False,
+        )
+        db.add(machine)
+        db.commit()
+        db.refresh(machine)
+
+        mock_simulations = {
+            "/path/to/1082010.260305-120010": {
+                "execution_id": "1082010.260305-120010",
+                "case_name": "case-artifacts",
+                "compset": "FHIST",
+                "compset_alias": "test_alias",
+                "grid_name": "grid1",
+                "grid_resolution": "0.9x1.25",
+                "machine": machine.name,
+                "simulation_start_date": "2020-01-01",
+                "initialization_type": "test",
+                "status": "completed",
+                "output_path": "run",
+                "archive_path": "archive",
+                "case_root": "case_root",
+                "postprocessing_script": "scripts/post.sh --flag value",
+            }
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            ingest_result = ingest_archive(
+                Path("/tmp/archive.zip"), Path("/tmp/out"), db
+            )
+
+        assert len(ingest_result.simulations) == 1
+        by_kind = {
+            artifact.kind: artifact.uri
+            for artifact in ingest_result.simulations[0].artifacts
+        }
+        assert by_kind[ArtifactKind.OUTPUT] == "run"
+        assert by_kind[ArtifactKind.ARCHIVE] == "archive"
+        assert by_kind[ArtifactKind.RUN_SCRIPT] == "case_root/.case.run"
+        assert by_kind[ArtifactKind.POSTPROCESS_SCRIPT] == "scripts/post.sh"
+
+    def test_ingest_metadata_only_preserves_missing_remote_like_paths(
+        self, db: Session
     ) -> None:
         machine = Machine(
             name="missing-artifact-machine",
@@ -2428,11 +2479,6 @@ class TestIngestHelpers:
         db.add(machine)
         db.commit()
         db.refresh(machine)
-
-        missing_output = tmp_path / "missing-run"
-        missing_archive = tmp_path / "missing-archive"
-        missing_case_root = tmp_path / "missing-case-root"
-        missing_post_script = tmp_path / "missing-post.sh"
 
         mock_simulations = {
             "/path/to/1082011.260305-120011": {
@@ -2446,10 +2492,10 @@ class TestIngestHelpers:
                 "simulation_start_date": "2020-01-01",
                 "initialization_type": "test",
                 "status": "completed",
-                "output_path": str(missing_output),
-                "archive_path": str(missing_archive),
-                "case_root": str(missing_case_root),
-                "postprocessing_script": f"{missing_post_script} --foo",
+                "output_path": "/lcrc/group/e3sm/missing-run",
+                "archive_path": "/lcrc/group/e3sm/missing-archive",
+                "case_root": "/lcrc/group/e3sm/missing-case-root",
+                "postprocessing_script": "/global/homes/a/ac.golaz/missing-post.sh --foo",
             }
         }
 
@@ -2463,6 +2509,18 @@ class TestIngestHelpers:
                 )
 
         assert len(ingest_result.simulations) == 1
-        simulation = ingest_result.simulations[0]
-        assert simulation.artifacts == []
-        assert mock_warning.call_count >= 4
+        by_kind = {
+            artifact.kind: artifact.uri
+            for artifact in ingest_result.simulations[0].artifacts
+        }
+        assert by_kind[ArtifactKind.OUTPUT] == "/lcrc/group/e3sm/missing-run"
+        assert by_kind[ArtifactKind.ARCHIVE] == "/lcrc/group/e3sm/missing-archive"
+        assert (
+            by_kind[ArtifactKind.RUN_SCRIPT]
+            == "/lcrc/group/e3sm/missing-case-root/.case.run"
+        )
+        assert (
+            by_kind[ArtifactKind.POSTPROCESS_SCRIPT]
+            == "/global/homes/a/ac.golaz/missing-post.sh"
+        )
+        mock_warning.assert_not_called()

--- a/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
@@ -10,9 +10,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import {
-  suppressNextBrowseInteraction,
-} from '@/features/browse/components/SimulationResults/selectionGuard';
+import { suppressNextBrowseInteraction } from '@/features/browse/components/SimulationResults/selectionGuard';
+import { getArtifactsByKind } from '@/types/artifact';
 import type { SimulationOut } from '@/types/index';
 
 interface SimulationBrowseDetailsDialogProps {
@@ -54,12 +53,26 @@ export const SimulationBrowseDetailsDialog = ({
   const updatedAtStr = new Date(simulation.updatedAt).toISOString().slice(0, 10);
   const diagnosticLinks = simulation.groupedLinks.diagnostic ?? [];
   const performanceLinks = simulation.groupedLinks.performance ?? [];
-  const runScripts = simulation.groupedArtifacts.runScript ?? [];
-  const archivePaths = simulation.groupedArtifacts.archive ?? [];
-  const postprocessingScripts =
-    simulation.groupedArtifacts.postProcessingScript ??
-    simulation.groupedArtifacts.postprocessingScript ??
-    [];
+  const outputPaths = getArtifactsByKind(
+    simulation.artifacts,
+    simulation.groupedArtifacts,
+    'output',
+  );
+  const archivePaths = getArtifactsByKind(
+    simulation.artifacts,
+    simulation.groupedArtifacts,
+    'archive',
+  );
+  const runScripts = getArtifactsByKind(
+    simulation.artifacts,
+    simulation.groupedArtifacts,
+    'run_script',
+  );
+  const postprocessingScripts = getArtifactsByKind(
+    simulation.artifacts,
+    simulation.groupedArtifacts,
+    'postprocessing_script',
+  );
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -88,7 +101,8 @@ export const SimulationBrowseDetailsDialog = ({
           <DialogHeader className="border-b border-slate-200 px-6 py-5 text-left">
             <DialogTitle className="text-xl text-slate-950">{simulation.executionId}</DialogTitle>
             <DialogDescription className="mt-2 text-sm leading-6 text-slate-600">
-              Additional browse details for <span className="font-medium">{simulation.caseName}</span>.
+              Additional browse details for{' '}
+              <span className="font-medium">{simulation.caseName}</span>.
             </DialogDescription>
           </DialogHeader>
 
@@ -346,7 +360,8 @@ export const SimulationBrowseDetailsDialog = ({
               </section>
             )}
 
-            {(runScripts.length > 0 ||
+            {(outputPaths.length > 0 ||
+              runScripts.length > 0 ||
               archivePaths.length > 0 ||
               postprocessingScripts.length > 0) && (
               <section className="space-y-3">
@@ -354,15 +369,29 @@ export const SimulationBrowseDetailsDialog = ({
                   Artifact Paths
                 </h3>
                 <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
+                  {outputPaths.length > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                        Output Paths
+                      </p>
+                      <ul className="mt-2 space-y-2 text-sm text-slate-700">
+                        {outputPaths.map((item) => (
+                          <li key={item.id} className="break-all">
+                            {item.label ?? item.uri}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
                   {runScripts.length > 0 && (
                     <div>
                       <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
                         Run Scripts
                       </p>
                       <ul className="mt-2 space-y-2 text-sm text-slate-700">
-                        {runScripts.map((item, index) => (
-                          <li key={index} className="break-all">
-                            {typeof item === 'string' ? item : (item.label ?? item.uri)}
+                        {runScripts.map((item) => (
+                          <li key={item.id} className="break-all">
+                            {item.label ?? item.uri}
                           </li>
                         ))}
                       </ul>
@@ -374,9 +403,9 @@ export const SimulationBrowseDetailsDialog = ({
                         Archive Paths
                       </p>
                       <ul className="mt-2 space-y-2 text-sm text-slate-700">
-                        {archivePaths.map((item, index) => (
-                          <li key={index} className="break-all">
-                            {typeof item === 'string' ? item : (item.label ?? item.uri)}
+                        {archivePaths.map((item) => (
+                          <li key={item.id} className="break-all">
+                            {item.label ?? item.uri}
                           </li>
                         ))}
                       </ul>
@@ -388,9 +417,9 @@ export const SimulationBrowseDetailsDialog = ({
                         Postprocessing Scripts
                       </p>
                       <ul className="mt-2 space-y-2 text-sm text-slate-700">
-                        {postprocessingScripts.map((item, index) => (
-                          <li key={index} className="break-all">
-                            {typeof item === 'string' ? item : (item.label ?? item.uri)}
+                        {postprocessingScripts.map((item) => (
+                          <li key={item.id} className="break-all">
+                            {item.label ?? item.uri}
                           </li>
                         ))}
                       </ul>

--- a/frontend/src/features/compare/ComparePage.tsx
+++ b/frontend/src/features/compare/ComparePage.tsx
@@ -6,6 +6,7 @@ import { TableCellText } from '@/components/ui/table-cell-text';
 import { AIFloatingButton } from '@/features/compare/components/AIFloatingButton';
 import CompareToolbar from '@/features/compare/components/CompareToolbar';
 import { norm, renderCellValue } from '@/features/compare/utils';
+import { type ArtifactKind, getArtifactsByKind } from '@/types/artifact';
 import type { SimulationOut } from '@/types/index';
 import { formatDate, getSimulationDuration } from '@/utils/utils';
 
@@ -86,7 +87,22 @@ export const ComparePage = ({
     return { label, values, renderMode };
   };
 
-  const makeGroupedMetricRow = (
+  const makeArtifactMetricRow = (
+    label: string,
+    kind: ArtifactKind,
+    fallback: unknown[] = [],
+  ): CompareMetricRow => {
+    const values = selectedSimulationIds.map((id) => {
+      const sim = selectedSimulations.find((s) => s.id === id);
+      if (!sim) return fallback;
+
+      return getArtifactsByKind(sim.artifacts, sim.groupedArtifacts, kind);
+    });
+
+    return { label, values };
+  };
+
+  const makeGroupedLinkMetricRow = (
     label: string,
     kind: string,
     fallback: unknown[] = [],
@@ -95,7 +111,7 @@ export const ComparePage = ({
       const sim = selectedSimulations.find((s) => s.id === id);
       if (!sim) return fallback;
 
-      return sim.groupedArtifacts[kind] ?? sim.groupedLinks[kind] ?? fallback;
+      return sim.groupedLinks[kind] ?? fallback;
     });
 
     return { label, values };
@@ -185,13 +201,13 @@ export const ComparePage = ({
     keyFeatures: [makeMetricRow('Key Features', 'keyFeatures', '')],
     knownIssues: [makeMetricRow('Known Issues', 'knownIssues', '')],
     locations: [
-      makeGroupedMetricRow('Output Paths', 'output'),
-      makeGroupedMetricRow('Archive Paths', 'archive'),
-      makeGroupedMetricRow('Run Script Paths', 'runScript'),
-      makeGroupedMetricRow('Batch Logs', 'batchLog'),
+      makeArtifactMetricRow('Output Paths', 'output'),
+      makeArtifactMetricRow('Archive Paths', 'archive'),
+      makeArtifactMetricRow('Run Script Paths', 'run_script'),
+      makeArtifactMetricRow('Post-processing Scripts', 'postprocessing_script'),
     ],
-    diagnostics: [makeGroupedMetricRow('Diagnostic Links', 'diagnostic')],
-    performance: [makeGroupedMetricRow('PACE Links', 'performance')],
+    diagnostics: [makeGroupedLinkMetricRow('Diagnostic Links', 'diagnostic')],
+    performance: [makeGroupedLinkMetricRow('PACE Links', 'performance')],
     notes: [makeMetricRow('Notes', 'notesMarkdown', '')],
     versionControl: [
       makeMetricRow('Repository URL', 'gitRepositoryUrl', '', 'rich'),
@@ -292,9 +308,10 @@ export const ComparePage = ({
     }
 
     const lines =
-      sectionKey === 'notes' || sectionKey === 'keyFeatures' || sectionKey === 'knownIssues' ? 3 : 2;
-    const textValue =
-      value === null || value === undefined || value === '' ? '—' : String(value);
+      sectionKey === 'notes' || sectionKey === 'keyFeatures' || sectionKey === 'knownIssues'
+        ? 3
+        : 2;
+    const textValue = value === null || value === undefined || value === '' ? '—' : String(value);
 
     return <TableCellText value={textValue} lines={lines} fullValueMode="tooltip" />;
   };

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -6,11 +6,7 @@ import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
@@ -22,6 +18,7 @@ import { SimulationPathCard } from '@/features/simulations/components/Simulation
 import { SimulationTypeBadge } from '@/features/simulations/components/SimulationTypeBadge';
 import { cn } from '@/lib/utils';
 import type { SimulationOut } from '@/types';
+import { getArtifactsByKind } from '@/types/artifact';
 import { formatDate, getSimulationDuration } from '@/utils/utils';
 
 // -------------------- Types --------------------
@@ -74,13 +71,7 @@ const formatDisplayValue = (value: unknown) => {
   }
 };
 
-const ReadonlyTextBlock = ({
-  value,
-  className,
-}: {
-  value?: string | null;
-  className?: string;
-}) => (
+const ReadonlyTextBlock = ({ value, className }: { value?: string | null; className?: string }) => (
   <div
     className={cn(
       'min-h-[80px] whitespace-pre-wrap rounded-md border bg-muted/30 px-3 py-2 text-sm break-words',
@@ -113,26 +104,38 @@ export const SimulationDetailsView = ({
   const [isAdvancedMetadataOpen, setIsAdvancedMetadataOpen] = useState(false);
   const [notes, setNotes] = useState(simulation.notesMarkdown || '');
   const performanceLinks = simulation.groupedLinks.performance ?? [];
-  const outputArtifacts =
-    simulation.groupedArtifacts.output?.map((artifact) => ({
-      url: artifact.uri,
-      label: artifact.label?.trim() || artifact.uri,
-    })) ?? [];
-  const archiveArtifacts =
-    simulation.groupedArtifacts.archive?.map((artifact) => ({
-      url: artifact.uri,
-      label: artifact.label?.trim() || artifact.uri,
-    })) ?? [];
-  const runScriptArtifacts =
-    simulation.groupedArtifacts.run_script?.map((artifact) => ({
-      url: artifact.uri,
-      label: artifact.label?.trim() || artifact.uri,
-    })) ?? [];
-  const postprocessingScriptArtifacts =
-    simulation.groupedArtifacts.postprocessing_script?.map((artifact) => ({
-      url: artifact.uri,
-      label: artifact.label?.trim() || artifact.uri,
-    })) ?? [];
+  const outputArtifacts = getArtifactsByKind(
+    simulation.artifacts,
+    simulation.groupedArtifacts,
+    'output',
+  ).map((artifact) => ({
+    url: artifact.uri,
+    label: artifact.label?.trim() || artifact.uri,
+  }));
+  const archiveArtifacts = getArtifactsByKind(
+    simulation.artifacts,
+    simulation.groupedArtifacts,
+    'archive',
+  ).map((artifact) => ({
+    url: artifact.uri,
+    label: artifact.label?.trim() || artifact.uri,
+  }));
+  const runScriptArtifacts = getArtifactsByKind(
+    simulation.artifacts,
+    simulation.groupedArtifacts,
+    'run_script',
+  ).map((artifact) => ({
+    url: artifact.uri,
+    label: artifact.label?.trim() || artifact.uri,
+  }));
+  const postprocessingScriptArtifacts = getArtifactsByKind(
+    simulation.artifacts,
+    simulation.groupedArtifacts,
+    'postprocessing_script',
+  ).map((artifact) => ({
+    url: artifact.uri,
+    label: artifact.label?.trim() || artifact.uri,
+  }));
 
   // Temporary local-only comments
   const [newComment, setNewComment] = useState('');
@@ -251,9 +254,7 @@ export const SimulationDetailsView = ({
                 </FieldRow>
                 {simulation.description && (
                   <div className="pt-2">
-                    <Label className="text-xs text-muted-foreground mb-1 block">
-                      Description
-                    </Label>
+                    <Label className="text-xs text-muted-foreground mb-1 block">Description</Label>
                     <ReadonlyTextBlock value={simulation.description} />
                   </div>
                 )}
@@ -332,9 +333,7 @@ export const SimulationDetailsView = ({
                     </table>
                   </div>
                 ) : (
-                  <p className="text-sm text-muted-foreground">
-                    No configuration differences.
-                  </p>
+                  <p className="text-sm text-muted-foreground">No configuration differences.</p>
                 )}
               </CardContent>
             </Card>
@@ -453,9 +452,7 @@ export const SimulationDetailsView = ({
                   )}
                 </div>
                 <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">
-                    Machine ID:
-                  </Label>
+                  <Label className="text-xs text-muted-foreground min-w-[100px]">Machine ID:</Label>
                   <ReadonlyInput
                     value={
                       simulation.machineId
@@ -526,17 +523,13 @@ export const SimulationDetailsView = ({
               <CardContent className="space-y-4">
                 {simulation.keyFeatures && (
                   <div>
-                    <Label className="text-xs text-muted-foreground mb-1 block">
-                      Key Features
-                    </Label>
+                    <Label className="text-xs text-muted-foreground mb-1 block">Key Features</Label>
                     <ReadonlyTextBlock value={simulation.keyFeatures} />
                   </div>
                 )}
                 {simulation.knownIssues && (
                   <div>
-                    <Label className="text-xs text-muted-foreground mb-1 block">
-                      Known Issues
-                    </Label>
+                    <Label className="text-xs text-muted-foreground mb-1 block">Known Issues</Label>
                     <ReadonlyTextBlock value={simulation.knownIssues} />
                   </div>
                 )}
@@ -546,10 +539,7 @@ export const SimulationDetailsView = ({
 
           {/* Advanced Metadata (Collapsible) */}
           {simulation.extra && Object.keys(simulation.extra).length > 0 && (
-            <Collapsible
-              open={isAdvancedMetadataOpen}
-              onOpenChange={setIsAdvancedMetadataOpen}
-            >
+            <Collapsible open={isAdvancedMetadataOpen} onOpenChange={setIsAdvancedMetadataOpen}>
               <Card>
                 <CardHeader className="pb-2">
                   <CollapsibleTrigger className="flex w-full items-center justify-between [&[data-state=open]>svg]:rotate-180">
@@ -709,8 +699,8 @@ export const SimulationDetailsView = ({
                                   </button>
                                 </TooltipTrigger>
                                 <TooltipContent>
-                                  Direct PACE experiment link not found. Search results may
-                                  still contain this run.
+                                  Direct PACE experiment link not found. Search results may still
+                                  contain this run.
                                 </TooltipContent>
                               </Tooltip>
                             </TooltipProvider>

--- a/frontend/src/features/simulations/components/SimulationPathCard.tsx
+++ b/frontend/src/features/simulations/components/SimulationPathCard.tsx
@@ -1,5 +1,5 @@
 import { TooltipTrigger } from '@radix-ui/react-tooltip';
-import { Archive, ClipboardList, FileText, Info, Link2, Package } from 'lucide-react';
+import { Archive, ClipboardList, Copy, ExternalLink, FileText, Info, Package } from 'lucide-react';
 import React, { JSX } from 'react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -30,6 +30,16 @@ export const SimulationPathCard = ({
   description,
 }: SimulationPathCard) => {
   const hasPaths = paths && paths.length > 0;
+  const copyPath = async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      // Clipboard access is best-effort for local path convenience.
+    }
+  };
+
+  const isExternalPath = (value: string) =>
+    value.startsWith('http://') || value.startsWith('https://') || value.startsWith('file:');
 
   return (
     <Card
@@ -70,16 +80,31 @@ export const SimulationPathCard = ({
               const url = typeof path === 'string' ? path : path.url;
               const label = typeof path === 'string' ? path : path.label;
               return (
-                <li key={url || label} className="flex items-center gap-2">
-                  <a
-                    className="text-blue-600 hover:underline flex items-center gap-1"
-                    href={url}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    <Link2 size={16} className="inline-block" />
-                    {label}
-                  </a>
+                <li key={url || label} className="flex items-start gap-2">
+                  {isExternalPath(url) ? (
+                    <a
+                      className="text-blue-600 hover:underline flex items-center gap-1 break-all"
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <ExternalLink size={16} className="inline-block shrink-0" />
+                      {label}
+                    </a>
+                  ) : (
+                    <div className="flex items-start gap-2 text-foreground">
+                      <code className="break-all rounded bg-muted px-2 py-1 text-xs">{label}</code>
+                      <button
+                        type="button"
+                        onClick={() => copyPath(url)}
+                        className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                        aria-label="Copy path"
+                        title="Copy full path"
+                      >
+                        <Copy size={14} />
+                      </button>
+                    </div>
+                  )}
                 </li>
               );
             })}

--- a/frontend/src/types/artifact.ts
+++ b/frontend/src/types/artifact.ts
@@ -25,3 +25,23 @@ export interface ArtifactOut extends ArtifactIn {
   createdAt: string; // ISO datetime
   updatedAt: string; // ISO datetime
 }
+
+const ARTIFACT_GROUP_KEYS: Record<ArtifactKind, string[]> = {
+  output: ['output'],
+  archive: ['archive'],
+  run_script: ['run_script', 'runScript'],
+  postprocessing_script: ['postprocessing_script', 'postprocessingScript', 'postProcessingScript'],
+};
+
+export const getArtifactsByKind = (
+  artifacts: ArtifactOut[],
+  groupedArtifacts: Record<string, ArtifactOut[]>,
+  kind: ArtifactKind,
+): ArtifactOut[] => {
+  for (const key of ARTIFACT_GROUP_KEYS[kind]) {
+    const grouped = groupedArtifacts[key];
+    if (grouped?.length) return grouped;
+  }
+
+  return artifacts.filter((artifact) => artifact.kind === kind);
+};


### PR DESCRIPTION
## Description

Adds issue #163 support for path-based artifacts by parsing values from CaseDocs XML, threading them through ingestion metadata, and preserving them as simulation artifacts during ingest.

Implemented behavior:
- Parse `CASEROOT` from `env_case.xml`
- Parse `RUNDIR`, `DOUT_S_ROOT`, and `POSTRUN_SCRIPT` from `env_run.xml`
- Derive run script artifact path as `${CASEROOT}/.case.run`
- Parse `POSTRUN_SCRIPT` with first-token extraction for the script path
- Preserve parsed path artifacts as WYSIWYG metadata for both `/ingestions/from-upload` and `/ingestions/from-path`
- Do not validate artifact paths on the API host; remote HPC filesystem paths are stored as provenance metadata
- Render output, archive, run-script, and postprocessing-script artifacts in the existing frontend details, browse, and compare surfaces
- Add parser, ingest, and API coverage for remote-path preservation and frontend-compatible artifact rendering

- Closes #163

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [x] Tests added or updated (if needed)
- [x] All tests pass (locally and CI/CD)
- [x] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)

No schema migration required.
No special deployment steps required.
