### PR TITLE
Fix post-login return redirect

### DIFF
--- a/backend/app/features/user/api/oauth.py
+++ b/backend/app/features/user/api/oauth.py
@@ -1,30 +1,148 @@
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
+from fastapi_users.authentication.strategy import Strategy
+from fastapi_users.exceptions import UserAlreadyExists
+from fastapi_users.manager import BaseUserManager
+from fastapi_users.router.oauth import (
+    STATE_TOKEN_AUDIENCE,
+    ErrorCode,
+    OAuth2AuthorizeResponse,
+    decode_jwt,
+    generate_state_token,
+)
+from httpx_oauth.integrations.fastapi import OAuth2AuthorizeCallback
 
 from app.core.config import settings
-from app.features.user.auth.oauth import GITHUB_OAUTH_BACKEND, GITHUB_OAUTH_CLIENT
+from app.features.user.auth.oauth import (
+    GITHUB_OAUTH_BACKEND,
+    GITHUB_OAUTH_CLIENT,
+    build_frontend_auth_redirect_url,
+    normalize_post_login_return_to,
+)
 from app.features.user.auth.token import JWT_BEARER_BACKEND
 from app.features.user.manager import (
     current_active_user,
     fastapi_users,
+    get_user_manager,
 )
 from app.features.user.schemas import UserRead, UserUpdate
 
 user_router = APIRouter(prefix="/users", tags=["users"])
 auth_router = APIRouter(prefix="/auth", tags=["auth"])
+oauth2_authorize_callback = OAuth2AuthorizeCallback(
+    GITHUB_OAUTH_CLIENT,
+    redirect_url=settings.github_redirect_url,
+)
+
 
 # --- GitHub OAuth Routes ---
-auth_router.include_router(
-    fastapi_users.get_oauth_router(
-        GITHUB_OAUTH_CLIENT,
-        GITHUB_OAUTH_BACKEND,
-        state_secret=settings.github_state_secret_key,
-        redirect_url=settings.github_redirect_url,
-        associate_by_email=True,
-        is_verified_by_default=True,
-    ),
-    prefix="/github",
+@auth_router.get(
+    "/github/authorize",
+    name="oauth:github.github.authorize",
+    response_model=OAuth2AuthorizeResponse,
 )
+async def github_authorize(
+    return_to: str | None = Query(default=None),
+    scopes: list[str] | None = Query(default=None),
+) -> OAuth2AuthorizeResponse:
+    state_data: dict[str, str] = {}
+    normalized_return_to = normalize_post_login_return_to(return_to)
+    if normalized_return_to is not None:
+        state_data["return_to"] = normalized_return_to
+
+    state = generate_state_token(state_data, settings.github_state_secret_key)
+    authorization_url = await GITHUB_OAUTH_CLIENT.get_authorization_url(
+        settings.github_redirect_url,
+        state,
+        scopes,
+    )
+
+    return OAuth2AuthorizeResponse(authorization_url=authorization_url)
+
+
+@auth_router.get(
+    "/github/callback",
+    name="oauth:github.github.callback",
+    description="The response varies based on the authentication backend used.",
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "INVALID_STATE_TOKEN": {
+                            "summary": "Invalid state token.",
+                            "value": None,
+                        },
+                        ErrorCode.LOGIN_BAD_CREDENTIALS: {
+                            "summary": "User is inactive.",
+                            "value": {"detail": ErrorCode.LOGIN_BAD_CREDENTIALS},
+                        },
+                    }
+                }
+            }
+        },
+    },
+)
+async def github_callback(
+    request: Request,
+    access_token_state=Depends(oauth2_authorize_callback),  # noqa: B008
+    user_manager: BaseUserManager = Depends(get_user_manager),  # noqa: B008
+    strategy: Strategy = Depends(GITHUB_OAUTH_BACKEND.get_strategy),  # noqa: B008
+):
+    token, state = access_token_state
+    account_id, account_email = await GITHUB_OAUTH_CLIENT.get_id_email(
+        token["access_token"]
+    )
+
+    if account_email is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ErrorCode.OAUTH_NOT_AVAILABLE_EMAIL,
+        )
+
+    if state is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        state_data = decode_jwt(
+            state,
+            settings.github_state_secret_key,
+            [STATE_TOKEN_AUDIENCE],
+        )
+    except Exception as exc:  # pragma: no cover - library-specific decode failures
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST) from exc
+
+    try:
+        user = await user_manager.oauth_callback(
+            GITHUB_OAUTH_CLIENT.name,
+            token["access_token"],
+            account_id,
+            account_email,
+            token.get("expires_at"),
+            token.get("refresh_token"),
+            request,
+            associate_by_email=True,
+            is_verified_by_default=True,
+        )
+    except UserAlreadyExists as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ErrorCode.OAUTH_USER_ALREADY_EXISTS,
+        ) from exc
+
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ErrorCode.LOGIN_BAD_CREDENTIALS,
+        )
+
+    response = await GITHUB_OAUTH_BACKEND.login(strategy, user)
+    response.headers["location"] = build_frontend_auth_redirect_url(
+        state_data.get("return_to")
+    )
+    await user_manager.on_after_login(user, request, response)
+    return response
+
 
 # --- JWT Login Routes ---
 auth_router.include_router(

--- a/backend/app/features/user/api/oauth.py
+++ b/backend/app/features/user/api/oauth.py
@@ -16,8 +16,8 @@ from app.core.config import settings
 from app.features.user.auth.oauth import (
     GITHUB_OAUTH_BACKEND,
     GITHUB_OAUTH_CLIENT,
-    build_frontend_auth_redirect_url,
-    normalize_post_login_return_to,
+    _build_frontend_auth_redirect_url,
+    _normalize_post_login_return_to,
 )
 from app.features.user.auth.token import JWT_BEARER_BACKEND
 from app.features.user.manager import (
@@ -45,8 +45,22 @@ async def github_authorize(
     return_to: str | None = Query(default=None),
     scopes: list[str] | None = Query(default=None),
 ) -> OAuth2AuthorizeResponse:
+    """Initiate the GitHub OAuth flow by generating an authorization URL.
+
+    Parameters:
+    -----------
+    return_to : str | None
+        The URL to redirect to after login.
+    scopes : list[str] | None
+        The OAuth scopes to request.
+
+    Returns:
+    --------
+    OAuth2AuthorizeResponse
+        An object containing the GitHub authorization URL.
+    """
     state_data: dict[str, str] = {}
-    normalized_return_to = normalize_post_login_return_to(return_to)
+    normalized_return_to = _normalize_post_login_return_to(return_to)
     if normalized_return_to is not None:
         state_data["return_to"] = normalized_return_to
 
@@ -89,6 +103,28 @@ async def github_callback(
     user_manager: BaseUserManager = Depends(get_user_manager),  # noqa: B008
     strategy: Strategy = Depends(GITHUB_OAUTH_BACKEND.get_strategy),  # noqa: B008
 ):
+    """
+    Handle the GitHub OAuth callback by processing the access token and logging
+    in the user.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    access_token_state : tuple[dict, str | None]
+        A tuple containing the access token information and the state token.
+    user_manager : BaseUserManager
+        The user manager instance for handling user operations.
+    strategy : Strategy
+        The authentication strategy for logging in the user.
+
+    Returns
+    -------
+    Response
+        A response object that redirects the user to the frontend with the
+        appropriate authentication state.
+    """
+
     token, state = access_token_state
     account_id, account_email = await GITHUB_OAUTH_CLIENT.get_id_email(
         token["access_token"]
@@ -137,7 +173,7 @@ async def github_callback(
         )
 
     response = await GITHUB_OAUTH_BACKEND.login(strategy, user)
-    response.headers["location"] = build_frontend_auth_redirect_url(
+    response.headers["location"] = _build_frontend_auth_redirect_url(
         state_data.get("return_to")
     )
     await user_manager.on_after_login(user, request, response)

--- a/backend/app/features/user/auth/oauth.py
+++ b/backend/app/features/user/auth/oauth.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
 from fastapi import Response
 from fastapi.responses import RedirectResponse
 from fastapi_users.authentication import AuthenticationBackend, CookieTransport
@@ -5,6 +7,49 @@ from httpx_oauth.clients.github import GitHubOAuth2
 
 from app.core.config import settings
 from app.features.user.auth.utils import get_jwt_strategy
+
+DEFAULT_POST_LOGIN_REDIRECT_PATH = "/"
+
+
+def normalize_post_login_return_to(return_to: str | None) -> str | None:
+    if not return_to:
+        return None
+
+    try:
+        parsed = urlparse(return_to)
+    except ValueError:
+        return None
+
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+
+    target_origin = f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
+    if target_origin not in settings.frontend_origins_list:
+        return None
+
+    path = parsed.path or DEFAULT_POST_LOGIN_REDIRECT_PATH
+    if not path.startswith("/") or path.startswith("//"):
+        return None
+    if path == "/auth/callback":
+        return None
+
+    return return_to
+
+
+def build_frontend_auth_redirect_url(return_to: str | None = None) -> str:
+    redirect_url = settings.frontend_auth_redirect_url
+    normalized_return_to = normalize_post_login_return_to(return_to)
+    if normalized_return_to is None:
+        return redirect_url
+
+    parsed_redirect_url = urlparse(redirect_url)
+    query_pairs = parse_qsl(parsed_redirect_url.query, keep_blank_values=True)
+    query_pairs = [(key, value) for key, value in query_pairs if key != "return_to"]
+    query_pairs.append(("return_to", normalized_return_to))
+
+    return urlunparse(
+        parsed_redirect_url._replace(query=urlencode(query_pairs, doseq=True))
+    )
 
 
 class CustomCookieTransport(CookieTransport):
@@ -23,9 +68,7 @@ class CustomCookieTransport(CookieTransport):
         Returns:
             Response: The HTTP response with the cookie set and redirection.
         """
-        response = RedirectResponse(
-            settings.frontend_auth_redirect_url, status_code=302
-        )
+        response = RedirectResponse(build_frontend_auth_redirect_url(), status_code=302)
 
         return self._set_login_cookie(response, token)
 

--- a/backend/app/features/user/auth/oauth.py
+++ b/backend/app/features/user/auth/oauth.py
@@ -102,7 +102,7 @@ def _normalize_post_login_return_to(return_to: str | None) -> str | None:
     path = parsed.path or DEFAULT_POST_LOGIN_REDIRECT_PATH
     if not path.startswith("/") or path.startswith("//"):
         return None
-    if path == "/auth/callback":
+    if path == "/auth/callback" or path.startswith("/auth/callback/"):
         return None
 
     return return_to

--- a/backend/app/features/user/auth/oauth.py
+++ b/backend/app/features/user/auth/oauth.py
@@ -11,7 +11,79 @@ from app.features.user.auth.utils import get_jwt_strategy
 DEFAULT_POST_LOGIN_REDIRECT_PATH = "/"
 
 
-def normalize_post_login_return_to(return_to: str | None) -> str | None:
+class CustomCookieTransport(CookieTransport):
+    """Custom cookie transport to handle OAuth login responses."""
+
+    async def get_login_response(self, token: str) -> Response:
+        """Create a login response that sets the cookie and redirects to frontend.
+
+        The default response is a 204 with no content, which is not suitable for
+        OAuth flows where we need to redirect the user after login.
+
+        Source: https://github.com/fastapi-users/fastapi-users/issues/434#issuecomment-1881945184
+
+        Parameters
+        ----------
+        token : str
+            The JWT token to set in the cookie.
+        Returns
+        -------
+        Response
+            The HTTP response with the cookie set and redirection.
+        """
+        response = RedirectResponse(
+            _build_frontend_auth_redirect_url(), status_code=302
+        )
+
+        return self._set_login_cookie(response, token)
+
+
+def _build_frontend_auth_redirect_url(return_to: str | None = None) -> str:
+    """Build the URL to redirect to after successful OAuth login
+
+    Parameters
+    ----------
+    return_to : str | None
+        The URL to redirect to after login. If None, defaults to the frontend
+        URL.
+
+    Returns
+    -------
+    str
+        The URL to redirect to after login, with the optional return_to
+        parameter included.
+    """
+
+    redirect_url = settings.frontend_auth_redirect_url
+    normalized_return_to = _normalize_post_login_return_to(return_to)
+    if normalized_return_to is None:
+        return redirect_url
+
+    parsed_redirect_url = urlparse(redirect_url)
+    query_pairs = parse_qsl(parsed_redirect_url.query, keep_blank_values=True)
+    query_pairs = [(key, value) for key, value in query_pairs if key != "return_to"]
+    query_pairs.append(("return_to", normalized_return_to))
+
+    return urlunparse(
+        parsed_redirect_url._replace(query=urlencode(query_pairs, doseq=True))
+    )
+
+
+def _normalize_post_login_return_to(return_to: str | None) -> str | None:
+    """
+    Normalize and validate the 'return_to' URL parameter for post-login
+    redirection.
+
+    Parameters
+    ----------
+    return_to : str | None
+        The URL to redirect to after login. If None, defaults to the frontend URL.
+
+    Returns
+    -------
+    str | None
+        The normalized and validated 'return_to' URL, or None if invalid.
+    """
     if not return_to:
         return None
 
@@ -34,43 +106,6 @@ def normalize_post_login_return_to(return_to: str | None) -> str | None:
         return None
 
     return return_to
-
-
-def build_frontend_auth_redirect_url(return_to: str | None = None) -> str:
-    redirect_url = settings.frontend_auth_redirect_url
-    normalized_return_to = normalize_post_login_return_to(return_to)
-    if normalized_return_to is None:
-        return redirect_url
-
-    parsed_redirect_url = urlparse(redirect_url)
-    query_pairs = parse_qsl(parsed_redirect_url.query, keep_blank_values=True)
-    query_pairs = [(key, value) for key, value in query_pairs if key != "return_to"]
-    query_pairs.append(("return_to", normalized_return_to))
-
-    return urlunparse(
-        parsed_redirect_url._replace(query=urlencode(query_pairs, doseq=True))
-    )
-
-
-class CustomCookieTransport(CookieTransport):
-    """Custom cookie transport to handle OAuth login responses."""
-
-    async def get_login_response(self, token: str) -> Response:
-        """Create a login response that sets the cookie and redirects to frontend.
-
-        The default response is a 204 with no content, which is not suitable for
-        OAuth flows where we need to redirect the user after login.
-
-        Source: https://github.com/fastapi-users/fastapi-users/issues/434#issuecomment-1881945184
-
-        Parameters:
-            token (str): The JWT token to set in the cookie.
-        Returns:
-            Response: The HTTP response with the cookie set and redirection.
-        """
-        response = RedirectResponse(build_frontend_auth_redirect_url(), status_code=302)
-
-        return self._set_login_cookie(response, token)
 
 
 COOKIE_TRANSPORT = CustomCookieTransport(

--- a/backend/tests/features/user/api/test_oauth.py
+++ b/backend/tests/features/user/api/test_oauth.py
@@ -1,10 +1,12 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastapi import status
 from fastapi.dependencies.models import Dependant
 from fastapi.routing import APIRoute
+from fastapi_users.router.oauth import STATE_TOKEN_AUDIENCE, decode_jwt
 from httpx import AsyncClient
 
 from app.api.version import API_BASE
@@ -52,6 +54,27 @@ class TestAuthRoutes:
             status.HTTP_307_TEMPORARY_REDIRECT,
         )
         assert "github" in response.text.lower() or "oauth" in response.text.lower()
+
+    async def test_github_oauth_authorize_embeds_return_to_in_state(
+        self, async_client: AsyncClient
+    ) -> None:
+        return_to = "https://127.0.0.1:5173/simulations/test-run?tab=summary"
+
+        response = await async_client.get(
+            f"{API_BASE}/auth/github/authorize",
+            params={"return_to": return_to},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        authorization_url = response.json()["authorization_url"]
+        state = parse_qs(urlparse(authorization_url).query)["state"][0]
+        state_data = decode_jwt(
+            state,
+            settings.github_state_secret_key,
+            [STATE_TOKEN_AUDIENCE],
+        )
+
+        assert state_data["return_to"] == return_to
 
     async def test_github_oauth_callback_invalid_state(
         self, async_client: AsyncClient

--- a/backend/tests/features/user/api/test_oauth.py
+++ b/backend/tests/features/user/api/test_oauth.py
@@ -1,17 +1,21 @@
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from fastapi import status
+from fastapi import HTTPException, status
 from fastapi.dependencies.models import Dependant
+from fastapi.responses import RedirectResponse
 from fastapi.routing import APIRoute
+from fastapi_users.exceptions import UserAlreadyExists
 from fastapi_users.router.oauth import STATE_TOKEN_AUDIENCE, decode_jwt
 from httpx import AsyncClient
+from starlette.requests import Request
 
 from app.api.version import API_BASE
 from app.core.config import settings
-from app.features.user.auth import oauth
+from app.features.user.api import oauth
 from app.features.user.manager import current_active_user
 from app.features.user.models import UserRole
 from app.main import app
@@ -98,6 +102,131 @@ class TestAuthRoutes:
 
         # Depending on cookie/JWT config, FastAPI-Users may redirect or just 400
         assert response.status_code in (200, 307, 400)
+
+    async def test_github_oauth_callback_rejects_missing_email(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            oauth.GITHUB_OAUTH_CLIENT,
+            "get_id_email",
+            AsyncMock(return_value=("mock_account_id", None)),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await oauth.github_callback(
+                Request({"type": "http", "headers": []}),
+                access_token_state=({"access_token": "fake_token"}, "valid-state"),
+                user_manager=SimpleNamespace(),
+                strategy=object(),
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc_info.value.detail == oauth.ErrorCode.OAUTH_NOT_AVAILABLE_EMAIL
+
+    async def test_github_oauth_callback_rejects_missing_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            oauth.GITHUB_OAUTH_CLIENT,
+            "get_id_email",
+            AsyncMock(return_value=("mock_account_id", "mockuser@example.com")),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await oauth.github_callback(
+                Request({"type": "http", "headers": []}),
+                access_token_state=({"access_token": "fake_token"}, None),
+                user_manager=SimpleNamespace(),
+                strategy=object(),
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+
+    async def test_github_oauth_callback_rejects_existing_user_conflict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            oauth.GITHUB_OAUTH_CLIENT,
+            "get_id_email",
+            AsyncMock(return_value=("mock_account_id", "mockuser@example.com")),
+        )
+        monkeypatch.setattr(oauth, "decode_jwt", lambda *_args, **_kwargs: {})
+        user_manager = SimpleNamespace(
+            oauth_callback=AsyncMock(side_effect=UserAlreadyExists()),
+            on_after_login=AsyncMock(),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await oauth.github_callback(
+                Request({"type": "http", "headers": []}),
+                access_token_state=({"access_token": "fake_token"}, "valid-state"),
+                user_manager=user_manager,
+                strategy=object(),
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc_info.value.detail == oauth.ErrorCode.OAUTH_USER_ALREADY_EXISTS
+
+    async def test_github_oauth_callback_rejects_inactive_user(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            oauth.GITHUB_OAUTH_CLIENT,
+            "get_id_email",
+            AsyncMock(return_value=("mock_account_id", "mockuser@example.com")),
+        )
+        monkeypatch.setattr(oauth, "decode_jwt", lambda *_args, **_kwargs: {})
+        user_manager = SimpleNamespace(
+            oauth_callback=AsyncMock(return_value=SimpleNamespace(is_active=False)),
+            on_after_login=AsyncMock(),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await oauth.github_callback(
+                Request({"type": "http", "headers": []}),
+                access_token_state=({"access_token": "fake_token"}, "valid-state"),
+                user_manager=user_manager,
+                strategy=object(),
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc_info.value.detail == oauth.ErrorCode.LOGIN_BAD_CREDENTIALS
+
+    async def test_github_oauth_callback_logs_in_and_redirects(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        return_to = "https://127.0.0.1:5173/simulations/test-run?tab=summary"
+        monkeypatch.setattr(
+            oauth.GITHUB_OAUTH_CLIENT,
+            "get_id_email",
+            AsyncMock(return_value=("mock_account_id", "mockuser@example.com")),
+        )
+        monkeypatch.setattr(
+            oauth, "decode_jwt", lambda *_args, **_kwargs: {"return_to": return_to}
+        )
+        monkeypatch.setattr(
+            oauth.GITHUB_OAUTH_BACKEND,
+            "login",
+            AsyncMock(return_value=RedirectResponse("/", status_code=302)),
+        )
+        user = SimpleNamespace(is_active=True)
+        user_manager = SimpleNamespace(
+            oauth_callback=AsyncMock(return_value=user),
+            on_after_login=AsyncMock(),
+        )
+
+        response = await oauth.github_callback(
+            Request({"type": "http", "headers": []}),
+            access_token_state=({"access_token": "fake_token"}, "valid-state"),
+            user_manager=user_manager,
+            strategy=object(),
+        )
+
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response.headers["location"].endswith(
+            "auth/callback?return_to=https%3A%2F%2F127.0.0.1%3A5173%2Fsimulations%2Ftest-run%3Ftab%3Dsummary"
+        )
+        user_manager.on_after_login.assert_awaited_once_with(user, ANY, response)
 
 
 class TestLogOutRoute:

--- a/backend/tests/features/user/auth/test_oauth.py
+++ b/backend/tests/features/user/auth/test_oauth.py
@@ -110,6 +110,21 @@ def test_normalize_post_login_return_to_rejects_unapproved_origin(monkeypatch):
     )
 
 
+@pytest.mark.parametrize(
+    "return_to",
+    [
+        "https://127.0.0.1:5173/auth/callback/",
+        "https://127.0.0.1:5173/auth/callback/anything",
+    ],
+)
+def test_normalize_post_login_return_to_rejects_callback_prefixed_paths(
+    monkeypatch, return_to: str
+):
+    monkeypatch.setattr(settings, "frontend_origins", "https://127.0.0.1:5173")
+
+    assert _normalize_post_login_return_to(return_to) is None
+
+
 def test_build_frontend_auth_redirect_url_appends_return_to(monkeypatch):
     monkeypatch.setattr(
         settings, "frontend_auth_redirect_url", "https://127.0.0.1:5173/auth/callback"

--- a/backend/tests/features/user/auth/test_oauth.py
+++ b/backend/tests/features/user/auth/test_oauth.py
@@ -3,6 +3,7 @@ from fastapi import Response
 from fastapi.responses import RedirectResponse
 
 from app.core.config import settings
+from app.features.user.auth import oauth
 from app.features.user.auth.oauth import (
     CustomCookieTransport,
     _build_frontend_auth_redirect_url,
@@ -108,6 +109,33 @@ def test_normalize_post_login_return_to_rejects_unapproved_origin(monkeypatch):
         _normalize_post_login_return_to("https://evil.example.com/simulations/123")
         is None
     )
+
+
+def test_normalize_post_login_return_to_rejects_invalid_url_parse(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "frontend_origins", "https://127.0.0.1:5173")
+    monkeypatch.setattr(
+        oauth, "urlparse", lambda _: (_ for _ in ()).throw(ValueError())
+    )
+
+    assert _normalize_post_login_return_to("not-a-url") is None
+
+
+@pytest.mark.parametrize(
+    "return_to",
+    [
+        "mailto:user@example.com",
+        "https:///missing-host",
+        "https://127.0.0.1:5173//double-slash",
+    ],
+)
+def test_normalize_post_login_return_to_rejects_invalid_url_shapes(
+    monkeypatch: pytest.MonkeyPatch, return_to: str
+):
+    monkeypatch.setattr(settings, "frontend_origins", "https://127.0.0.1:5173")
+
+    assert _normalize_post_login_return_to(return_to) is None
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/features/user/auth/test_oauth.py
+++ b/backend/tests/features/user/auth/test_oauth.py
@@ -3,7 +3,11 @@ from fastapi import Response
 from fastapi.responses import RedirectResponse
 
 from app.core.config import settings
-from app.features.user.auth.oauth import CustomCookieTransport
+from app.features.user.auth.oauth import (
+    CustomCookieTransport,
+    build_frontend_auth_redirect_url,
+    normalize_post_login_return_to,
+)
 
 
 @pytest.mark.asyncio
@@ -80,3 +84,43 @@ async def test_get_login_response_with_different_settings(monkeypatch):
     assert "HttpOnly" not in set_cookie
     assert "Max-Age=100" in set_cookie
     assert "SameSite=strict" in set_cookie
+
+
+def test_normalize_post_login_return_to_accepts_allowed_frontend_origin(monkeypatch):
+    monkeypatch.setattr(
+        settings,
+        "frontend_origins",
+        "https://127.0.0.1:5173,https://localhost:5173",
+    )
+
+    assert (
+        normalize_post_login_return_to(
+            "https://127.0.0.1:5173/simulations/123?tab=1#rail"
+        )
+        == "https://127.0.0.1:5173/simulations/123?tab=1#rail"
+    )
+
+
+def test_normalize_post_login_return_to_rejects_unapproved_origin(monkeypatch):
+    monkeypatch.setattr(settings, "frontend_origins", "https://127.0.0.1:5173")
+
+    assert (
+        normalize_post_login_return_to("https://evil.example.com/simulations/123")
+        is None
+    )
+
+
+def test_build_frontend_auth_redirect_url_appends_return_to(monkeypatch):
+    monkeypatch.setattr(
+        settings, "frontend_auth_redirect_url", "https://127.0.0.1:5173/auth/callback"
+    )
+    monkeypatch.setattr(settings, "frontend_origins", "https://127.0.0.1:5173")
+
+    redirect_url = build_frontend_auth_redirect_url(
+        "https://127.0.0.1:5173/simulations/123?tab=summary"
+    )
+
+    assert (
+        redirect_url
+        == "https://127.0.0.1:5173/auth/callback?return_to=https%3A%2F%2F127.0.0.1%3A5173%2Fsimulations%2F123%3Ftab%3Dsummary"
+    )

--- a/backend/tests/features/user/auth/test_oauth.py
+++ b/backend/tests/features/user/auth/test_oauth.py
@@ -5,8 +5,8 @@ from fastapi.responses import RedirectResponse
 from app.core.config import settings
 from app.features.user.auth.oauth import (
     CustomCookieTransport,
-    build_frontend_auth_redirect_url,
-    normalize_post_login_return_to,
+    _build_frontend_auth_redirect_url,
+    _normalize_post_login_return_to,
 )
 
 
@@ -94,7 +94,7 @@ def test_normalize_post_login_return_to_accepts_allowed_frontend_origin(monkeypa
     )
 
     assert (
-        normalize_post_login_return_to(
+        _normalize_post_login_return_to(
             "https://127.0.0.1:5173/simulations/123?tab=1#rail"
         )
         == "https://127.0.0.1:5173/simulations/123?tab=1#rail"
@@ -105,7 +105,7 @@ def test_normalize_post_login_return_to_rejects_unapproved_origin(monkeypatch):
     monkeypatch.setattr(settings, "frontend_origins", "https://127.0.0.1:5173")
 
     assert (
-        normalize_post_login_return_to("https://evil.example.com/simulations/123")
+        _normalize_post_login_return_to("https://evil.example.com/simulations/123")
         is None
     )
 
@@ -116,7 +116,7 @@ def test_build_frontend_auth_redirect_url_appends_return_to(monkeypatch):
     )
     monkeypatch.setattr(settings, "frontend_origins", "https://127.0.0.1:5173")
 
-    redirect_url = build_frontend_auth_redirect_url(
+    redirect_url = _build_frontend_auth_redirect_url(
         "https://127.0.0.1:5173/simulations/123?tab=summary"
     )
 

--- a/frontend/src/auth/AuthCallback.tsx
+++ b/frontend/src/auth/AuthCallback.tsx
@@ -13,8 +13,9 @@ export const AuthCallback: React.FC = () => {
 
   useEffect(() => {
     const completeLogin = async () => {
+      const storedReturnTarget = consumePostLoginReturnTarget();
       const returnTarget =
-        readPostLoginReturnTarget(window.location.search) ?? consumePostLoginReturnTarget();
+        readPostLoginReturnTarget(window.location.search) ?? storedReturnTarget;
 
       try {
         // NOTE: FastAPI Users exchanges the OAuth code and sets the cookie.

--- a/frontend/src/auth/AuthCallback.tsx
+++ b/frontend/src/auth/AuthCallback.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '@/auth/hooks/useAuth';
+import { consumePostLoginReturnTarget, readPostLoginReturnTarget } from '@/auth/returnTarget';
 import { Spinner } from '@/components/ui/spinner';
 import { toast } from '@/hooks/use-toast';
 
@@ -12,10 +13,29 @@ export const AuthCallback: React.FC = () => {
 
   useEffect(() => {
     const completeLogin = async () => {
+      const returnTarget =
+        readPostLoginReturnTarget(window.location.search) ?? consumePostLoginReturnTarget();
+
       try {
         // NOTE: FastAPI Users exchanges the OAuth code and sets the cookie.
         // Here we just need to refresh the user data to confirm login.
-        await refreshUser();
+        const isAuthenticated = await refreshUser();
+
+        if (!isAuthenticated) {
+          toast({
+            title: 'Login Failed',
+            description: (
+              <div className="flex items-center gap-2">
+                <XCircle className="h-5 w-5 text-red-600" />
+                <span>We couldn’t sign you in. Please try again.</span>
+              </div>
+            ),
+            duration: 3000,
+          });
+
+          navigate('/', { replace: true });
+          return;
+        }
 
         toast({
           title: 'Logged In',
@@ -28,7 +48,7 @@ export const AuthCallback: React.FC = () => {
           duration: 2000,
         });
 
-        navigate('/', { replace: true });
+        navigate(returnTarget, { replace: true });
       } catch (err) {
         console.error('OAuth post-login failed:', err);
 

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -4,6 +4,11 @@ import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'reac
 import { api, registerLogoutHandler } from '@/api/api';
 import { setAuthenticated } from '@/api/authState';
 import { AuthContext, AuthContextType } from '@/auth/context';
+import {
+  buildCurrentReturnPath,
+  buildCurrentReturnTarget,
+  savePostLoginReturnTarget,
+} from '@/auth/returnTarget';
 import { toast } from '@/hooks/use-toast';
 import type { User } from '@/types/user';
 
@@ -11,14 +16,16 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
-  const refreshUser = useCallback(async (): Promise<void> => {
+  const refreshUser = useCallback(async (): Promise<boolean> => {
     try {
       const { data } = await api.get<User>('/users/me');
       setUser(data);
       setAuthenticated(true);
+      return true;
     } catch {
       setUser(null);
       setAuthenticated(false);
+      return false;
     } finally {
       setLoading(false);
     }
@@ -26,8 +33,13 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 
   const loginWithGithub = async () => {
     try {
-      const { data } = await api.get<{ authorization_url: string }>('/auth/github/authorize');
+      const returnTo = buildCurrentReturnTarget();
+      const { data } = await api.get<{ authorization_url: string }>('/auth/github/authorize', {
+        params: { return_to: returnTo },
+      });
       const { authorization_url } = data;
+
+      savePostLoginReturnTarget(buildCurrentReturnPath());
 
       // Redirect browser to GitHub authorization URL to initiate OAuth flow.
       window.location.href = authorization_url;

--- a/frontend/src/auth/context.ts
+++ b/frontend/src/auth/context.ts
@@ -8,7 +8,7 @@ export interface AuthContextType {
   isAuthenticated: boolean;
   loginWithGithub: () => void;
   logout: () => Promise<void>;
-  refreshUser: () => Promise<void>;
+  refreshUser: () => Promise<boolean>;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/frontend/src/auth/returnTarget.ts
+++ b/frontend/src/auth/returnTarget.ts
@@ -1,0 +1,74 @@
+const POST_LOGIN_RETURN_TARGET_KEY = 'post-login-return-target';
+const AUTH_CALLBACK_PATH = '/auth/callback';
+const DEFAULT_RETURN_TARGET = '/';
+
+const isAuthCallbackTarget = (target: string): boolean =>
+  target === AUTH_CALLBACK_PATH ||
+  target.startsWith(`${AUTH_CALLBACK_PATH}?`) ||
+  target.startsWith(`${AUTH_CALLBACK_PATH}#`);
+
+const isValidReturnPath = (target: string): boolean =>
+  target.startsWith('/') && !target.startsWith('//') && !isAuthCallbackTarget(target);
+
+export const buildCurrentReturnTarget = (): string => window.location.href;
+
+export const buildCurrentReturnPath = (): string =>
+  `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+const toRelativeReturnPath = (target: string): string | null => {
+  if (isValidReturnPath(target)) {
+    return target;
+  }
+
+  try {
+    const parsed = new URL(target, window.location.origin);
+    if (parsed.origin !== window.location.origin) {
+      return null;
+    }
+
+    const relativeTarget = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    return isValidReturnPath(relativeTarget) ? relativeTarget : null;
+  } catch {
+    return null;
+  }
+};
+
+export const savePostLoginReturnTarget = (target: string): void => {
+  const normalizedTarget = toRelativeReturnPath(target);
+  if (normalizedTarget === null) {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(POST_LOGIN_RETURN_TARGET_KEY, normalizedTarget);
+  } catch {
+    // Ignore storage failures and fall back to the default redirect.
+  }
+};
+
+export const readPostLoginReturnTarget = (search: string): string | null => {
+  const returnTo = new URLSearchParams(search).get('return_to');
+  if (!returnTo) {
+    return null;
+  }
+
+  return toRelativeReturnPath(returnTo);
+};
+
+export const consumePostLoginReturnTarget = (): string => {
+  try {
+    const target = window.sessionStorage.getItem(POST_LOGIN_RETURN_TARGET_KEY);
+    window.sessionStorage.removeItem(POST_LOGIN_RETURN_TARGET_KEY);
+
+    if (target) {
+      const normalizedTarget = toRelativeReturnPath(target);
+      if (normalizedTarget) {
+        return normalizedTarget;
+      }
+    }
+  } catch {
+    // Ignore storage failures and fall back to the default redirect.
+  }
+
+  return DEFAULT_RETURN_TARGET;
+};

--- a/frontend/src/auth/returnTarget.ts
+++ b/frontend/src/auth/returnTarget.ts
@@ -3,9 +3,7 @@ const AUTH_CALLBACK_PATH = '/auth/callback';
 const DEFAULT_RETURN_TARGET = '/';
 
 const isAuthCallbackTarget = (target: string): boolean =>
-  target === AUTH_CALLBACK_PATH ||
-  target.startsWith(`${AUTH_CALLBACK_PATH}?`) ||
-  target.startsWith(`${AUTH_CALLBACK_PATH}#`);
+  target === AUTH_CALLBACK_PATH || target.startsWith(`${AUTH_CALLBACK_PATH}/`);
 
 const isValidReturnPath = (target: string): boolean =>
   target.startsWith('/') && !target.startsWith('//') && !isAuthCallbackTarget(target);


### PR DESCRIPTION
## Description

Closes #84

- Preserve the requested frontend location through GitHub OAuth and return users to that page after login instead of always sending them to `/`.
- Move `return_to` through backend OAuth state and frontend callback handling so the redirect survives full OAuth round-trips.
- Treat OAuth callback login as successful only after `/users/me` confirms an authenticated session.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [x] Tests added or updated (if needed)
- [ ] All tests pass (locally and CI/CD)
- [ ] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)
- None.

## Test Notes
- `uv run pytest tests/features/user/auth/test_oauth.py tests/features/user/api/test_oauth.py`
- `make frontend-lint`
- `pnpm --dir frontend run type-check` still fails on pre-existing unrelated `ArtifactIn[]` vs `ArtifactOut[]` type errors in browse/compare/simulations UI files.