### PR TITLE
Add docs update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_update.yml
+++ b/.github/ISSUE_TEMPLATE/docs_update.yml
@@ -1,0 +1,39 @@
+name: Docs Update
+description: Report missing, wrong, stale, or unclear documentation.
+title: "[Docs]: "
+labels: ["type: doc"]
+assignees: []
+
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Doc location
+      description: Path, page, or link.
+      placeholder: docs/developer/README.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or missing?
+      description: Describe gap briefly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested update
+      description: Optional proposed wording or direction.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Extra context
+      description: Related links or examples.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Use this file for contribution workflow. For local setup, architecture, and deve
 Start from an issue when the work is not trivial.
 
 - bug reports: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- docs updates: `.github/ISSUE_TEMPLATE/docs_update.yml`
 - enhancements: `.github/ISSUE_TEMPLATE/enhancement_request.yml`
 - planning work: `.github/ISSUE_TEMPLATE/planning_task.yml`
 - DevOps work: `.github/ISSUE_TEMPLATE/devops.yml`


### PR DESCRIPTION
## Summary
- add a new GitHub issue template for documentation updates
- keep the form terse and OSS-friendly with only the key fields
- list the docs template in `CONTRIBUTING.md`

## Why
Contributors had issue flows for bugs, enhancements, planning, and DevOps, but no focused template for missing or stale documentation.

## Validation
- `make pre-commit-run`
