### PR TITLE
Add support for locally hosted LLM providers (e.g., Ollama)

### DIFF
--- a/.envs/example/backend.env.example
+++ b/.envs/example/backend.env.example
@@ -91,8 +91,6 @@ ASSISTANT_OLLAMA_API_KEY=
 
 # --- LivAI (LLNL-hosted) ---
 # Models: https://livai-tools.llnl.gov/models
-# Recommended: gpt-5.4 (full model handles structured output reliably)
-# Avoid: gpt-5.4-mini (may truncate structured responses before completing all required fields)
 ASSISTANT_LIVAI_API_KEY=
 ASSISTANT_LIVAI_MODEL=gpt-5.4
 ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/

--- a/.envs/example/backend.env.example
+++ b/.envs/example/backend.env.example
@@ -78,14 +78,18 @@ COOKIE_MAX_AGE=3600
 # Enable or disable the AI summary assistant feature.
 ASSISTANT_LLM_ENABLED=false
 
-# Provider selection: "ollama" | "livai" | "openai" | "anthropic"
+# Provider selection: "ollama" | "livai"
 # Only configure the section for your chosen provider below.
 ASSISTANT_LLM_PROVIDER=ollama
 
 # --- Ollama (local OpenAI-compatible runtime) ---
 # SimBoard accepts the Ollama root URL and appends /v1 for OpenAI-compatible calls.
+# Use gemma4:e4b for fast dev (4GB), gemma4:26b for quality (26GB).
+# Install: brew install ollama (macOS) or https://docs.ollama.com/quickstart
+# Pull model: ollama pull gemma4:e4b  (or make ollama-pull-e4b)
+# Keep models loaded: make ollama-setup-macos (sets OLLAMA_KEEP_ALIVE=-1)
 ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
-ASSISTANT_OLLAMA_MODEL=gemma4:26b
+ASSISTANT_OLLAMA_MODEL=gemma4:e4b
 ASSISTANT_OLLAMA_API_KEY=
 
 # --- LivAI (LLNL-hosted) ---
@@ -93,16 +97,6 @@ ASSISTANT_OLLAMA_API_KEY=
 ASSISTANT_LIVAI_API_KEY=
 ASSISTANT_LIVAI_MODEL=
 ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
-
-# --- OpenAI ---
-# Models: https://platform.openai.com/docs/models
-ASSISTANT_OPENAI_API_KEY=
-ASSISTANT_OPENAI_MODEL=
-
-# --- Anthropic ---
-# Models: https://docs.anthropic.com/en/docs/about-claude/models
-ASSISTANT_ANTHROPIC_API_KEY=
-ASSISTANT_ANTHROPIC_MODEL=
 
 # --- Shared settings ---
 # Max seconds to wait for an LLM response before timing out.

--- a/.envs/example/backend.env.example
+++ b/.envs/example/backend.env.example
@@ -78,9 +78,15 @@ COOKIE_MAX_AGE=3600
 # Enable or disable the AI summary assistant feature.
 ASSISTANT_LLM_ENABLED=false
 
-# Provider selection: "livai" | "openai" | "anthropic"
+# Provider selection: "ollama" | "livai" | "openai" | "anthropic"
 # Only configure the section for your chosen provider below.
-ASSISTANT_LLM_PROVIDER=livai
+ASSISTANT_LLM_PROVIDER=ollama
+
+# --- Ollama (local OpenAI-compatible runtime) ---
+# SimBoard accepts the Ollama root URL and appends /v1 for OpenAI-compatible calls.
+ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
+ASSISTANT_OLLAMA_MODEL=gemma4:26b
+ASSISTANT_OLLAMA_API_KEY=
 
 # --- LivAI (LLNL-hosted) ---
 # Models: https://livai-tools.llnl.gov/models

--- a/.envs/example/backend.env.example
+++ b/.envs/example/backend.env.example
@@ -86,12 +86,15 @@ ASSISTANT_LLM_PROVIDER=ollama
 # SimBoard accepts the Ollama root URL and appends /v1 for OpenAI-compatible calls.
 ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
 ASSISTANT_OLLAMA_MODEL=llama3.1:8b
+# ASSISTANT_OLLAMA_API_KEY is optional for local runs and can stay blank unless an auth proxy requires it.
 ASSISTANT_OLLAMA_API_KEY=
 
 # --- LivAI (LLNL-hosted) ---
 # Models: https://livai-tools.llnl.gov/models
+# Recommended: gpt-5.4 (full model handles structured output reliably)
+# Avoid: gpt-5.4-mini (may truncate structured responses before completing all required fields)
 ASSISTANT_LIVAI_API_KEY=
-ASSISTANT_LIVAI_MODEL=
+ASSISTANT_LIVAI_MODEL=gpt-5.4
 ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
 
 # --- Shared settings ---
@@ -100,6 +103,8 @@ ASSISTANT_LLM_TIMEOUT_SECONDS=30
 # Sampling temperature for assistant LLM summaries.
 ASSISTANT_LLM_TEMPERATURE=0.2
 # Max tokens to allow in assistant LLM summary output.
-ASSISTANT_LLM_MAX_TOKENS=256
+# Guidance: 4096-8192 for gpt-5.4; 2048 for mini models (if used despite limitations)
+ASSISTANT_LLM_MAX_TOKENS=4096
 # Max characters from the simulation snapshot sent as LLM context.
+# Guidance: 12000-16000 balances detail vs token budget; reduce to 8000-10000 for mini models
 ASSISTANT_SNAPSHOT_MAX_CHARS=12000

--- a/.envs/example/backend.env.example
+++ b/.envs/example/backend.env.example
@@ -84,12 +84,8 @@ ASSISTANT_LLM_PROVIDER=ollama
 
 # --- Ollama (local OpenAI-compatible runtime) ---
 # SimBoard accepts the Ollama root URL and appends /v1 for OpenAI-compatible calls.
-# Use gemma4:e4b for fast dev (4GB), gemma4:26b for quality (26GB).
-# Install: brew install ollama (macOS) or https://docs.ollama.com/quickstart
-# Pull model: ollama pull gemma4:e4b  (or make ollama-pull-e4b)
-# Keep models loaded: make ollama-setup-macos (sets OLLAMA_KEEP_ALIVE=-1)
 ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
-ASSISTANT_OLLAMA_MODEL=gemma4:e4b
+ASSISTANT_OLLAMA_MODEL=llama3.1:8b
 ASSISTANT_OLLAMA_API_KEY=
 
 # --- LivAI (LLNL-hosted) ---
@@ -104,6 +100,6 @@ ASSISTANT_LLM_TIMEOUT_SECONDS=30
 # Sampling temperature for assistant LLM summaries.
 ASSISTANT_LLM_TEMPERATURE=0.2
 # Max tokens to allow in assistant LLM summary output.
-ASSISTANT_LLM_MAX_TOKENS=2048
+ASSISTANT_LLM_MAX_TOKENS=256
 # Max characters from the simulation snapshot sent as LLM context.
 ASSISTANT_SNAPSHOT_MAX_CHARS=12000

--- a/.envs/example/backend.production.env.example
+++ b/.envs/example/backend.production.env.example
@@ -87,9 +87,15 @@ COOKIE_MAX_AGE=3600
 # Enable or disable the AI summary assistant feature.
 ASSISTANT_LLM_ENABLED=false
 
-# Provider selection: "livai" | "openai" | "anthropic"
+# Provider selection: "ollama" | "livai" | "openai" | "anthropic"
 # Only configure the section for your chosen provider below.
-ASSISTANT_LLM_PROVIDER=livai
+ASSISTANT_LLM_PROVIDER=ollama
+
+# --- Ollama (OpenAI-compatible runtime) ---
+# SimBoard accepts the Ollama root URL and appends /v1 for OpenAI-compatible calls.
+ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
+ASSISTANT_OLLAMA_MODEL=gemma4:26b
+ASSISTANT_OLLAMA_API_KEY=
 
 # --- LivAI (LLNL-hosted) ---
 # Models: https://livai-tools.llnl.gov/models

--- a/.envs/example/backend.production.env.example
+++ b/.envs/example/backend.production.env.example
@@ -99,8 +99,10 @@ ASSISTANT_OLLAMA_API_KEY=
 
 # --- LivAI (LLNL-hosted) ---
 # Models: https://livai-tools.llnl.gov/models
+# Recommended: gpt-5.4 (full model handles structured output reliably)
+# Avoid: gpt-5.4-mini (may truncate structured responses before completing all required fields)
 ASSISTANT_LIVAI_API_KEY=
-ASSISTANT_LIVAI_MODEL=
+ASSISTANT_LIVAI_MODEL=gpt-5.4
 ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
 
 # --- Shared settings ---
@@ -109,6 +111,8 @@ ASSISTANT_LLM_TIMEOUT_SECONDS=30
 # Sampling temperature for assistant LLM summaries.
 ASSISTANT_LLM_TEMPERATURE=0.2
 # Max tokens to allow in assistant LLM summary output.
-ASSISTANT_LLM_MAX_TOKENS=2048
+# Guidance: 4096-8192 for gpt-5.4; 2048 for mini models (if used despite limitations)
+ASSISTANT_LLM_MAX_TOKENS=8192
 # Max characters from the simulation snapshot sent as LLM context.
+# Guidance: 12000-16000 balances detail vs token budget; reduce to 8000-10000 for mini models
 ASSISTANT_SNAPSHOT_MAX_CHARS=12000

--- a/.envs/example/backend.production.env.example
+++ b/.envs/example/backend.production.env.example
@@ -95,12 +95,11 @@ ASSISTANT_LLM_PROVIDER=ollama
 # SimBoard accepts the Ollama root URL and appends /v1 for OpenAI-compatible calls.
 ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
 ASSISTANT_OLLAMA_MODEL=gemma4:26b
+# ASSISTANT_OLLAMA_API_KEY is optional for local runs and can stay blank unless an auth proxy requires it.
 ASSISTANT_OLLAMA_API_KEY=
 
 # --- LivAI (LLNL-hosted) ---
 # Models: https://livai-tools.llnl.gov/models
-# Recommended: gpt-5.4 (full model handles structured output reliably)
-# Avoid: gpt-5.4-mini (may truncate structured responses before completing all required fields)
 ASSISTANT_LIVAI_API_KEY=
 ASSISTANT_LIVAI_MODEL=gpt-5.4
 ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/

--- a/.envs/example/backend.production.env.example
+++ b/.envs/example/backend.production.env.example
@@ -87,7 +87,7 @@ COOKIE_MAX_AGE=3600
 # Enable or disable the AI summary assistant feature.
 ASSISTANT_LLM_ENABLED=false
 
-# Provider selection: "ollama" | "livai" | "openai" | "anthropic"
+# Provider selection: "ollama" | "livai"
 # Only configure the section for your chosen provider below.
 ASSISTANT_LLM_PROVIDER=ollama
 
@@ -102,16 +102,6 @@ ASSISTANT_OLLAMA_API_KEY=
 ASSISTANT_LIVAI_API_KEY=
 ASSISTANT_LIVAI_MODEL=
 ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
-
-# --- OpenAI ---
-# Models: https://platform.openai.com/docs/models
-ASSISTANT_OPENAI_API_KEY=
-ASSISTANT_OPENAI_MODEL=
-
-# --- Anthropic ---
-# Models: https://docs.anthropic.com/en/docs/about-claude/models
-ASSISTANT_ANTHROPIC_API_KEY=
-ASSISTANT_ANTHROPIC_MODEL=
 
 # --- Shared settings ---
 # Max seconds to wait for an LLM response before timing out.

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,13 @@ help:
 	@echo "  make pre-commit-run                        # Run all pre-commit hooks"
 	@echo ""
 
+	@echo "$(BLUE)Ollama (Local LLM):$(NC)"
+	@echo "  make ollama-serve                          # Start Ollama server with OLLAMA_KEEP_ALIVE=-1"
+	@echo "  make ollama-pull-fast                      # Pull llama3.1:8b (fast dev model)"
+	@echo "  make ollama-pull-dev                       # Pull gemma4:e4b (stronger dev model)"
+	@echo "  make ollama-pull-quality                   # Pull gemma4:26b (quality model)"
+	@echo ""
+
 	@echo "$(BLUE)Docker Compose:$(NC)"
 	@echo "  make docker-build svc=<svc>                # Build Docker image(s)"
 	@echo "  make docker-rebuild svc=<svc>              # Build Docker image(s) without cache"
@@ -310,3 +317,37 @@ docker-ps:
 
 docker-config:
 	$(COMPOSE) config
+
+# ============================================================
+# 🤖 OLLAMA LOCAL LLM COMMANDS
+# ============================================================
+
+.PHONY: \
+	ollama-serve \
+	ollama-pull-fast \
+	ollama-pull-dev \
+	ollama-pull-quality \
+	ollama-pull-e4b \
+	ollama-pull-26b
+
+ollama-serve:
+	@echo "$(GREEN)🚀 Starting Ollama server with OLLAMA_KEEP_ALIVE=-1...$(NC)"
+	OLLAMA_KEEP_ALIVE=-1 ollama serve
+
+ollama-pull-fast:
+	@echo "$(GREEN)📥 Pulling llama3.1:8b (fast dev model)...$(NC)"
+	ollama pull llama3.1:8b
+
+ollama-pull-dev:
+	@echo "$(GREEN)📥 Pulling gemma4:e4b (stronger dev model)...$(NC)"
+	ollama pull gemma4:e4b
+
+ollama-pull-quality:
+	@echo "$(GREEN)📥 Pulling gemma4:26b (quality model)...$(NC)"
+	ollama pull gemma4:26b
+
+ollama-pull-e4b:
+	@$(MAKE) ollama-pull-dev
+
+ollama-pull-26b:
+	@$(MAKE) ollama-pull-quality

--- a/backend/README.md
+++ b/backend/README.md
@@ -41,10 +41,8 @@ Backend env templates live in `.envs/example/backend.env.example` and local deve
 Assistant summary configuration uses the `ASSISTANT_*` namespace:
 
 - `ASSISTANT_LLM_ENABLED`
-- `ASSISTANT_LLM_PROVIDER` with `ollama`, `openai`, `anthropic`, or `livai`
+- `ASSISTANT_LLM_PROVIDER` with `ollama` or `livai`
 - `ASSISTANT_OLLAMA_API_KEY` / `ASSISTANT_OLLAMA_MODEL` / `ASSISTANT_OLLAMA_BASE_URL`
-- `ASSISTANT_OPENAI_API_KEY` / `ASSISTANT_OPENAI_MODEL`
-- `ASSISTANT_ANTHROPIC_API_KEY` / `ASSISTANT_ANTHROPIC_MODEL`
 - `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
 - `ASSISTANT_LLM_TIMEOUT_SECONDS`
 - `ASSISTANT_LLM_TEMPERATURE`
@@ -56,6 +54,17 @@ For local open-weight runs, prefer Ollama with Gemma 4:
 - `gemma4:e4b` for fast local iteration and prompt-contract checks
 - `gemma4:26b` for preferred summary quality checks
 - `gemma4:31b` only if local hardware can support it
+
+Quick start (from repo root):
+
+```bash
+# Pull models
+make ollama-pull-e4b   # fast dev model (~4GB)
+make ollama-pull-26b   # quality model (~26GB)
+
+# Optional: configure keep-alive to eliminate model reload latency
+make ollama-setup-macos
+```
 
 On macOS, prefer native Ollama install for local development. Docker Desktop does not provide GPU passthrough for Ollama on macOS, so containerized local runs are typically much slower and are not the recommended default.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -49,9 +49,10 @@ Assistant summary configuration uses the `ASSISTANT_*` namespace:
 - `ASSISTANT_LLM_MAX_TOKENS`
 - `ASSISTANT_SNAPSHOT_MAX_CHARS`
 
-For local open-weight runs, prefer Ollama with Gemma 4:
+For local open-weight runs, prefer Ollama with one of these models:
 
-- `gemma4:e4b` for fast local iteration and prompt-contract checks
+- `llama3.1:8b` for faster local iteration on developer hardware
+- `gemma4:e4b` for local quality checks when hardware and latency budget allow it
 - `gemma4:26b` for preferred summary quality checks
 - `gemma4:31b` only if local hardware can support it
 
@@ -59,11 +60,12 @@ Quick start (from repo root):
 
 ```bash
 # Pull models
-make ollama-pull-e4b   # fast dev model (~4GB)
-make ollama-pull-26b   # quality model (~26GB)
+make ollama-pull-fast          # llama3.1:8b, fast dev model (~5GB)
+make ollama-pull-dev           # gemma4:e4b, stronger dev model (~9GB)
+make ollama-pull-quality       # gemma4:26b, quality model (~26GB)
 
-# Optional: configure keep-alive to eliminate model reload latency
-make ollama-setup-macos
+# Start local Ollama runtime with keep-alive enabled
+make ollama-serve
 ```
 
 On macOS, prefer native Ollama install for local development. Docker Desktop does not provide GPU passthrough for Ollama on macOS, so containerized local runs are typically much slower and are not the recommended default.

--- a/backend/README.md
+++ b/backend/README.md
@@ -36,44 +36,8 @@ make backend-upgrade
 
 ## Configuration
 
-Backend env templates live in `.envs/example/backend.env.example` and local developer values live in `.envs/local/backend.env`.
+Backend env templates live in `.envs/example/backend.env.example`. Local developer values live in `.envs/local/backend.env`.
 
-Assistant summary configuration uses the `ASSISTANT_*` namespace:
+Restart the backend after changing local env values.
 
-- `ASSISTANT_LLM_ENABLED`
-- `ASSISTANT_LLM_PROVIDER` with `ollama` or `livai`
-- `ASSISTANT_OLLAMA_API_KEY` / `ASSISTANT_OLLAMA_MODEL` / `ASSISTANT_OLLAMA_BASE_URL`
-- `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
-- `ASSISTANT_LLM_TIMEOUT_SECONDS`
-- `ASSISTANT_LLM_TEMPERATURE`
-- `ASSISTANT_LLM_MAX_TOKENS`
-- `ASSISTANT_SNAPSHOT_MAX_CHARS`
-
-For local open-weight runs, prefer Ollama with one of these models:
-
-- `llama3.1:8b` for faster local iteration on developer hardware
-- `gemma4:e4b` for local quality checks when hardware and latency budget allow it
-- `gemma4:26b` for preferred summary quality checks
-- `gemma4:31b` only if local hardware can support it
-
-Quick start (from repo root):
-
-```bash
-# Pull models
-make ollama-pull-fast          # llama3.1:8b, fast dev model (~5GB)
-make ollama-pull-dev           # gemma4:e4b, stronger dev model (~9GB)
-make ollama-pull-quality       # gemma4:26b, quality model (~26GB)
-
-# Start local Ollama runtime with keep-alive enabled
-make ollama-serve
-```
-
-On macOS, prefer native Ollama install for local development. Docker Desktop does not provide GPU passthrough for Ollama on macOS, so containerized local runs are typically much slower and are not the recommended default.
-
-For Ollama, SimBoard accepts `ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434` and normalizes it to Ollama's OpenAI-compatible `/v1` endpoint internally. `ASSISTANT_OLLAMA_API_KEY` is optional for local runs and can stay blank unless a proxy in front of Ollama requires auth.
-
-For LivAI, `ASSISTANT_LIVAI_*` names are canonical.
-For the current LivAI OpenAI-compatible chat path, SimBoard omits `temperature` for `gpt-5*` models because that endpoint rejects the parameter.
-For step-by-step local setup and provider examples, see [docs/developer/README.md](../docs/developer/README.md#assistant-llm-env-setup).
-
-For repo-wide setup and contributor workflow, see [docs/developer/README.md](../docs/developer/README.md).
+For repo-wide setup, assistant LLM configuration, and contributor workflow, see [docs/developer/README.md](../docs/developer/README.md).

--- a/backend/README.md
+++ b/backend/README.md
@@ -41,7 +41,8 @@ Backend env templates live in `.envs/example/backend.env.example` and local deve
 Assistant summary configuration uses the `ASSISTANT_*` namespace:
 
 - `ASSISTANT_LLM_ENABLED`
-- `ASSISTANT_LLM_PROVIDER` with `openai`, `anthropic`, or `livai`
+- `ASSISTANT_LLM_PROVIDER` with `ollama`, `openai`, `anthropic`, or `livai`
+- `ASSISTANT_OLLAMA_API_KEY` / `ASSISTANT_OLLAMA_MODEL` / `ASSISTANT_OLLAMA_BASE_URL`
 - `ASSISTANT_OPENAI_API_KEY` / `ASSISTANT_OPENAI_MODEL`
 - `ASSISTANT_ANTHROPIC_API_KEY` / `ASSISTANT_ANTHROPIC_MODEL`
 - `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
@@ -49,6 +50,16 @@ Assistant summary configuration uses the `ASSISTANT_*` namespace:
 - `ASSISTANT_LLM_TEMPERATURE`
 - `ASSISTANT_LLM_MAX_TOKENS`
 - `ASSISTANT_SNAPSHOT_MAX_CHARS`
+
+For local open-weight runs, prefer Ollama with Gemma 4:
+
+- `gemma4:e4b` for fast local iteration and prompt-contract checks
+- `gemma4:26b` for preferred summary quality checks
+- `gemma4:31b` only if local hardware can support it
+
+On macOS, prefer native Ollama install for local development. Docker Desktop does not provide GPU passthrough for Ollama on macOS, so containerized local runs are typically much slower and are not the recommended default.
+
+For Ollama, SimBoard accepts `ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434` and normalizes it to Ollama's OpenAI-compatible `/v1` endpoint internally. `ASSISTANT_OLLAMA_API_KEY` is optional for local runs and can stay blank unless a proxy in front of Ollama requires auth.
 
 For LivAI, `ASSISTANT_LIVAI_*` names are canonical.
 For the current LivAI OpenAI-compatible chat path, SimBoard omits `temperature` for `gpt-5*` models because that endpoint rejects the parameter.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -142,11 +142,7 @@ class Settings(BaseSettings):
 
     # --- Assistant LLM config ---
     assistant_llm_enabled: bool = False
-    assistant_llm_provider: Literal["openai", "anthropic", "livai", "ollama"] = "openai"
-    assistant_openai_api_key: SecretStr | None = None
-    assistant_openai_model: str | None = None
-    assistant_anthropic_api_key: SecretStr | None = None
-    assistant_anthropic_model: str | None = None
+    assistant_llm_provider: Literal["livai", "ollama"] = "ollama"
     assistant_livai_api_key: SecretStr | None = None
     assistant_livai_model: str | None = None
     assistant_livai_base_url: str = "https://livai-api.llnl.gov/"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -142,7 +142,7 @@ class Settings(BaseSettings):
 
     # --- Assistant LLM config ---
     assistant_llm_enabled: bool = False
-    assistant_llm_provider: Literal["openai", "anthropic", "livai"] = "openai"
+    assistant_llm_provider: Literal["openai", "anthropic", "livai", "ollama"] = "openai"
     assistant_openai_api_key: SecretStr | None = None
     assistant_openai_model: str | None = None
     assistant_anthropic_api_key: SecretStr | None = None
@@ -150,6 +150,9 @@ class Settings(BaseSettings):
     assistant_livai_api_key: SecretStr | None = None
     assistant_livai_model: str | None = None
     assistant_livai_base_url: str = "https://livai-api.llnl.gov/"
+    assistant_ollama_api_key: SecretStr | None = None
+    assistant_ollama_model: str | None = None
+    assistant_ollama_base_url: str = "http://localhost:11434"
     assistant_llm_timeout_seconds: float = 30.0
     assistant_llm_temperature: float = 0.2
     assistant_llm_max_tokens: int = 2048
@@ -159,6 +162,11 @@ class Settings(BaseSettings):
     @classmethod
     def _strip_livai_base_url(cls, value: str) -> str:
         return value.strip()
+
+    @field_validator("assistant_ollama_base_url", mode="before")
+    @classmethod
+    def _strip_ollama_base_url(cls, value: str) -> str:
+        return value.strip().rstrip("/")
 
 
 settings = Settings()

--- a/backend/app/features/assistant/api.py
+++ b/backend/app/features/assistant/api.py
@@ -56,7 +56,7 @@ async def summarize_simulation(
         duration_ms = (perf_counter() - start) * 1000
         logger.info(
             "simulation_summary trace_id=%s simulation_id=%s user_id=%s success=false "
-            "status=not_found latency_ms=%.2f llm_latency_ms=%.2f generation_mode=%s "
+            "status=not_found llm_success=false fallback_used=false latency_ms=%.2f llm_latency_ms=%.2f generation_mode=%s "
             "generation_provider=%s generation_model=%s fallback_reason=%s "
             "citation_count=0 caveat_count=0",
             trace_id,
@@ -73,15 +73,23 @@ async def summarize_simulation(
 
     generation = await generate_simulation_summary(simulation)
     summary = generation.summary.model_copy(update={"trace_id": trace_id})
+    llm_success = summary.generation_mode == "llm"
+    fallback_used = (
+        not llm_success
+        and generation.fallback_reason is not None
+        and generation.fallback_reason != "llm_disabled"
+    )
 
     duration_ms = (perf_counter() - start) * 1000
     logger.info(
         "simulation_summary trace_id=%s simulation_id=%s user_id=%s success=true "
-        "latency_ms=%.2f llm_latency_ms=%.2f generation_mode=%s generation_provider=%s "
-        "generation_model=%s fallback_reason=%s citation_count=%d caveat_count=%d",
+        "llm_success=%s fallback_used=%s latency_ms=%.2f llm_latency_ms=%.2f generation_mode=%s "
+        "generation_provider=%s generation_model=%s fallback_reason=%s citation_count=%d caveat_count=%d",
         trace_id,
         simulation.id,
         user.id,
+        str(llm_success).lower(),
+        str(fallback_used).lower(),
         duration_ms,
         generation.llm_latency_ms,
         summary.generation_mode,

--- a/backend/app/features/assistant/api.py
+++ b/backend/app/features/assistant/api.py
@@ -72,12 +72,17 @@ async def summarize_simulation(
         raise HTTPException(status_code=404, detail="Simulation not found")
 
     generation = await generate_simulation_summary(simulation)
-    summary = generation.summary.model_copy(update={"trace_id": trace_id})
-    llm_success = summary.generation_mode == "llm"
+    llm_success = generation.summary.generation_mode == "llm"
     fallback_used = (
         not llm_success
         and generation.fallback_reason is not None
         and generation.fallback_reason != "llm_disabled"
+    )
+    summary = generation.summary.model_copy(
+        update={
+            "trace_id": trace_id,
+            "fallback_used": fallback_used,
+        }
     )
 
     duration_ms = (perf_counter() - start) * 1000

--- a/backend/app/features/assistant/llm_generator.py
+++ b/backend/app/features/assistant/llm_generator.py
@@ -62,6 +62,20 @@ class SummaryLLMGenerator:
         self.config = config
 
     async def generate(self, snapshot: SimulationSnapshot) -> SimulationSummaryContent:
+        """
+        Generates a simulation summary from the given snapshot using the
+        configured LLM provider.
+
+        Parameters
+        ----------
+        snapshot : SimulationSnapshot
+            The simulation snapshot containing metadata to summarize.
+
+        Returns
+        -------
+        SimulationSummaryContent
+            The generated simulation summary content.
+        """
         async with AsyncClient(timeout=self.config.timeout_seconds) as http_client:
             model = self._build_model(http_client)
             agent = Agent(
@@ -70,15 +84,33 @@ class SummaryLLMGenerator:
                 system_prompt=SUMMARY_SYSTEM_PROMPT,
                 model_settings=self._build_model_settings(),
             )
+
             result = await agent.run(self._build_user_prompt(snapshot))
             return result.output
 
     def _build_model(self, http_client: AsyncClient) -> OpenAIChatModel:
+        """Builds the OpenAIChatModel based on the configuration and HTTP client.
+
+        For Ollama, if the API key is not set, it uses a placeholder value to
+        allow the client to initialize without credentials, since Ollama can run
+        without an API key.
+
+        Parameters
+        ----------
+        http_client : AsyncClient
+            The HTTP client to use for making requests to the LLM provider.
+
+        Returns
+        -------
+        OpenAIChatModel
+            The initialized OpenAIChatModel ready for generating summaries.
+        """
         api_key = (
             self.config.api_key.get_secret_value()
             if self.config.api_key is not None
             else None
         )
+
         if self.config.provider == "ollama":
             api_key = api_key or _OLLAMA_PLACEHOLDER_API_KEY
 
@@ -96,10 +128,11 @@ class SummaryLLMGenerator:
                     _enforce_credentials=False,
                 )
             }
-        return OpenAIChatModel(
-            self.config.model_name,
-            provider=OpenAIProvider(**provider_kwargs),
+
+        model = OpenAIChatModel(
+            self.config.model_name, provider=OpenAIProvider(**provider_kwargs)
         )
+        return model
 
     def _resolve_base_url(self) -> str | None:
         if self.config.provider != "ollama" or self.config.base_url is None:
@@ -108,17 +141,20 @@ class SummaryLLMGenerator:
         parsed = urlparse(self.config.base_url)
         if parsed.path not in {"", "/"}:
             return self.config.base_url
+
         return f"{self.config.base_url.rstrip('/')}/v1"
 
     def _build_model_settings(self) -> ModelSettings | None:
         settings: ModelSettings = {
             "max_tokens": self.config.max_tokens,
         }
+
         if not (
             self.config.provider == "livai"
             and self.config.model_name.startswith("gpt-5")
         ):
             settings["temperature"] = self.config.temperature
+
         return settings or None
 
     def _build_output_type(
@@ -126,6 +162,7 @@ class SummaryLLMGenerator:
     ) -> type[SimulationSummaryContent] | PromptedOutput[SimulationSummaryContent]:
         if self.config.provider == "ollama":
             return PromptedOutput(SimulationSummaryContent)
+
         return SimulationSummaryContent
 
     def _build_user_prompt(self, snapshot: SimulationSnapshot) -> str:
@@ -134,6 +171,7 @@ class SummaryLLMGenerator:
             for path, entry in sorted(CITATION_REGISTRY.items())
         )
         snapshot_json = snapshot.model_dump_json(indent=2, exclude_none=True)
+
         return (
             "Simulation metadata snapshot:\n"
             f"{snapshot_json}\n\n"

--- a/backend/app/features/assistant/llm_generator.py
+++ b/backend/app/features/assistant/llm_generator.py
@@ -4,9 +4,11 @@ from dataclasses import dataclass
 from urllib.parse import urlparse
 
 from httpx import AsyncClient
+from openai import AsyncOpenAI
 from pydantic import SecretStr
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.output import PromptedOutput
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.settings import ModelSettings
 
@@ -28,6 +30,12 @@ Rules:
 - Keep claims grounded in citations.
 - Use only allowed citation paths and source types provided in prompt.
 - Produce concise, factual output for all structured fields.
+- Keep `answer` to 2-4 short sentences and under 120 words.
+- Prioritize the few most decision-useful facts: status, case/campaign, configuration, machine, and notable provenance or timing only when material.
+- Do not enumerate every available field.
+- Do not repeat raw citation paths or add inline bracketed citations such as `[simulation.status]` inside the answer text.
+- Put evidence only in the structured `citations` field, not inline in prose.
+- Prefer natural language over field-by-field narration.
 """.strip()
 
 
@@ -51,7 +59,7 @@ class SummaryLLMGenerator:
             model = self._build_model(http_client)
             agent = Agent(
                 model,
-                output_type=SimulationSummaryContent,
+                output_type=self._build_output_type(),
                 system_prompt=SUMMARY_SYSTEM_PROMPT,
                 model_settings=self._build_model_settings(),
             )
@@ -64,13 +72,23 @@ class SummaryLLMGenerator:
             if self.config.api_key is not None
             else None
         )
+        provider_kwargs = {
+            "api_key": api_key,
+            "base_url": self._resolve_base_url(),
+            "http_client": http_client,
+        }
+        if self.config.provider == "ollama":
+            provider_kwargs = {
+                "openai_client": AsyncOpenAI(
+                    **provider_kwargs,
+                    max_retries=0,
+                    timeout=self.config.timeout_seconds,
+                    _enforce_credentials=False,
+                )
+            }
         return OpenAIChatModel(
             self.config.model_name,
-            provider=OpenAIProvider(
-                api_key=api_key,
-                base_url=self._resolve_base_url(),
-                http_client=http_client,
-            ),
+            provider=OpenAIProvider(**provider_kwargs),
         )
 
     def _resolve_base_url(self) -> str | None:
@@ -92,6 +110,13 @@ class SummaryLLMGenerator:
         ):
             settings["temperature"] = self.config.temperature
         return settings or None
+
+    def _build_output_type(
+        self,
+    ) -> type[SimulationSummaryContent] | PromptedOutput[SimulationSummaryContent]:
+        if self.config.provider == "ollama":
+            return PromptedOutput(SimulationSummaryContent)
+        return SimulationSummaryContent
 
     def _build_user_prompt(self, snapshot: SimulationSnapshot) -> str:
         allowed_citations = "\n".join(

--- a/backend/app/features/assistant/llm_generator.py
+++ b/backend/app/features/assistant/llm_generator.py
@@ -43,6 +43,8 @@ Rules:
 - Prefer natural language over field-by-field narration.
 """.strip()
 
+_OLLAMA_PLACEHOLDER_API_KEY = "api-key-not-set"
+
 
 @dataclass(frozen=True)
 class AssistantLLMConfig:
@@ -77,6 +79,9 @@ class SummaryLLMGenerator:
             if self.config.api_key is not None
             else None
         )
+        if self.config.provider == "ollama":
+            api_key = api_key or _OLLAMA_PLACEHOLDER_API_KEY
+
         provider_kwargs = {
             "api_key": api_key,
             "base_url": self._resolve_base_url(),

--- a/backend/app/features/assistant/llm_generator.py
+++ b/backend/app/features/assistant/llm_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 from httpx import AsyncClient
 from pydantic import SecretStr
@@ -31,12 +32,14 @@ Rules:
 - Produce concise, factual output for all structured fields.
 """.strip()
 
+OPENAI_COMPATIBLE_PROVIDERS = {"openai", "livai", "ollama"}
+
 
 @dataclass(frozen=True)
 class AssistantLLMConfig:
     provider: SummaryGenerationProvider
     model_name: str
-    api_key: SecretStr
+    api_key: SecretStr | None
     timeout_seconds: float
     temperature: float
     max_tokens: int
@@ -62,13 +65,17 @@ class SummaryLLMGenerator:
     def _build_model(
         self, http_client: AsyncClient
     ) -> OpenAIChatModel | AnthropicModel:
-        api_key = self.config.api_key.get_secret_value()
-        if self.config.provider in {"openai", "livai"}:
+        api_key = (
+            self.config.api_key.get_secret_value()
+            if self.config.api_key is not None
+            else None
+        )
+        if self.config.provider in OPENAI_COMPATIBLE_PROVIDERS:
             return OpenAIChatModel(
                 self.config.model_name,
                 provider=OpenAIProvider(
                     api_key=api_key,
-                    base_url=self.config.base_url,
+                    base_url=self._resolve_base_url(),
                     http_client=http_client,
                 ),
             )
@@ -76,6 +83,15 @@ class SummaryLLMGenerator:
             self.config.model_name,
             provider=AnthropicProvider(api_key=api_key, http_client=http_client),
         )
+
+    def _resolve_base_url(self) -> str | None:
+        if self.config.provider != "ollama" or self.config.base_url is None:
+            return self.config.base_url
+
+        parsed = urlparse(self.config.base_url)
+        if parsed.path not in {"", "/"}:
+            return self.config.base_url
+        return f"{self.config.base_url.rstrip('/')}/v1"
 
     def _build_model_settings(self) -> ModelSettings | None:
         settings: ModelSettings = {

--- a/backend/app/features/assistant/llm_generator.py
+++ b/backend/app/features/assistant/llm_generator.py
@@ -6,9 +6,7 @@ from urllib.parse import urlparse
 from httpx import AsyncClient
 from pydantic import SecretStr
 from pydantic_ai import Agent
-from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.openai import OpenAIChatModel
-from pydantic_ai.providers.anthropic import AnthropicProvider
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.settings import ModelSettings
 
@@ -31,8 +29,6 @@ Rules:
 - Use only allowed citation paths and source types provided in prompt.
 - Produce concise, factual output for all structured fields.
 """.strip()
-
-OPENAI_COMPATIBLE_PROVIDERS = {"openai", "livai", "ollama"}
 
 
 @dataclass(frozen=True)
@@ -62,26 +58,19 @@ class SummaryLLMGenerator:
             result = await agent.run(self._build_user_prompt(snapshot))
             return result.output
 
-    def _build_model(
-        self, http_client: AsyncClient
-    ) -> OpenAIChatModel | AnthropicModel:
+    def _build_model(self, http_client: AsyncClient) -> OpenAIChatModel:
         api_key = (
             self.config.api_key.get_secret_value()
             if self.config.api_key is not None
             else None
         )
-        if self.config.provider in OPENAI_COMPATIBLE_PROVIDERS:
-            return OpenAIChatModel(
-                self.config.model_name,
-                provider=OpenAIProvider(
-                    api_key=api_key,
-                    base_url=self._resolve_base_url(),
-                    http_client=http_client,
-                ),
-            )
-        return AnthropicModel(
+        return OpenAIChatModel(
             self.config.model_name,
-            provider=AnthropicProvider(api_key=api_key, http_client=http_client),
+            provider=OpenAIProvider(
+                api_key=api_key,
+                base_url=self._resolve_base_url(),
+                http_client=http_client,
+            ),
         )
 
     def _resolve_base_url(self) -> str | None:

--- a/backend/app/features/assistant/llm_generator.py
+++ b/backend/app/features/assistant/llm_generator.py
@@ -29,7 +29,12 @@ Rules:
 - If metadata is missing or truncated, say so in caveats.
 - Keep claims grounded in citations.
 - Use only allowed citation paths and source types provided in prompt.
+- Every `citations.path` value must exactly match one allowed path string.
+- Never shorten or rewrite citation paths. For example, use `simulation.status`, `case.name`, and `machine.name`, not `status` or `name`.
+- If you cannot cite a claim with an exact allowed path, omit that claim instead of inventing a citation path.
 - Produce concise, factual output for all structured fields.
+- Return every structured field required by schema, even when brief.
+- `suggested_followups` must contain at least one concrete item.
 - Keep `answer` to 2-4 short sentences and under 120 words.
 - Prioritize the few most decision-useful facts: status, case/campaign, configuration, machine, and notable provenance or timing only when material.
 - Do not enumerate every available field.

--- a/backend/app/features/assistant/orchestrator.py
+++ b/backend/app/features/assistant/orchestrator.py
@@ -96,21 +96,47 @@ def _format_model_error(exc: Exception) -> str:
     return exc.__class__.__name__
 
 
+def _canonicalize_citation_path(path: str, source_type: str | None = None) -> str:
+    normalized = path.strip()
+    if normalized in VALID_CITATION_PATHS:
+        return normalized
+
+    matches = [
+        candidate
+        for candidate in VALID_CITATION_PATHS
+        if candidate.endswith(f".{normalized}")
+    ]
+    if source_type is not None:
+        typed_matches = [
+            candidate
+            for candidate in matches
+            if get_citation_entry(candidate).source_type == source_type
+        ]
+        if len(typed_matches) == 1:
+            return typed_matches[0]
+    if len(matches) == 1:
+        return matches[0]
+
+    raise ValueError(f"invalid_citation_path:{path}")
+
+
 def _standardize_citations(
     citations: list[SummaryCitationOut],
     snapshot: SimulationSnapshot,
 ) -> list[SummaryCitationOut]:
     normalized: list[SummaryCitationOut] = []
     for citation in citations:
-        if citation.path not in VALID_CITATION_PATHS:
-            raise ValueError(f"invalid_citation_path:{citation.path}")
-        if not snapshot_has_citation_path(snapshot, citation.path):
-            raise ValueError(f"missing_citation_path:{citation.path}")
-        entry = get_citation_entry(citation.path)
+        canonical_path = _canonicalize_citation_path(
+            citation.path,
+            citation.source_type,
+        )
+        if not snapshot_has_citation_path(snapshot, canonical_path):
+            raise ValueError(f"missing_citation_path:{canonical_path}")
+        entry = get_citation_entry(canonical_path)
         normalized.append(
             SummaryCitationOut(
                 source_type=entry.source_type,
-                path=citation.path,
+                path=canonical_path,
                 label=entry.label,
             )
         )
@@ -183,6 +209,19 @@ def _build_deterministic_response(
             "generation_provider": None,
             "generation_model": None,
         }
+    )
+
+
+def _fill_missing_llm_followups(
+    content: SimulationSummaryContent,
+    snapshot: SimulationSnapshot,
+) -> SimulationSummaryContent:
+    if content.suggested_followups:
+        return content
+
+    fallback_summary = build_simulation_summary(snapshot)
+    return content.model_copy(
+        update={"suggested_followups": fallback_summary.suggested_followups}
     )
 
 
@@ -288,6 +327,7 @@ async def generate_simulation_summary(
     start = perf_counter()
     try:
         llm_content = await generator.generate(snapshot)
+        llm_content = _fill_missing_llm_followups(llm_content, snapshot)
         validated = _validate_llm_content(llm_content, snapshot)
         response = SimulationSummaryResponse(
             **validated.model_dump(),

--- a/backend/app/features/assistant/orchestrator.py
+++ b/backend/app/features/assistant/orchestrator.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import json
+import re
 from dataclasses import dataclass
 from time import perf_counter
 
 from pydantic import ValidationError
+from pydantic_ai.exceptions import (
+    ModelAPIError,
+    ModelHTTPError,
+    UnexpectedModelBehavior,
+)
 
 from app.core.config import settings
 from app.features.assistant.llm_generator import AssistantLLMConfig, SummaryLLMGenerator
@@ -70,6 +77,25 @@ class SummaryGenerationResult:
     attempted_model: str | None
 
 
+def _trim_fallback_reason(value: str, limit: int = 500) -> str:
+    if len(value) <= limit:
+        return value
+    return f"{value[: limit - 3]}..."
+
+
+def _format_model_error(exc: Exception) -> str:
+    if isinstance(exc, ModelHTTPError):
+        body = exc.body
+        if body is not None and not isinstance(body, str):
+            body = json.dumps(body, sort_keys=True)
+        return _trim_fallback_reason(
+            f"{exc.__class__.__name__}: status_code={exc.status_code}; body={body}"
+        )
+    if isinstance(exc, (ModelAPIError, UnexpectedModelBehavior)):
+        return _trim_fallback_reason(f"{exc.__class__.__name__}: {exc}")
+    return exc.__class__.__name__
+
+
 def _standardize_citations(
     citations: list[SummaryCitationOut],
     snapshot: SimulationSnapshot,
@@ -102,11 +128,26 @@ def _merge_unique_strings(*groups: list[str]) -> list[str]:
     return merged
 
 
+_INLINE_CITATION_RE = re.compile(
+    r"\s*\[(?:simulation|case|machine|artifacts|links)[^\]]+\]"
+)
+_MULTISPACE_RE = re.compile(r"\s+")
+_SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([,.;:])")
+
+
+def _normalize_llm_answer(answer: str) -> str:
+    cleaned = _INLINE_CITATION_RE.sub("", answer)
+    cleaned = _MULTISPACE_RE.sub(" ", cleaned).strip()
+    cleaned = _SPACE_BEFORE_PUNCT_RE.sub(r"\1", cleaned)
+    return cleaned
+
+
 def _validate_llm_content(
     content: SimulationSummaryContent,
     snapshot: SimulationSnapshot,
 ) -> SimulationSummaryContent:
-    if not content.answer.strip():
+    normalized_answer = _normalize_llm_answer(content.answer)
+    if not normalized_answer:
         raise ValueError("empty_answer")
     if not content.citations:
         raise ValueError("missing_citations")
@@ -117,6 +158,7 @@ def _validate_llm_content(
 
     return content.model_copy(
         update={
+            "answer": normalized_answer,
             "citations": _standardize_citations(content.citations, snapshot),
             "caveats": _merge_unique_strings(
                 snapshot.snapshot_caveats, content.caveats
@@ -264,7 +306,7 @@ async def generate_simulation_summary(
     except (ValidationError, ValueError) as exc:
         fallback_reason = getattr(exc, "args", ["llm_validation_failed"])[0]
     except Exception as exc:  # pragma: no cover - exercised via patched tests
-        fallback_reason = exc.__class__.__name__
+        fallback_reason = _format_model_error(exc)
 
     return SummaryGenerationResult(
         summary=_build_deterministic_response(

--- a/backend/app/features/assistant/orchestrator.py
+++ b/backend/app/features/assistant/orchestrator.py
@@ -67,6 +67,12 @@ _SNAPSHOT_PATH_ACCESSORS = {
     else None,
 }
 
+_INLINE_CITATION_RE = re.compile(
+    r"\s*\[(?:simulation|case|machine|artifacts|links)[^\]]+\]"
+)
+_MULTISPACE_RE = re.compile(r"\s+")
+_SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([,.;:])")
+
 
 @dataclass(frozen=True)
 class SummaryGenerationResult:
@@ -77,152 +83,113 @@ class SummaryGenerationResult:
     attempted_model: str | None
 
 
-def _trim_fallback_reason(value: str, limit: int = 500) -> str:
-    if len(value) <= limit:
-        return value
-    return f"{value[: limit - 3]}..."
+async def generate_simulation_summary(
+    simulation: Simulation,
+) -> SummaryGenerationResult:
+    attempted_provider: SummaryGenerationProvider | None = None
+    attempted_model: str | None = None
 
+    if settings.assistant_llm_enabled:
+        attempted_provider = settings.assistant_llm_provider
+        attempted_model = _configured_model_name(settings.assistant_llm_provider)
 
-def _format_model_error(exc: Exception) -> str:
-    if isinstance(exc, ModelHTTPError):
-        body = exc.body
-        if body is not None and not isinstance(body, str):
-            body = json.dumps(body, sort_keys=True)
-        return _trim_fallback_reason(
-            f"{exc.__class__.__name__}: status_code={exc.status_code}; body={body}"
-        )
-    if isinstance(exc, (ModelAPIError, UnexpectedModelBehavior)):
-        return _trim_fallback_reason(f"{exc.__class__.__name__}: {exc}")
-    return exc.__class__.__name__
-
-
-def _canonicalize_citation_path(path: str, source_type: str | None = None) -> str:
-    normalized = path.strip()
-    if normalized in VALID_CITATION_PATHS:
-        return normalized
-
-    matches = [
-        candidate
-        for candidate in VALID_CITATION_PATHS
-        if candidate.endswith(f".{normalized}")
-    ]
-    if source_type is not None:
-        typed_matches = [
-            candidate
-            for candidate in matches
-            if get_citation_entry(candidate).source_type == source_type
-        ]
-        if len(typed_matches) == 1:
-            return typed_matches[0]
-    if len(matches) == 1:
-        return matches[0]
-
-    raise ValueError(f"invalid_citation_path:{path}")
-
-
-def _standardize_citations(
-    citations: list[SummaryCitationOut],
-    snapshot: SimulationSnapshot,
-) -> list[SummaryCitationOut]:
-    normalized: list[SummaryCitationOut] = []
-    for citation in citations:
-        canonical_path = _canonicalize_citation_path(
-            citation.path,
-            citation.source_type,
-        )
-        if not snapshot_has_citation_path(snapshot, canonical_path):
-            raise ValueError(f"missing_citation_path:{canonical_path}")
-        entry = get_citation_entry(canonical_path)
-        normalized.append(
-            SummaryCitationOut(
-                source_type=entry.source_type,
-                path=canonical_path,
-                label=entry.label,
-            )
-        )
-    return normalized
-
-
-def _merge_unique_strings(*groups: list[str]) -> list[str]:
-    seen: set[str] = set()
-    merged: list[str] = []
-    for group in groups:
-        for item in group:
-            if item not in seen:
-                seen.add(item)
-                merged.append(item)
-    return merged
-
-
-_INLINE_CITATION_RE = re.compile(
-    r"\s*\[(?:simulation|case|machine|artifacts|links)[^\]]+\]"
-)
-_MULTISPACE_RE = re.compile(r"\s+")
-_SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([,.;:])")
-
-
-def _normalize_llm_answer(answer: str) -> str:
-    cleaned = _INLINE_CITATION_RE.sub("", answer)
-    cleaned = _MULTISPACE_RE.sub(" ", cleaned).strip()
-    cleaned = _SPACE_BEFORE_PUNCT_RE.sub(r"\1", cleaned)
-    return cleaned
-
-
-def _validate_llm_content(
-    content: SimulationSummaryContent,
-    snapshot: SimulationSnapshot,
-) -> SimulationSummaryContent:
-    normalized_answer = _normalize_llm_answer(content.answer)
-    if not normalized_answer:
-        raise ValueError("empty_answer")
-    if not content.citations:
-        raise ValueError("missing_citations")
-    if not content.limitations:
-        raise ValueError("missing_limitations")
-    if not content.suggested_followups:
-        raise ValueError("missing_followups")
-
-    return content.model_copy(
-        update={
-            "answer": normalized_answer,
-            "citations": _standardize_citations(content.citations, snapshot),
-            "caveats": _merge_unique_strings(
-                snapshot.snapshot_caveats, content.caveats
+    try:
+        snapshot = build_simulation_snapshot(simulation)
+    except SnapshotBudgetExceededError as exc:
+        result = SummaryGenerationResult(
+            summary=_build_deterministic_response(
+                exc.snapshot,
+                include_fallback_caveat=settings.assistant_llm_enabled,
             ),
-            "limitations": _merge_unique_strings(content.limitations, LLM_LIMITATIONS),
-        }
+            fallback_reason=str(exc)
+            if settings.assistant_llm_enabled
+            else "llm_disabled",
+            llm_latency_ms=0.0,
+            attempted_provider=attempted_provider,
+            attempted_model=attempted_model,
+        )
+
+        return result
+
+    if not settings.assistant_llm_enabled:
+        result = SummaryGenerationResult(
+            summary=_build_deterministic_response(
+                snapshot,
+                include_fallback_caveat=False,
+            ),
+            fallback_reason="llm_disabled",
+            llm_latency_ms=0.0,
+            attempted_provider=None,
+            attempted_model=None,
+        )
+
+        return result
+
+    try:
+        config = _resolve_llm_config()
+        attempted_provider = config.provider
+        attempted_model = config.model_name
+        generator = SummaryLLMGenerator(config)
+    except ValueError as exc:
+        result = SummaryGenerationResult(
+            summary=_build_deterministic_response(
+                snapshot,
+                include_fallback_caveat=True,
+            ),
+            fallback_reason=str(exc),
+            llm_latency_ms=0.0,
+            attempted_provider=attempted_provider,
+            attempted_model=attempted_model,
+        )
+
+        return result
+
+    start = perf_counter()
+    try:
+        llm_content = await generator.generate(snapshot)
+        llm_content = _fill_missing_llm_followups(llm_content, snapshot)
+        validated = _validate_llm_content(llm_content, snapshot)
+
+        response = SimulationSummaryResponse(
+            **validated.model_dump(),
+            generation_mode="llm",
+            generation_provider=config.provider,
+            generation_model=config.model_name,
+            trace_id="00000000-0000-0000-0000-000000000000",
+        )
+        result = SummaryGenerationResult(
+            summary=response,
+            fallback_reason=None,
+            llm_latency_ms=(perf_counter() - start) * 1000,
+            attempted_provider=config.provider,
+            attempted_model=config.model_name,
+        )
+
+        return result
+    except (ValidationError, ValueError) as exc:
+        fallback_reason = getattr(exc, "args", ["llm_validation_failed"])[0]
+    except Exception as exc:  # pragma: no cover - exercised via patched tests
+        fallback_reason = _format_model_error(exc)
+
+    result = SummaryGenerationResult(
+        summary=_build_deterministic_response(
+            snapshot,
+            include_fallback_caveat=True,
+        ),
+        fallback_reason=str(fallback_reason),
+        llm_latency_ms=(perf_counter() - start) * 1000,
+        attempted_provider=config.provider,
+        attempted_model=config.model_name,
     )
 
-
-def _build_deterministic_response(
-    snapshot: SimulationSnapshot,
-    *,
-    include_fallback_caveat: bool,
-) -> SimulationSummaryResponse:
-    base = build_simulation_summary(
-        snapshot,
-        include_fallback_caveat=include_fallback_caveat,
-    )
-    return base.model_copy(
-        update={
-            "generation_mode": "deterministic",
-            "generation_provider": None,
-            "generation_model": None,
-        }
-    )
+    return result
 
 
-def _fill_missing_llm_followups(
-    content: SimulationSummaryContent,
-    snapshot: SimulationSnapshot,
-) -> SimulationSummaryContent:
-    if content.suggested_followups:
-        return content
+def _configured_model_name(provider: SummaryGenerationProvider) -> str | None:
+    if provider == "livai":
+        return settings.assistant_livai_model
 
-    fallback_summary = build_simulation_summary(snapshot)
-    return content.model_copy(
-        update={"suggested_followups": fallback_summary.suggested_followups}
-    )
+    return settings.assistant_ollama_model
 
 
 def _resolve_llm_config() -> AssistantLLMConfig:
@@ -263,111 +230,182 @@ def _resolve_llm_config() -> AssistantLLMConfig:
     raise ValueError("unsupported_provider")
 
 
-def _configured_model_name(provider: SummaryGenerationProvider) -> str | None:
-    if provider == "livai":
-        return settings.assistant_livai_model
-    return settings.assistant_ollama_model
+def _standardize_citations(
+    citations: list[SummaryCitationOut],
+    snapshot: SimulationSnapshot,
+) -> list[SummaryCitationOut]:
+    normalized: list[SummaryCitationOut] = []
 
-
-async def generate_simulation_summary(
-    simulation: Simulation,
-) -> SummaryGenerationResult:
-    attempted_provider: SummaryGenerationProvider | None = None
-    attempted_model: str | None = None
-
-    if settings.assistant_llm_enabled:
-        attempted_provider = settings.assistant_llm_provider
-        attempted_model = _configured_model_name(settings.assistant_llm_provider)
-
-    try:
-        snapshot = build_simulation_snapshot(simulation)
-    except SnapshotBudgetExceededError as exc:
-        return SummaryGenerationResult(
-            summary=_build_deterministic_response(
-                exc.snapshot,
-                include_fallback_caveat=settings.assistant_llm_enabled,
-            ),
-            fallback_reason=str(exc)
-            if settings.assistant_llm_enabled
-            else "llm_disabled",
-            llm_latency_ms=0.0,
-            attempted_provider=attempted_provider,
-            attempted_model=attempted_model,
+    for citation in citations:
+        canonical_path = _canonicalize_citation_path(
+            citation.path,
+            citation.source_type,
         )
 
-    if not settings.assistant_llm_enabled:
-        return SummaryGenerationResult(
-            summary=_build_deterministic_response(
-                snapshot,
-                include_fallback_caveat=False,
-            ),
-            fallback_reason="llm_disabled",
-            llm_latency_ms=0.0,
-            attempted_provider=None,
-            attempted_model=None,
+        if not _snapshot_has_citation_path(snapshot, canonical_path):
+            raise ValueError(f"missing_citation_path:{canonical_path}")
+
+        entry = get_citation_entry(canonical_path)
+
+        normalized.append(
+            SummaryCitationOut(
+                source_type=entry.source_type,
+                path=canonical_path,
+                label=entry.label,
+            )
         )
-
-    try:
-        config = _resolve_llm_config()
-        attempted_provider = config.provider
-        attempted_model = config.model_name
-        generator = SummaryLLMGenerator(config)
-    except ValueError as exc:
-        return SummaryGenerationResult(
-            summary=_build_deterministic_response(
-                snapshot,
-                include_fallback_caveat=True,
-            ),
-            fallback_reason=str(exc),
-            llm_latency_ms=0.0,
-            attempted_provider=attempted_provider,
-            attempted_model=attempted_model,
-        )
-
-    start = perf_counter()
-    try:
-        llm_content = await generator.generate(snapshot)
-        llm_content = _fill_missing_llm_followups(llm_content, snapshot)
-        validated = _validate_llm_content(llm_content, snapshot)
-        response = SimulationSummaryResponse(
-            **validated.model_dump(),
-            generation_mode="llm",
-            generation_provider=config.provider,
-            generation_model=config.model_name,
-            trace_id="00000000-0000-0000-0000-000000000000",
-        )
-        return SummaryGenerationResult(
-            summary=response,
-            fallback_reason=None,
-            llm_latency_ms=(perf_counter() - start) * 1000,
-            attempted_provider=config.provider,
-            attempted_model=config.model_name,
-        )
-    except (ValidationError, ValueError) as exc:
-        fallback_reason = getattr(exc, "args", ["llm_validation_failed"])[0]
-    except Exception as exc:  # pragma: no cover - exercised via patched tests
-        fallback_reason = _format_model_error(exc)
-
-    return SummaryGenerationResult(
-        summary=_build_deterministic_response(
-            snapshot,
-            include_fallback_caveat=True,
-        ),
-        fallback_reason=str(fallback_reason),
-        llm_latency_ms=(perf_counter() - start) * 1000,
-        attempted_provider=config.provider,
-        attempted_model=config.model_name,
-    )
+    return normalized
 
 
-def snapshot_has_citation_path(snapshot: SimulationSnapshot, path: str) -> bool:
+def _canonicalize_citation_path(path: str, source_type: str | None = None) -> str:
+    normalized = path.strip()
+
+    if normalized in VALID_CITATION_PATHS:
+        return normalized
+
+    matches = [
+        candidate
+        for candidate in VALID_CITATION_PATHS
+        if candidate.endswith(f".{normalized}")
+    ]
+
+    if source_type is not None:
+        typed_matches = [
+            candidate
+            for candidate in matches
+            if get_citation_entry(candidate).source_type == source_type
+        ]
+
+        if len(typed_matches) == 1:
+            return typed_matches[0]
+
+    if len(matches) == 1:
+        return matches[0]
+
+    raise ValueError(f"invalid_citation_path:{path}")
+
+
+def _snapshot_has_citation_path(snapshot: SimulationSnapshot, path: str) -> bool:
     accessor = _SNAPSHOT_PATH_ACCESSORS.get(path)
+
     if accessor is not None:
         return bool(accessor(snapshot))
+
     if path.startswith("artifacts[kind="):
         kind = path[len("artifacts[kind=") : -1]
+
         return any(item.kind == kind for item in snapshot.artifacts)
     if path.startswith("links[kind="):
         kind = path[len("links[kind=") : -1]
+
         return any(item.kind == kind for item in snapshot.links)
+
     return False
+
+
+def _merge_unique_strings(*groups: list[str]) -> list[str]:
+    seen: set[str] = set()
+    merged: list[str] = []
+
+    for group in groups:
+        for item in group:
+            if item not in seen:
+                seen.add(item)
+                merged.append(item)
+
+    return merged
+
+
+def _validate_llm_content(
+    content: SimulationSummaryContent,
+    snapshot: SimulationSnapshot,
+) -> SimulationSummaryContent:
+    normalized_answer = _normalize_llm_answer(content.answer)
+
+    if not normalized_answer:
+        raise ValueError("empty_answer")
+    if not content.citations:
+        raise ValueError("missing_citations")
+    if not content.limitations:
+        raise ValueError("missing_limitations")
+    if not content.suggested_followups:
+        raise ValueError("missing_followups")
+
+    return content.model_copy(
+        update={
+            "answer": normalized_answer,
+            "citations": _standardize_citations(content.citations, snapshot),
+            "caveats": _merge_unique_strings(
+                snapshot.snapshot_caveats, content.caveats
+            ),
+            "limitations": _merge_unique_strings(content.limitations, LLM_LIMITATIONS),
+        }
+    )
+
+
+def _normalize_llm_answer(answer: str) -> str:
+    cleaned = _INLINE_CITATION_RE.sub("", answer)
+    cleaned = _MULTISPACE_RE.sub(" ", cleaned).strip()
+    cleaned = _SPACE_BEFORE_PUNCT_RE.sub(r"\1", cleaned)
+
+    return cleaned
+
+
+def _build_deterministic_response(
+    snapshot: SimulationSnapshot,
+    *,
+    include_fallback_caveat: bool,
+) -> SimulationSummaryResponse:
+    base = build_simulation_summary(
+        snapshot,
+        include_fallback_caveat=include_fallback_caveat,
+    )
+
+    return base.model_copy(
+        update={
+            "generation_mode": "deterministic",
+            "generation_provider": None,
+            "generation_model": None,
+        }
+    )
+
+
+def _fill_missing_llm_followups(
+    content: SimulationSummaryContent,
+    snapshot: SimulationSnapshot,
+) -> SimulationSummaryContent:
+    if content.suggested_followups:
+        return content
+
+    fallback_summary = build_simulation_summary(snapshot)
+
+    return content.model_copy(
+        update={"suggested_followups": fallback_summary.suggested_followups}
+    )
+
+
+def _format_model_error(exc: Exception) -> str:
+    if isinstance(exc, ModelHTTPError):
+        body = exc.body
+
+        if body is not None and not isinstance(body, str):
+            body = json.dumps(body, sort_keys=True)
+        return _trim_fallback_reason(
+            f"{exc.__class__.__name__}: status_code={exc.status_code}; body={body}"
+        )
+
+    if isinstance(exc, (ModelAPIError, UnexpectedModelBehavior)):
+        return _trim_fallback_reason(f"{exc.__class__.__name__}: {exc}")
+
+    message = str(exc).strip()
+    if not message:
+        return exc.__class__.__name__
+
+    return _trim_fallback_reason(f"{exc.__class__.__name__}: {message}")
+
+
+def _trim_fallback_reason(value: str, limit: int = 500) -> str:
+    if len(value) <= limit:
+        return value
+
+    return f"{value[: limit - 3]}..."

--- a/backend/app/features/assistant/orchestrator.py
+++ b/backend/app/features/assistant/orchestrator.py
@@ -146,36 +146,6 @@ def _build_deterministic_response(
 
 def _resolve_llm_config() -> AssistantLLMConfig:
     provider = settings.assistant_llm_provider
-    if provider == "openai":
-        if (
-            settings.assistant_openai_api_key is None
-            or not settings.assistant_openai_model
-        ):
-            raise ValueError("openai_misconfigured")
-        return AssistantLLMConfig(
-            provider="openai",
-            model_name=settings.assistant_openai_model,
-            api_key=settings.assistant_openai_api_key,
-            timeout_seconds=settings.assistant_llm_timeout_seconds,
-            temperature=settings.assistant_llm_temperature,
-            max_tokens=settings.assistant_llm_max_tokens,
-        )
-
-    if provider == "anthropic":
-        if (
-            settings.assistant_anthropic_api_key is None
-            or not settings.assistant_anthropic_model
-        ):
-            raise ValueError("anthropic_misconfigured")
-        return AssistantLLMConfig(
-            provider="anthropic",
-            model_name=settings.assistant_anthropic_model,
-            api_key=settings.assistant_anthropic_api_key,
-            timeout_seconds=settings.assistant_llm_timeout_seconds,
-            temperature=settings.assistant_llm_temperature,
-            max_tokens=settings.assistant_llm_max_tokens,
-        )
-
     if provider == "livai":
         if (
             settings.assistant_livai_api_key is None
@@ -213,10 +183,6 @@ def _resolve_llm_config() -> AssistantLLMConfig:
 
 
 def _configured_model_name(provider: SummaryGenerationProvider) -> str | None:
-    if provider == "openai":
-        return settings.assistant_openai_model
-    if provider == "anthropic":
-        return settings.assistant_anthropic_model
     if provider == "livai":
         return settings.assistant_livai_model
     return settings.assistant_ollama_model

--- a/backend/app/features/assistant/orchestrator.py
+++ b/backend/app/features/assistant/orchestrator.py
@@ -193,6 +193,22 @@ def _resolve_llm_config() -> AssistantLLMConfig:
             base_url=settings.assistant_livai_base_url,
         )
 
+    if provider == "ollama":
+        if (
+            not settings.assistant_ollama_model
+            or not settings.assistant_ollama_base_url
+        ):
+            raise ValueError("ollama_misconfigured")
+        return AssistantLLMConfig(
+            provider="ollama",
+            model_name=settings.assistant_ollama_model,
+            api_key=settings.assistant_ollama_api_key,
+            timeout_seconds=settings.assistant_llm_timeout_seconds,
+            temperature=settings.assistant_llm_temperature,
+            max_tokens=settings.assistant_llm_max_tokens,
+            base_url=settings.assistant_ollama_base_url,
+        )
+
     raise ValueError("unsupported_provider")
 
 
@@ -201,7 +217,9 @@ def _configured_model_name(provider: SummaryGenerationProvider) -> str | None:
         return settings.assistant_openai_model
     if provider == "anthropic":
         return settings.assistant_anthropic_model
-    return settings.assistant_livai_model
+    if provider == "livai":
+        return settings.assistant_livai_model
+    return settings.assistant_ollama_model
 
 
 async def generate_simulation_summary(

--- a/backend/app/features/assistant/orchestrator.py
+++ b/backend/app/features/assistant/orchestrator.py
@@ -100,7 +100,7 @@ async def generate_simulation_summary(
             summary=_build_deterministic_response(
                 exc.snapshot,
                 include_fallback_caveat=settings.assistant_llm_enabled,
-            ),
+            ).model_copy(update={"fallback_used": settings.assistant_llm_enabled}),
             fallback_reason=str(exc)
             if settings.assistant_llm_enabled
             else "llm_disabled",
@@ -135,7 +135,7 @@ async def generate_simulation_summary(
             summary=_build_deterministic_response(
                 snapshot,
                 include_fallback_caveat=True,
-            ),
+            ).model_copy(update={"fallback_used": True}),
             fallback_reason=str(exc),
             llm_latency_ms=0.0,
             attempted_provider=attempted_provider,
@@ -153,6 +153,7 @@ async def generate_simulation_summary(
         response = SimulationSummaryResponse(
             **validated.model_dump(),
             generation_mode="llm",
+            fallback_used=False,
             generation_provider=config.provider,
             generation_model=config.model_name,
             trace_id="00000000-0000-0000-0000-000000000000",
@@ -175,7 +176,7 @@ async def generate_simulation_summary(
         summary=_build_deterministic_response(
             snapshot,
             include_fallback_caveat=True,
-        ),
+        ).model_copy(update={"fallback_used": True}),
         fallback_reason=str(fallback_reason),
         llm_latency_ms=(perf_counter() - start) * 1000,
         attempted_provider=config.provider,

--- a/backend/app/features/assistant/schemas.py
+++ b/backend/app/features/assistant/schemas.py
@@ -24,7 +24,7 @@ class SummaryCitationOut(CamelOutBaseModel):
 
 
 SummaryGenerationMode = Literal["llm", "deterministic"]
-SummaryGenerationProvider = Literal["openai", "anthropic", "livai"]
+SummaryGenerationProvider = Literal["openai", "anthropic", "livai", "ollama"]
 
 
 class SimulationSummaryContent(CamelOutBaseModel):

--- a/backend/app/features/assistant/schemas.py
+++ b/backend/app/features/assistant/schemas.py
@@ -62,6 +62,10 @@ class SimulationSummaryResponse(SimulationSummaryContent):
         ...,
         description="Whether the summary came from the LLM path or deterministic fallback.",
     )
+    fallback_used: bool = Field(
+        default=False,
+        description="Whether this summary came from an attempted LLM generation that fell back to deterministic output.",
+    )
     generation_provider: SummaryGenerationProvider | None = Field(
         ...,
         description="Provider name when LLM generation succeeds; otherwise null.",

--- a/backend/app/features/assistant/schemas.py
+++ b/backend/app/features/assistant/schemas.py
@@ -24,7 +24,7 @@ class SummaryCitationOut(CamelOutBaseModel):
 
 
 SummaryGenerationMode = Literal["llm", "deterministic"]
-SummaryGenerationProvider = Literal["openai", "anthropic", "livai", "ollama"]
+SummaryGenerationProvider = Literal["livai", "ollama"]
 
 
 class SimulationSummaryContent(CamelOutBaseModel):

--- a/backend/app/features/assistant/service.py
+++ b/backend/app/features/assistant/service.py
@@ -272,6 +272,7 @@ def build_simulation_summary(
         limitations=DETERMINISTIC_LIMITATIONS,
         suggested_followups=draft.followups,
         generation_mode="deterministic",
+        fallback_used=False,
         generation_provider=None,
         generation_model=None,
         trace_id="00000000-0000-0000-0000-000000000000",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "pydantic-settings>=2.4.0",
   "python-dotenv>=1.0.1",
   "python-dateutil>=2.8.2,<3.0.0",
-  "pydantic-ai-slim[anthropic,openai]>=1.0.0,<2.0.0",
+  "pydantic-ai-slim[openai]>=1.0.0,<2.0.0",
 
   # --- Authentication / Authorization ---
   "fastapi-users[sqlalchemy,oauth]>=14.0.0,<15.0.0",

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -166,6 +166,45 @@ class TestSettings:
         assert configured.assistant_livai_api_key is not None
         assert configured.assistant_livai_api_key.get_secret_value() == "livai-key"
 
+    def test_assistant_ollama_env_names_are_canonical_and_strip_whitespace(self):
+        configured = Settings(
+            _env_file=None,
+            FRONTEND_ORIGIN="http://localhost:3000",
+            FRONTEND_AUTH_REDIRECT_URL="http://localhost:3000/auth/callback",
+            FRONTEND_ORIGINS="http://localhost:3000",
+            database_url="postgresql+psycopg://user:password@localhost/simboard",
+            test_database_url="postgresql+psycopg://user:password@localhost/simboard_test",
+            github_client_id="github-client-id",
+            github_client_secret="github-client-secret",
+            github_redirect_url="http://localhost:8000/auth/github/callback",
+            github_state_secret_key="state-secret",
+            assistant_ollama_base_url=" http://localhost:11434/  ",
+            assistant_ollama_api_key="ollama-key",
+            assistant_ollama_model="gemma4:26b",
+        )
+
+        assert configured.assistant_ollama_base_url == "http://localhost:11434"
+        assert configured.assistant_ollama_model == "gemma4:26b"
+        assert configured.assistant_ollama_api_key is not None
+        assert configured.assistant_ollama_api_key.get_secret_value() == "ollama-key"
+
+    def test_assistant_ollama_model_accepts_arbitrary_string(self):
+        configured = Settings(
+            _env_file=None,
+            FRONTEND_ORIGIN="http://localhost:3000",
+            FRONTEND_AUTH_REDIRECT_URL="http://localhost:3000/auth/callback",
+            FRONTEND_ORIGINS="http://localhost:3000",
+            database_url="postgresql+psycopg://user:password@localhost/simboard",
+            test_database_url="postgresql+psycopg://user:password@localhost/simboard_test",
+            github_client_id="github-client-id",
+            github_client_secret="github-client-secret",
+            github_redirect_url="http://localhost:8000/auth/github/callback",
+            github_state_secret_key="state-secret",
+            assistant_ollama_model="gemma4:26b-q4_K_M",
+        )
+
+        assert configured.assistant_ollama_model == "gemma4:26b-q4_K_M"
+
     def test_assistant_llm_tuning_env_values_load_from_settings(self):
         configured = Settings(
             _env_file=None,

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -166,6 +166,22 @@ class TestSettings:
         assert configured.assistant_livai_api_key is not None
         assert configured.assistant_livai_api_key.get_secret_value() == "livai-key"
 
+    def test_assistant_llm_provider_defaults_to_ollama(self):
+        configured = Settings(
+            _env_file=None,
+            FRONTEND_ORIGIN="http://localhost:3000",
+            FRONTEND_AUTH_REDIRECT_URL="http://localhost:3000/auth/callback",
+            FRONTEND_ORIGINS="http://localhost:3000",
+            database_url="postgresql+psycopg://user:password@localhost/simboard",
+            test_database_url="postgresql+psycopg://user:password@localhost/simboard_test",
+            github_client_id="github-client-id",
+            github_client_secret="github-client-secret",
+            github_redirect_url="http://localhost:8000/auth/github/callback",
+            github_state_secret_key="state-secret",
+        )
+
+        assert configured.assistant_llm_provider == "ollama"
+
     def test_assistant_ollama_env_names_are_canonical_and_strip_whitespace(self):
         configured = Settings(
             _env_file=None,

--- a/backend/tests/features/assistant/test_api.py
+++ b/backend/tests/features/assistant/test_api.py
@@ -126,6 +126,7 @@ class TestSummarizeSimulationEndpoint:
         ]
         assert isinstance(data["suggestedFollowups"], list)
         assert UUID(data["traceId"])
+        assert data["fallbackUsed"] is False
         assert {citation["path"] for citation in data["citations"]} >= {
             "simulation.execution_id",
             "case.name",
@@ -246,6 +247,7 @@ class TestSummarizeSimulationUnit:
         response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)
 
         assert response.answer == "Deterministic assistant summary."
+        assert response.fallback_used is False
         assert response.trace_id == trace_id
         assert logged
         assert "success=true" in logged[0][0]
@@ -310,6 +312,7 @@ class TestSummarizeSimulationUnit:
         response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)
 
         assert response.answer == "Deterministic fallback summary."
+        assert response.fallback_used is True
         assert response.trace_id == trace_id
         assert logged
         assert "success=true" in logged[0][0]
@@ -371,6 +374,7 @@ class TestSummarizeSimulationUnit:
         response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)
 
         assert response.generation_mode == "llm"
+        assert response.fallback_used is False
         assert response.generation_provider == "ollama"
         assert response.generation_model == "gemma4:26b"
         assert response.trace_id == trace_id

--- a/backend/tests/features/assistant/test_api.py
+++ b/backend/tests/features/assistant/test_api.py
@@ -249,9 +249,74 @@ class TestSummarizeSimulationUnit:
         assert response.trace_id == trace_id
         assert logged
         assert "success=true" in logged[0][0]
+        assert "llm_success=%s" in logged[0][0]
+        assert "fallback_used=%s" in logged[0][0]
         assert logged[0][1][0] == trace_id
         assert logged[0][1][1] == sim_id
         assert logged[0][1][2] == user.id
+        assert logged[0][1][3] == "false"
+        assert logged[0][1][4] == "false"
+
+    @pytest.mark.asyncio
+    async def test_summarize_simulation_logs_true_fallback_when_llm_attempt_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sim_id = uuid4()
+        trace_id = uuid4()
+        user = User(
+            id=uuid4(),
+            email="user@example.com",
+            is_active=True,
+            is_verified=True,
+            role=UserRole.USER,
+        )
+        db = _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})())
+        summary = SimulationSummaryResponse(
+            answer="Deterministic fallback summary.",
+            citations=[],
+            assumptions=[],
+            caveats=[],
+            limitations=["limit"],
+            suggested_followups=["follow up"],
+            generation_mode="deterministic",
+            generation_provider=None,
+            generation_model=None,
+            trace_id=uuid4(),
+        )
+        logged: list[tuple[str, tuple[object, ...]]] = []
+
+        async def fake_generate(simulation):
+            assert simulation.id == sim_id
+            return type(
+                "GenerationResult",
+                (),
+                {
+                    "summary": summary,
+                    "fallback_reason": "ModelHTTPError",
+                    "llm_latency_ms": 12.5,
+                    "attempted_provider": "ollama",
+                    "attempted_model": "gemma4:3b",
+                },
+            )()
+
+        monkeypatch.setattr(assistant_api, "generate_simulation_summary", fake_generate)
+        monkeypatch.setattr(assistant_api, "uuid4", lambda: trace_id)
+        monkeypatch.setattr(
+            assistant_api.logger,
+            "info",
+            lambda message, *args: logged.append((message, args)),
+        )
+
+        response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)
+
+        assert response.answer == "Deterministic fallback summary."
+        assert response.trace_id == trace_id
+        assert logged
+        assert "success=true" in logged[0][0]
+        assert "llm_success=%s" in logged[0][0]
+        assert "fallback_used=%s" in logged[0][0]
+        assert logged[0][1][3] == "false"
+        assert logged[0][1][4] == "true"
 
     @pytest.mark.asyncio
     async def test_summarize_simulation_returns_ollama_generation_metadata(
@@ -279,6 +344,7 @@ class TestSummarizeSimulationUnit:
             generation_model="gemma4:26b",
             trace_id=uuid4(),
         )
+        logged: list[tuple[str, tuple[object, ...]]] = []
 
         async def fake_generate(simulation):
             assert simulation.id == sim_id
@@ -296,6 +362,11 @@ class TestSummarizeSimulationUnit:
 
         monkeypatch.setattr(assistant_api, "generate_simulation_summary", fake_generate)
         monkeypatch.setattr(assistant_api, "uuid4", lambda: trace_id)
+        monkeypatch.setattr(
+            assistant_api.logger,
+            "info",
+            lambda message, *args: logged.append((message, args)),
+        )
 
         response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)
 
@@ -303,6 +374,11 @@ class TestSummarizeSimulationUnit:
         assert response.generation_provider == "ollama"
         assert response.generation_model == "gemma4:26b"
         assert response.trace_id == trace_id
+        assert logged
+        assert "llm_success=%s" in logged[0][0]
+        assert "fallback_used=%s" in logged[0][0]
+        assert logged[0][1][3] == "true"
+        assert logged[0][1][4] == "false"
 
     @pytest.mark.asyncio
     async def test_summarize_simulation_raises_404_for_missing_simulation(
@@ -334,5 +410,7 @@ class TestSummarizeSimulationUnit:
         assert exc_info.value.detail == "Simulation not found"
         assert logged
         assert "status=not_found" in logged[0][0]
+        assert "llm_success=false" in logged[0][0]
+        assert "fallback_used=false" in logged[0][0]
         assert logged[0][1][0] == trace_id
         assert logged[0][1][1] == sim_id

--- a/backend/tests/features/assistant/test_api.py
+++ b/backend/tests/features/assistant/test_api.py
@@ -243,7 +243,7 @@ class TestSummarizeSimulationUnit:
             lambda message, *args: logged.append((message, args)),
         )
 
-        response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)  # type: ignore[arg-type]
+        response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)
 
         assert response.answer == "Deterministic assistant summary."
         assert response.trace_id == trace_id
@@ -252,6 +252,57 @@ class TestSummarizeSimulationUnit:
         assert logged[0][1][0] == trace_id
         assert logged[0][1][1] == sim_id
         assert logged[0][1][2] == user.id
+
+    @pytest.mark.asyncio
+    async def test_summarize_simulation_returns_ollama_generation_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sim_id = uuid4()
+        trace_id = uuid4()
+        user = User(
+            id=uuid4(),
+            email="user@example.com",
+            is_active=True,
+            is_verified=True,
+            role=UserRole.USER,
+        )
+        db = _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})())
+        summary = SimulationSummaryResponse(
+            answer="LLM assistant summary.",
+            citations=[],
+            assumptions=[],
+            caveats=[],
+            limitations=["limit"],
+            suggested_followups=["follow up"],
+            generation_mode="llm",
+            generation_provider="ollama",
+            generation_model="gemma4:26b",
+            trace_id=uuid4(),
+        )
+
+        async def fake_generate(simulation):
+            assert simulation.id == sim_id
+            return type(
+                "GenerationResult",
+                (),
+                {
+                    "summary": summary,
+                    "fallback_reason": None,
+                    "llm_latency_ms": 9.0,
+                    "attempted_provider": "ollama",
+                    "attempted_model": "gemma4:26b",
+                },
+            )()
+
+        monkeypatch.setattr(assistant_api, "generate_simulation_summary", fake_generate)
+        monkeypatch.setattr(assistant_api, "uuid4", lambda: trace_id)
+
+        response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)
+
+        assert response.generation_mode == "llm"
+        assert response.generation_provider == "ollama"
+        assert response.generation_model == "gemma4:26b"
+        assert response.trace_id == trace_id
 
     @pytest.mark.asyncio
     async def test_summarize_simulation_raises_404_for_missing_simulation(
@@ -277,7 +328,7 @@ class TestSummarizeSimulationUnit:
         )
 
         with pytest.raises(assistant_api.HTTPException) as exc_info:
-            await assistant_api.summarize_simulation(sim_id, db=db, user=user)  # type: ignore[arg-type]
+            await assistant_api.summarize_simulation(sim_id, db=db, user=user)
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Simulation not found"

--- a/backend/tests/features/assistant/test_llm_generator.py
+++ b/backend/tests/features/assistant/test_llm_generator.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 from httpx import AsyncClient
 from pydantic import SecretStr
+from pydantic_ai.output import PromptedOutput
 
 from app.features.assistant import llm_generator
 from app.features.assistant.llm_generator import AssistantLLMConfig, SummaryLLMGenerator
@@ -84,6 +85,24 @@ class TestSummaryLLMGenerator:
             model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
 
         assert str(model.client.base_url) == "http://localhost:11434/v1/"
+        assert model.client.max_retries == 0
+
+    @pytest.mark.asyncio
+    async def test_build_model_keeps_default_retries_for_livai(self) -> None:
+        config = AssistantLLMConfig(
+            provider="livai",
+            model_name="livai-model",
+            api_key=SecretStr("livai-key"),
+            timeout_seconds=30.0,
+            temperature=0.2,
+            max_tokens=2048,
+            base_url="https://example.livai.test/v1",
+        )
+
+        async with AsyncClient() as http_client:
+            model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
+
+        assert model.client.max_retries == 2
 
     def test_build_model_settings_omits_temperature_for_livai_gpt5(self) -> None:
         config = AssistantLLMConfig(
@@ -149,6 +168,48 @@ class TestSummaryLLMGenerator:
         assert "simulation.execution_id (simulation_field)" in prompt
         assert "case.name (case_field)" in prompt
 
+    def test_summary_system_prompt_enforces_short_natural_answer_shape(self) -> None:
+        assert (
+            "Keep `answer` to 2-4 short sentences"
+            in llm_generator.SUMMARY_SYSTEM_PROMPT
+        )
+        assert (
+            "Do not enumerate every available field."
+            in llm_generator.SUMMARY_SYSTEM_PROMPT
+        )
+        assert "Do not repeat raw citation paths" in llm_generator.SUMMARY_SYSTEM_PROMPT
+
+    def test_build_output_type_uses_prompted_output_for_ollama(self) -> None:
+        output_type = SummaryLLMGenerator(
+            AssistantLLMConfig(
+                provider="ollama",
+                model_name="gemma4:e4b",
+                api_key=None,
+                timeout_seconds=30.0,
+                temperature=0.2,
+                max_tokens=2048,
+                base_url="http://localhost:11434",
+            )
+        )._build_output_type()
+
+        assert isinstance(output_type, PromptedOutput)
+        assert output_type.outputs is SimulationSummaryContent
+
+    def test_build_output_type_keeps_native_type_for_livai(self) -> None:
+        output_type = SummaryLLMGenerator(
+            AssistantLLMConfig(
+                provider="livai",
+                model_name="livai-model",
+                api_key=SecretStr("livai-key"),
+                timeout_seconds=30.0,
+                temperature=0.2,
+                max_tokens=2048,
+                base_url="https://example.livai.test/v1",
+            )
+        )._build_output_type()
+
+        assert output_type is SimulationSummaryContent
+
     @pytest.mark.asyncio
     async def test_generate_returns_agent_output(
         self, monkeypatch: pytest.MonkeyPatch
@@ -206,3 +267,55 @@ class TestSummaryLLMGenerator:
             "max_tokens": 2048,
         }
         assert "Allowed citation paths:" in str(captured["prompt"])
+
+    @pytest.mark.asyncio
+    async def test_generate_uses_prompted_output_for_ollama(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        expected = SimulationSummaryContent(
+            answer="Generated summary.",
+            citations=[
+                SummaryCitationOut(
+                    source_type="simulation_field",
+                    path="simulation.execution_id",
+                    label="Execution ID",
+                )
+            ],
+            assumptions=[],
+            caveats=[],
+            limitations=["limit"],
+            suggested_followups=["follow up"],
+        )
+        captured: dict[str, object] = {}
+
+        class FakeAgent:
+            def __init__(
+                self, model, output_type, system_prompt, model_settings=None
+            ) -> None:
+                captured["model"] = model
+                captured["output_type"] = output_type
+                captured["system_prompt"] = system_prompt
+                captured["model_settings"] = model_settings
+
+            async def run(self, prompt: str):
+                captured["prompt"] = prompt
+                return SimpleNamespace(output=expected)
+
+        monkeypatch.setattr(llm_generator, "Agent", FakeAgent)
+
+        generator = SummaryLLMGenerator(
+            AssistantLLMConfig(
+                provider="ollama",
+                model_name="gemma4:e4b",
+                api_key=None,
+                timeout_seconds=30.0,
+                temperature=0.2,
+                max_tokens=2048,
+                base_url="http://localhost:11434",
+            )
+        )
+
+        result = await generator.generate(_make_snapshot())
+
+        assert result == expected
+        assert isinstance(captured["output_type"], PromptedOutput)

--- a/backend/tests/features/assistant/test_llm_generator.py
+++ b/backend/tests/features/assistant/test_llm_generator.py
@@ -52,6 +52,40 @@ class TestSummaryLLMGenerator:
         assert str(model.client.base_url) == "https://example.livai.test/v1/"
 
     @pytest.mark.asyncio
+    async def test_build_model_normalizes_ollama_root_url_to_v1(self) -> None:
+        config = AssistantLLMConfig(
+            provider="ollama",
+            model_name="gemma4:26b",
+            api_key=None,
+            timeout_seconds=30.0,
+            temperature=0.2,
+            max_tokens=2048,
+            base_url="http://localhost:11434",
+        )
+
+        async with AsyncClient() as http_client:
+            model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
+
+        assert str(model.client.base_url) == "http://localhost:11434/v1/"
+
+    @pytest.mark.asyncio
+    async def test_build_model_preserves_explicit_ollama_v1_base_url(self) -> None:
+        config = AssistantLLMConfig(
+            provider="ollama",
+            model_name="gemma4:e4b",
+            api_key=SecretStr("ollama-key"),
+            timeout_seconds=30.0,
+            temperature=0.2,
+            max_tokens=2048,
+            base_url="http://localhost:11434/v1",
+        )
+
+        async with AsyncClient() as http_client:
+            model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
+
+        assert str(model.client.base_url) == "http://localhost:11434/v1/"
+
+    @pytest.mark.asyncio
     async def test_build_model_uses_anthropic_provider(self) -> None:
         config = AssistantLLMConfig(
             provider="anthropic",

--- a/backend/tests/features/assistant/test_llm_generator.py
+++ b/backend/tests/features/assistant/test_llm_generator.py
@@ -85,22 +85,6 @@ class TestSummaryLLMGenerator:
 
         assert str(model.client.base_url) == "http://localhost:11434/v1/"
 
-    @pytest.mark.asyncio
-    async def test_build_model_uses_anthropic_provider(self) -> None:
-        config = AssistantLLMConfig(
-            provider="anthropic",
-            model_name="claude-test",
-            api_key=SecretStr("anthropic-key"),
-            timeout_seconds=30.0,
-            temperature=0.2,
-            max_tokens=2048,
-        )
-
-        async with AsyncClient() as http_client:
-            model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
-
-        assert model.__class__.__name__ == "AnthropicModel"
-
     def test_build_model_settings_omits_temperature_for_livai_gpt5(self) -> None:
         config = AssistantLLMConfig(
             provider="livai",
@@ -132,14 +116,15 @@ class TestSummaryLLMGenerator:
             "max_tokens": 2048,
         }
 
-    def test_build_model_settings_includes_tuning_for_openai(self) -> None:
+    def test_build_model_settings_includes_tuning_for_ollama(self) -> None:
         config = AssistantLLMConfig(
-            provider="openai",
-            model_name="gpt-test",
-            api_key=SecretStr("openai-key"),
+            provider="ollama",
+            model_name="gemma4:26b",
+            api_key=None,
             timeout_seconds=30.0,
             temperature=0.2,
             max_tokens=2048,
+            base_url="http://localhost:11434",
         )
 
         assert SummaryLLMGenerator(config)._build_model_settings() == {
@@ -150,12 +135,13 @@ class TestSummaryLLMGenerator:
     def test_build_user_prompt_includes_snapshot_and_allowed_citations(self) -> None:
         prompt = SummaryLLMGenerator(
             AssistantLLMConfig(
-                provider="openai",
-                model_name="gpt-test",
-                api_key=SecretStr("openai-key"),
+                provider="livai",
+                model_name="livai-model",
+                api_key=SecretStr("livai-key"),
                 timeout_seconds=30.0,
                 temperature=0.2,
                 max_tokens=2048,
+                base_url="https://example.livai.test/v1",
             )
         )._build_user_prompt(_make_snapshot())
 
@@ -200,12 +186,13 @@ class TestSummaryLLMGenerator:
 
         generator = SummaryLLMGenerator(
             AssistantLLMConfig(
-                provider="openai",
-                model_name="gpt-test",
-                api_key=SecretStr("openai-key"),
+                provider="livai",
+                model_name="livai-model",
+                api_key=SecretStr("livai-key"),
                 timeout_seconds=30.0,
                 temperature=0.2,
                 max_tokens=2048,
+                base_url="https://example.livai.test/v1",
             )
         )
 

--- a/backend/tests/features/assistant/test_llm_generator.py
+++ b/backend/tests/features/assistant/test_llm_generator.py
@@ -68,6 +68,7 @@ class TestSummaryLLMGenerator:
             model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
 
         assert str(model.client.base_url) == "http://localhost:11434/v1/"
+        assert model.client.api_key == "api-key-not-set"
 
     @pytest.mark.asyncio
     async def test_build_model_preserves_explicit_ollama_v1_base_url(self) -> None:

--- a/backend/tests/features/assistant/test_llm_generator.py
+++ b/backend/tests/features/assistant/test_llm_generator.py
@@ -178,6 +178,17 @@ class TestSummaryLLMGenerator:
             in llm_generator.SUMMARY_SYSTEM_PROMPT
         )
         assert "Do not repeat raw citation paths" in llm_generator.SUMMARY_SYSTEM_PROMPT
+        assert (
+            "Every `citations.path` value must exactly match one allowed path string."
+            in (llm_generator.SUMMARY_SYSTEM_PROMPT)
+        )
+        assert (
+            "use `simulation.status`, `case.name`, and `machine.name`, not `status` or `name`."
+            in llm_generator.SUMMARY_SYSTEM_PROMPT
+        )
+        assert "`suggested_followups` must contain at least one concrete item." in (
+            llm_generator.SUMMARY_SYSTEM_PROMPT
+        )
 
     def test_build_output_type_uses_prompted_output_for_ollama(self) -> None:
         output_type = SummaryLLMGenerator(

--- a/backend/tests/features/assistant/test_orchestrator.py
+++ b/backend/tests/features/assistant/test_orchestrator.py
@@ -18,6 +18,7 @@ from app.features.assistant.snapshot import (
     SnapshotBudgetExceededError,
     SnapshotCaseFields,
     SnapshotLink,
+    SnapshotMachineFields,
     SnapshotSimulationFields,
 )
 from app.features.simulation.models import Simulation
@@ -208,6 +209,87 @@ class TestValidationHelpers:
                 _make_snapshot(),
             )
 
+    def test_standardize_citations_canonicalizes_unambiguous_suffix_path(self) -> None:
+        result = orchestrator._standardize_citations(
+            [
+                SummaryCitationOut(
+                    source_type="simulation_field",
+                    path="status",
+                    label="Status",
+                )
+            ],
+            _make_snapshot(),
+        )
+
+        assert result == [
+            SummaryCitationOut(
+                source_type="simulation_field",
+                path="simulation.status",
+                label="Simulation status",
+            )
+        ]
+
+    def test_standardize_citations_rejects_ambiguous_suffix_path(self) -> None:
+        with pytest.raises(ValueError, match="invalid_citation_path:name"):
+            orchestrator._standardize_citations(
+                [
+                    SummaryCitationOut(
+                        source_type="simulation_field",
+                        path="name",
+                        label="Name",
+                    )
+                ],
+                _make_snapshot(),
+            )
+
+    def test_standardize_citations_uses_source_type_to_disambiguate_suffix_path(
+        self,
+    ) -> None:
+        result = orchestrator._standardize_citations(
+            [
+                SummaryCitationOut(
+                    source_type="case_field",
+                    path="name",
+                    label="Name",
+                )
+            ],
+            _make_snapshot(),
+        )
+
+        assert result == [
+            SummaryCitationOut(
+                source_type="case_field",
+                path="case.name",
+                label="Case name",
+            )
+        ]
+
+    def test_standardize_citations_uses_source_type_for_machine_name_suffix_path(
+        self,
+    ) -> None:
+        snapshot = _make_snapshot().model_copy(
+            update={"machine": SnapshotMachineFields(name="perlmutter")}
+        )
+
+        result = orchestrator._standardize_citations(
+            [
+                SummaryCitationOut(
+                    source_type="machine_field",
+                    path="name",
+                    label="Name",
+                )
+            ],
+            snapshot,
+        )
+
+        assert result == [
+            SummaryCitationOut(
+                source_type="machine_field",
+                path="machine.name",
+                label="Machine name",
+            )
+        ]
+
     def test_standardize_citations_rejects_missing_snapshot_path(self) -> None:
         with pytest.raises(ValueError, match="missing_citation_path:machine.name"):
             orchestrator._standardize_citations(
@@ -254,6 +336,18 @@ class TestValidationHelpers:
 
         assert result.answer == (
             "Simulation assistant-livai-exec belongs to case assistant_livai_case."
+        )
+
+    def test_fill_missing_llm_followups_uses_deterministic_followups(self) -> None:
+        snapshot = _make_snapshot()
+
+        result = orchestrator._fill_missing_llm_followups(
+            _make_llm_content(suggested_followups=[]),
+            snapshot,
+        )
+
+        assert result.suggested_followups == (
+            orchestrator.build_simulation_summary(snapshot).suggested_followups
         )
 
     def test_snapshot_has_citation_path_supports_related_record_selectors(self) -> None:
@@ -495,6 +589,129 @@ class TestGenerateSimulationSummary:
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"
         assert LLM_FALLBACK_CAVEAT in result.summary.caveats
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_keeps_llm_mode_when_followups_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_livai_settings(monkeypatch)
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            return _make_llm_content(suggested_followups=[])
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason is None
+        assert result.summary.generation_mode == "llm"
+        assert result.summary.generation_provider == "livai"
+        assert result.summary.generation_model == "livai-model"
+        assert result.summary.suggested_followups == (
+            orchestrator.build_simulation_summary(snapshot).suggested_followups
+        )
+        assert result.attempted_provider == "livai"
+        assert result.attempted_model == "livai-model"
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_canonicalizes_unambiguous_citation_alias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model="llama3.1:8b")
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            return _make_llm_content(
+                citations=[
+                    SummaryCitationOut(
+                        source_type="simulation_field",
+                        path="status",
+                        label="Status",
+                    )
+                ]
+            )
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason is None
+        assert result.summary.generation_mode == "llm"
+        assert result.summary.generation_provider == "ollama"
+        assert result.summary.generation_model == "llama3.1:8b"
+        assert result.summary.citations == [
+            SummaryCitationOut(
+                source_type="simulation_field",
+                path="simulation.status",
+                label="Simulation status",
+            )
+        ]
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model == "llama3.1:8b"
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_uses_source_type_to_fix_name_alias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model="llama3.1:8b")
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            return _make_llm_content(
+                citations=[
+                    SummaryCitationOut(
+                        source_type="case_field",
+                        path="name",
+                        label="Name",
+                    )
+                ]
+            )
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason is None
+        assert result.summary.generation_mode == "llm"
+        assert result.summary.generation_provider == "ollama"
+        assert result.summary.generation_model == "llama3.1:8b"
+        assert result.summary.citations == [
+            SummaryCitationOut(
+                source_type="case_field",
+                path="case.name",
+                label="Case name",
+            )
+        ]
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model == "llama3.1:8b"
 
     @pytest.mark.asyncio
     async def test_generate_simulation_summary_falls_back_on_unexpected_exception(

--- a/backend/tests/features/assistant/test_orchestrator.py
+++ b/backend/tests/features/assistant/test_orchestrator.py
@@ -89,6 +89,24 @@ def _set_livai_settings(
     monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
 
 
+def _set_ollama_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enabled: bool = True,
+    api_key: SecretStr | None = None,
+    model: str | None = "gemma4:26b",
+    base_url: str = "http://localhost:11434",
+) -> None:
+    monkeypatch.setattr(settings, "assistant_llm_enabled", enabled)
+    monkeypatch.setattr(settings, "assistant_llm_provider", "ollama")
+    monkeypatch.setattr(settings, "assistant_ollama_api_key", api_key)
+    monkeypatch.setattr(settings, "assistant_ollama_model", model)
+    monkeypatch.setattr(settings, "assistant_ollama_base_url", base_url)
+    monkeypatch.setattr(settings, "assistant_llm_timeout_seconds", 30.0)
+    monkeypatch.setattr(settings, "assistant_llm_temperature", 0.2)
+    monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
+
+
 class TestResolveLLMConfig:
     def test_resolve_llm_config_for_openai_returns_expected_config(
         self, monkeypatch: pytest.MonkeyPatch
@@ -106,6 +124,7 @@ class TestResolveLLMConfig:
 
         assert config.provider == "openai"
         assert config.model_name == "gpt-test"
+        assert config.api_key is not None
         assert config.api_key.get_secret_value() == "openai-key"
         assert config.temperature == 0.2
         assert config.max_tokens == 2048
@@ -119,8 +138,22 @@ class TestResolveLLMConfig:
 
         assert config.provider == "livai"
         assert config.model_name == "livai-model"
+        assert config.api_key is not None
         assert config.api_key.get_secret_value() == "livai-key"
         assert config.base_url == "https://api.livai.llnl.gov/v1"
+
+    @pytest.mark.parametrize("model_name", ["gemma4:e4b", "gemma4:26b"])
+    def test_resolve_llm_config_for_ollama_uses_configured_model_and_base_url(
+        self, monkeypatch: pytest.MonkeyPatch, model_name: str
+    ) -> None:
+        _set_ollama_settings(monkeypatch, model=model_name)
+
+        config = orchestrator._resolve_llm_config()
+
+        assert config.provider == "ollama"
+        assert config.model_name == model_name
+        assert config.api_key is None
+        assert config.base_url == "http://localhost:11434"
 
     def test_resolve_llm_config_for_anthropic_returns_expected_config(
         self, monkeypatch: pytest.MonkeyPatch
@@ -138,6 +171,7 @@ class TestResolveLLMConfig:
 
         assert config.provider == "anthropic"
         assert config.model_name == "claude-test"
+        assert config.api_key is not None
         assert config.api_key.get_secret_value() == "anthropic-key"
         assert config.temperature == 0.2
         assert config.max_tokens == 2048
@@ -162,6 +196,24 @@ class TestResolveLLMConfig:
         with pytest.raises(ValueError, match="anthropic_misconfigured"):
             orchestrator._resolve_llm_config()
 
+    @pytest.mark.parametrize(
+        ("model", "base_url"),
+        [
+            (None, "http://localhost:11434"),
+            ("gemma4:26b", ""),
+        ],
+    )
+    def test_resolve_llm_config_rejects_ollama_misconfiguration(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        model: str | None,
+        base_url: str,
+    ) -> None:
+        _set_ollama_settings(monkeypatch, model=model, base_url=base_url)
+
+        with pytest.raises(ValueError, match="ollama_misconfigured"):
+            orchestrator._resolve_llm_config()
+
     def test_resolve_llm_config_rejects_unsupported_provider(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -176,6 +228,7 @@ class TestResolveLLMConfig:
             ("openai", "gpt-test"),
             ("anthropic", "claude-test"),
             ("livai", "livai-model"),
+            ("ollama", "gemma4:26b"),
         ],
     )
     def test_configured_model_name_uses_provider_setting(
@@ -189,6 +242,7 @@ class TestResolveLLMConfig:
         monkeypatch.setattr(settings, "assistant_openai_model", "gpt-test")
         monkeypatch.setattr(settings, "assistant_anthropic_model", "claude-test")
         monkeypatch.setattr(settings, "assistant_livai_model", "livai-model")
+        monkeypatch.setattr(settings, "assistant_ollama_model", "gemma4:26b")
 
         assert (
             orchestrator._configured_model_name(
@@ -334,6 +388,36 @@ class TestGenerateSimulationSummary:
         assert result.attempted_model == "livai-model"
 
     @pytest.mark.asyncio
+    async def test_generate_simulation_summary_returns_ollama_provider_on_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model="gemma4:26b")
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            return _make_llm_content()
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason is None
+        assert result.summary.generation_mode == "llm"
+        assert result.summary.generation_provider == "ollama"
+        assert result.summary.generation_model == "gemma4:26b"
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model == "gemma4:26b"
+
+    @pytest.mark.asyncio
     async def test_generate_simulation_summary_falls_back_for_livai_misconfiguration(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -353,6 +437,28 @@ class TestGenerateSimulationSummary:
         assert result.summary.generation_model is None
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"
+        assert LLM_FALLBACK_CAVEAT in result.summary.caveats
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_falls_back_for_ollama_misconfiguration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model=None)
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == "ollama_misconfigured"
+        assert result.summary.generation_mode == "deterministic"
+        assert result.summary.generation_provider is None
+        assert result.summary.generation_model is None
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model is None
         assert LLM_FALLBACK_CAVEAT in result.summary.caveats
 
     @pytest.mark.asyncio

--- a/backend/tests/features/assistant/test_orchestrator.py
+++ b/backend/tests/features/assistant/test_orchestrator.py
@@ -5,7 +5,11 @@ from pydantic import SecretStr
 
 from app.core.config import settings
 from app.features.assistant import orchestrator
-from app.features.assistant.schemas import SimulationSummaryContent, SummaryCitationOut
+from app.features.assistant.schemas import (
+    SimulationSummaryContent,
+    SummaryCitationOut,
+    SummaryGenerationProvider,
+)
 from app.features.assistant.service import LLM_FALLBACK_CAVEAT
 from app.features.assistant.snapshot import (
     SimulationSnapshot,
@@ -108,27 +112,6 @@ def _set_ollama_settings(
 
 
 class TestResolveLLMConfig:
-    def test_resolve_llm_config_for_openai_returns_expected_config(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(settings, "assistant_llm_provider", "openai")
-        monkeypatch.setattr(
-            settings, "assistant_openai_api_key", SecretStr("openai-key")
-        )
-        monkeypatch.setattr(settings, "assistant_openai_model", "gpt-test")
-        monkeypatch.setattr(settings, "assistant_llm_timeout_seconds", 20.0)
-        monkeypatch.setattr(settings, "assistant_llm_temperature", 0.2)
-        monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
-
-        config = orchestrator._resolve_llm_config()
-
-        assert config.provider == "openai"
-        assert config.model_name == "gpt-test"
-        assert config.api_key is not None
-        assert config.api_key.get_secret_value() == "openai-key"
-        assert config.temperature == 0.2
-        assert config.max_tokens == 2048
-
     def test_resolve_llm_config_for_livai_uses_wrapper_key_and_base_url(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -154,47 +137,6 @@ class TestResolveLLMConfig:
         assert config.model_name == model_name
         assert config.api_key is None
         assert config.base_url == "http://localhost:11434"
-
-    def test_resolve_llm_config_for_anthropic_returns_expected_config(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(settings, "assistant_llm_provider", "anthropic")
-        monkeypatch.setattr(
-            settings, "assistant_anthropic_api_key", SecretStr("anthropic-key")
-        )
-        monkeypatch.setattr(settings, "assistant_anthropic_model", "claude-test")
-        monkeypatch.setattr(settings, "assistant_llm_timeout_seconds", 15.0)
-        monkeypatch.setattr(settings, "assistant_llm_temperature", 0.2)
-        monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
-
-        config = orchestrator._resolve_llm_config()
-
-        assert config.provider == "anthropic"
-        assert config.model_name == "claude-test"
-        assert config.api_key is not None
-        assert config.api_key.get_secret_value() == "anthropic-key"
-        assert config.temperature == 0.2
-        assert config.max_tokens == 2048
-
-    def test_resolve_llm_config_rejects_openai_misconfiguration(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(settings, "assistant_llm_provider", "openai")
-        monkeypatch.setattr(settings, "assistant_openai_api_key", None)
-        monkeypatch.setattr(settings, "assistant_openai_model", "gpt-test")
-
-        with pytest.raises(ValueError, match="openai_misconfigured"):
-            orchestrator._resolve_llm_config()
-
-    def test_resolve_llm_config_rejects_anthropic_misconfiguration(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(settings, "assistant_llm_provider", "anthropic")
-        monkeypatch.setattr(settings, "assistant_anthropic_api_key", None)
-        monkeypatch.setattr(settings, "assistant_anthropic_model", "claude-test")
-
-        with pytest.raises(ValueError, match="anthropic_misconfigured"):
-            orchestrator._resolve_llm_config()
 
     @pytest.mark.parametrize(
         ("model", "base_url"),
@@ -225,8 +167,6 @@ class TestResolveLLMConfig:
     @pytest.mark.parametrize(
         ("provider", "expected"),
         [
-            ("openai", "gpt-test"),
-            ("anthropic", "claude-test"),
             ("livai", "livai-model"),
             ("ollama", "gemma4:26b"),
         ],
@@ -234,22 +174,13 @@ class TestResolveLLMConfig:
     def test_configured_model_name_uses_provider_setting(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        provider: str,
+        provider: SummaryGenerationProvider,
         expected: str,
     ) -> None:
-        from app.features.assistant.schemas import SummaryGenerationProvider
-
-        monkeypatch.setattr(settings, "assistant_openai_model", "gpt-test")
-        monkeypatch.setattr(settings, "assistant_anthropic_model", "claude-test")
         monkeypatch.setattr(settings, "assistant_livai_model", "livai-model")
         monkeypatch.setattr(settings, "assistant_ollama_model", "gemma4:26b")
 
-        assert (
-            orchestrator._configured_model_name(
-                cast(SummaryGenerationProvider, provider)
-            )
-            == expected
-        )
+        assert orchestrator._configured_model_name(provider) == expected
 
 
 class TestValidationHelpers:

--- a/backend/tests/features/assistant/test_orchestrator.py
+++ b/backend/tests/features/assistant/test_orchestrator.py
@@ -389,6 +389,7 @@ class TestGenerateSimulationSummary:
 
         assert result.fallback_reason == "llm_disabled"
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is False
         assert result.attempted_provider is None
         assert result.attempted_model is None
 
@@ -465,6 +466,7 @@ class TestGenerateSimulationSummary:
 
         assert result.fallback_reason is None
         assert result.summary.generation_mode == "llm"
+        assert result.summary.fallback_used is False
         assert result.summary.generation_provider == "ollama"
         assert result.summary.generation_model == "gemma4:26b"
         assert result.attempted_provider == "ollama"
@@ -508,6 +510,7 @@ class TestGenerateSimulationSummary:
 
         assert result.fallback_reason == "ollama_misconfigured"
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is True
         assert result.summary.generation_provider is None
         assert result.summary.generation_model is None
         assert result.attempted_provider == "ollama"
@@ -535,6 +538,7 @@ class TestGenerateSimulationSummary:
         assert result.fallback_reason is not None
         assert result.fallback_reason.startswith("Snapshot size ")
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is True
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"
         assert LLM_FALLBACK_CAVEAT in result.summary.caveats
@@ -559,6 +563,7 @@ class TestGenerateSimulationSummary:
 
         assert result.fallback_reason == "llm_disabled"
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is False
         assert result.attempted_provider is None
         assert result.attempted_model is None
         assert LLM_FALLBACK_CAVEAT not in result.summary.caveats
@@ -588,6 +593,7 @@ class TestGenerateSimulationSummary:
 
         assert result.fallback_reason == "missing_limitations"
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is True
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"
         assert LLM_FALLBACK_CAVEAT in result.summary.caveats
@@ -740,6 +746,7 @@ class TestGenerateSimulationSummary:
 
         assert result.fallback_reason == "RuntimeError: boom"
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is True
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"
 

--- a/backend/tests/features/assistant/test_orchestrator.py
+++ b/backend/tests/features/assistant/test_orchestrator.py
@@ -360,14 +360,16 @@ class TestValidationHelpers:
             }
         )
 
-        assert orchestrator.snapshot_has_citation_path(
+        assert orchestrator._snapshot_has_citation_path(
             snapshot, "artifacts[kind=output]"
         )
-        assert orchestrator.snapshot_has_citation_path(
+        assert orchestrator._snapshot_has_citation_path(
             snapshot, "links[kind=diagnostic]"
         )
-        assert not orchestrator.snapshot_has_citation_path(snapshot, "links[kind=docs]")
-        assert not orchestrator.snapshot_has_citation_path(snapshot, "invalid.path")
+        assert not orchestrator._snapshot_has_citation_path(
+            snapshot, "links[kind=docs]"
+        )
+        assert not orchestrator._snapshot_has_citation_path(snapshot, "invalid.path")
 
 
 class TestGenerateSimulationSummary:
@@ -736,7 +738,7 @@ class TestGenerateSimulationSummary:
 
         result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
 
-        assert result.fallback_reason == "RuntimeError"
+        assert result.fallback_reason == "RuntimeError: boom"
         assert result.summary.generation_mode == "deterministic"
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"

--- a/backend/tests/features/assistant/test_orchestrator.py
+++ b/backend/tests/features/assistant/test_orchestrator.py
@@ -2,6 +2,7 @@ from typing import cast
 
 import pytest
 from pydantic import SecretStr
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 
 from app.core.config import settings
 from app.features.assistant import orchestrator
@@ -184,6 +185,16 @@ class TestResolveLLMConfig:
 
 
 class TestValidationHelpers:
+    def test_normalize_llm_answer_strips_inline_citation_markers(self) -> None:
+        answer = (
+            "This simulation completed [simulation.status]. It ran on chrysalis "
+            "[machine.name] and used WCYCL20TR [simulation.compset]."
+        )
+
+        assert orchestrator._normalize_llm_answer(answer) == (
+            "This simulation completed. It ran on chrysalis and used WCYCL20TR."
+        )
+
     def test_standardize_citations_rejects_invalid_path(self) -> None:
         with pytest.raises(ValueError, match="invalid_citation_path:invalid.path"):
             orchestrator._standardize_citations(
@@ -229,6 +240,21 @@ class TestValidationHelpers:
                 _make_llm_content(**overrides),
                 _make_snapshot(),
             )
+
+    def test_validate_llm_content_normalizes_inline_citation_markers(self) -> None:
+        result = orchestrator._validate_llm_content(
+            _make_llm_content(
+                answer=(
+                    "Simulation assistant-livai-exec belongs to case "
+                    "assistant_livai_case [case.name]."
+                )
+            ),
+            _make_snapshot(),
+        )
+
+        assert result.answer == (
+            "Simulation assistant-livai-exec belongs to case assistant_livai_case."
+        )
 
     def test_snapshot_has_citation_path_supports_related_record_selectors(self) -> None:
         snapshot = _make_snapshot().model_copy(
@@ -497,3 +523,65 @@ class TestGenerateSimulationSummary:
         assert result.summary.generation_mode == "deterministic"
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_preserves_model_api_error_details(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model="gemma4:e4b")
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            raise ModelAPIError("gemma4:e4b", "unsupported value for tools")
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == ("ModelAPIError: unsupported value for tools")
+        assert result.summary.generation_mode == "deterministic"
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model == "gemma4:e4b"
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_preserves_model_http_error_details(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model="gemma4:e4b")
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            raise ModelHTTPError(
+                400,
+                "gemma4:e4b",
+                {"error": {"message": "unknown field `tools`"}},
+            )
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == (
+            'ModelHTTPError: status_code=400; body={"error": {"message": "unknown field `tools`"}}'
+        )
+        assert result.summary.generation_mode == "deterministic"
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model == "gemma4:e4b"

--- a/backend/tests/features/assistant/test_orchestrator.py
+++ b/backend/tests/features/assistant/test_orchestrator.py
@@ -229,6 +229,11 @@ class TestValidationHelpers:
             )
         ]
 
+    def test_canonicalize_citation_path_uses_unique_suffix_without_source_type(
+        self,
+    ) -> None:
+        assert orchestrator._canonicalize_citation_path("status") == "simulation.status"
+
     def test_standardize_citations_rejects_ambiguous_suffix_path(self) -> None:
         with pytest.raises(ValueError, match="invalid_citation_path:name"):
             orchestrator._standardize_citations(
@@ -370,6 +375,12 @@ class TestValidationHelpers:
             snapshot, "links[kind=docs]"
         )
         assert not orchestrator._snapshot_has_citation_path(snapshot, "invalid.path")
+
+    def test_format_model_error_uses_exception_name_when_message_blank(self) -> None:
+        assert orchestrator._format_model_error(Exception()) == "Exception"
+
+    def test_trim_fallback_reason_adds_ellipsis_when_limit_exceeded(self) -> None:
+        assert orchestrator._trim_fallback_reason("abcdef", limit=5) == "ab..."
 
 
 class TestGenerateSimulationSummary:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -39,25 +39,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.102.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/47/cb2a71f70431fb09af4db83e3ea89eb2dd8e0e348d27af53ed32e6c599dd/anthropic-0.102.0.tar.gz", hash = "sha256:96f747cad11886c4ae12d4080131b94eebd68b202bd2190fe27959031bb1fa9c", size = 763697, upload-time = "2026-05-13T18:12:41.624Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/75/0f6c603594876413bc858a00e7cc0d80a0cc14edf5c7b959a3ea6ec45e44/anthropic-0.102.0-py3-none-any.whl", hash = "sha256:ab96540bbd4b0f36564252d955a86f8abbe4f00944a24bc9931acc9b139bab6f", size = 763070, upload-time = "2026-05-13T18:12:43.474Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -534,15 +515,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -1632,9 +1604,6 @@ wheels = [
 ]
 
 [package.optional-dependencies]
-anthropic = [
-    { name = "anthropic" },
-]
 openai = [
     { name = "openai" },
     { name = "tiktoken" },
@@ -2196,7 +2165,7 @@ dependencies = [
     { name = "fastapi-users", extra = ["oauth", "sqlalchemy"] },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
-    { name = "pydantic-ai-slim", extra = ["anthropic", "openai"] },
+    { name = "pydantic-ai-slim", extra = ["openai"] },
     { name = "pydantic-settings" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
@@ -2226,7 +2195,7 @@ requires-dist = [
     { name = "fastapi-users", extras = ["sqlalchemy", "oauth"], specifier = ">=14.0.0,<15.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.1,<3.3.0" },
     { name = "pydantic", specifier = ">=2.12.3,<2.13.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], specifier = ">=1.0.0,<2.0.0" },
+    { name = "pydantic-ai-slim", extras = ["openai"], specifier = ">=1.0.0,<2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },

--- a/docs/ai-196-local-llm/README.md
+++ b/docs/ai-196-local-llm/README.md
@@ -4,43 +4,106 @@ Issue: [#196](https://github.com/E3SM-Project/simboard/issues/196)
 
 ## Task
 
-Add locally hosted LLM provider support, starting with Ollama, by extending the existing `dev-ai` assistant summary backend.
+Add local LLM support for SimBoard AI-assisted simulation summaries and related assistance using Ollama as local inference runtime and Gemma 4 as preferred open-weight model family.
 
 ## Scope
 
 ### In scope
 
-- Extend assistant provider config and runtime selection in backend.
-- Add Ollama/local endpoint and model support for existing summary generation flow.
-- Update env templates and developer/deployment docs.
-- Add backend tests for config, provider resolution, client construction, and fallback behavior.
+- Extend existing assistant summary backend to support local Ollama-backed generation.
+- Keep backend model-configurable so runtime is not hardcoded to one Gemma 4 tag.
+- Prefer Gemma 4 family for local prototype guidance and quality testing.
+- Preserve source-grounded summary behavior, structured output contracts, and deterministic fallback behavior.
+- Keep retrieval small, curated, and prototype-oriented when used.
+- Update env templates and developer docs for local Ollama setup.
+- Add backend and contract tests for config, adapter behavior, validation, fallback, and API-path coverage.
 
 ### Out of scope
 
 - New frontend model or provider controls.
-- Shipping Ollama container manifests or Docker Compose setup.
-- Retrieval, tool use, or broader agent features beyond the current summary endpoint.
+- Shipping Ollama container manifests or Docker Compose assets in this repo.
+- Broad RAG architecture, vector databases, or large ingestion/indexing work for this phase.
+- Non-Ollama local runtimes for this prototype.
 
-## Approach
+## Recommended model path
+
+- `gemma4:e4b`
+  - Use for fast local development, adapter testing, UI iteration, and prompt-contract validation.
+- `gemma4:26b`
+  - Use as preferred quality target for SimBoard summaries, comparisons, and source-grounded assistance.
+- `gemma4:31b`
+  - Treat as optional if hardware allows and `gemma4:26b` quality is insufficient.
+
+Plan should document Gemma 4 as recommended Ollama family, but implementation must remain model-configurable so another Ollama-served model can be swapped through config without code changes.
+
+## Configuration
+
+Use existing SimBoard assistant env naming rather than introducing a second env namespace.
+
+Required repo-facing settings:
+
+```env
+ASSISTANT_LLM_ENABLED=true
+ASSISTANT_LLM_PROVIDER=ollama
+ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
+ASSISTANT_OLLAMA_MODEL=gemma4:26b
+ASSISTANT_OLLAMA_API_KEY=
+ASSISTANT_LLM_TIMEOUT_SECONDS=30
+ASSISTANT_LLM_TEMPERATURE=0.2
+ASSISTANT_LLM_MAX_TOKENS=2048
+```
+
+Local runtime example equivalent:
+
+```env
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=gemma4:26b
+```
+
+Doc guidance should explain:
+
+- switch to `gemma4:e4b` for fast local iteration
+- switch back to `gemma4:26b` for quality checks
+- use `gemma4:31b` only when local hardware supports it
+- Ollama remains runtime; model tag remains config
+
+## Implementation approach
 
 1. Extend provider enums and config types in [backend/app/features/assistant/schemas.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/schemas.py) and [backend/app/core/config.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/core/config.py) to include `ollama`.
-2. Add Ollama settings in config and env docs:
+2. Add Ollama config fields in [backend/app/core/config.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/core/config.py):
    - `ASSISTANT_OLLAMA_BASE_URL`
    - `ASSISTANT_OLLAMA_MODEL`
-   - optional auth/header setting only if a real deployment needs it
-3. Refactor provider resolution in [backend/app/features/assistant/orchestrator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/orchestrator.py) so Ollama becomes one more supported provider without changing deterministic fallback behavior.
-4. Update [backend/app/features/assistant/llm_generator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/llm_generator.py) to build the Ollama/local client.
-5. Prefer the existing OpenAI-compatible path if Ollama works with the current `pydantic_ai` structured output contract; otherwise add the smallest provider-specific branch needed for Ollama.
-6. Keep the assistant API and response schema unchanged unless local-provider constraints force a change.
-7. Preserve current logging and fallback semantics:
-   - attempted provider/model logged
-   - deterministic fallback on misconfig, timeout, unreachable endpoint, or invalid structured output
-8. Update docs and examples in:
+   - `ASSISTANT_OLLAMA_API_KEY` if endpoint protection is required by local or proxied deployment
+3. Refactor provider resolution in [backend/app/features/assistant/orchestrator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/orchestrator.py) so provider selection and model selection stay config-driven.
+4. Keep integration model-agnostic through adapter boundary in [backend/app/features/assistant/llm_generator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/llm_generator.py):
+   - prompt construction isolated from transport details
+   - model invocation isolated behind provider/model adapter
+   - response validation isolated from provider client
+   - persistence and API response assembly isolated from generation path
+5. Prefer existing OpenAI-compatible path if Ollama works cleanly through current `pydantic_ai` structured output flow; otherwise add smallest Ollama-specific adapter branch needed without hardcoding Gemma 4 tags into invocation logic.
+6. Preserve structured output contract for summaries:
+   - response shape defined in Pydantic schema
+   - JSON/schema validation applied before persistence or API success response
+   - invalid or incomplete model output triggers deterministic fallback
+7. Keep summaries source-grounded:
+   - use only SimBoard metadata and small curated context supplied by backend
+   - when retrieved or injected context is used, include explicit citation/source fields tied to allowed source paths
+   - reject unsupported free-form claims through validation and fallback path
+8. Keep API shape stable except for extending `generation_provider` to allow `ollama`, and update [frontend/src/types/simulation.ts](/Users/vo13/Repositories/tomvothecoder/simboard/frontend/src/types/simulation.ts) to match.
+9. Update docs and examples in:
    - [.envs/example/backend.env.example](/Users/vo13/Repositories/tomvothecoder/simboard/.envs/example/backend.env.example)
    - [.envs/example/backend.production.env.example](/Users/vo13/Repositories/tomvothecoder/simboard/.envs/example/backend.production.env.example)
    - [backend/README.md](/Users/vo13/Repositories/tomvothecoder/simboard/backend/README.md)
    - [docs/developer/README.md](/Users/vo13/Repositories/tomvothecoder/simboard/docs/developer/README.md)
-   - [docs/deploy/spin.md](/Users/vo13/Repositories/tomvothecoder/simboard/docs/deploy/spin.md) if Spin secret/env guidance should mention assistant vars
+   - document one supported local Ollama bootstrap path using upstream Ollama install/container guidance plus `gemma4:e4b` and `gemma4:26b` pull/run steps
+   - [docs/deploy/spin.md](/Users/vo13/Repositories/tomvothecoder/simboard/docs/deploy/spin.md) only if deployment env guidance should mention assistant vars
+
+## Retrieval constraints for this phase
+
+- No broad RAG rollout.
+- No vector DB requirement.
+- No automatic large-context corpus assembly.
+- If retrieval is used, keep it small, explicit, curated, and easy to inspect in tests and logs.
 
 ## Tests
 
@@ -48,33 +111,53 @@ Add locally hosted LLM provider support, starting with Ollama, by extending the 
 
 - [backend/tests/core/test_config.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/core/test_config.py)
   - Ollama env vars load and normalize correctly.
+  - `ASSISTANT_OLLAMA_MODEL` remains arbitrary string config, not hardcoded allowlist.
+  - Missing base URL or model yields stable misconfiguration behavior.
 - [backend/tests/features/assistant/test_orchestrator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/features/assistant/test_orchestrator.py)
-  - Ollama config resolves.
-  - Ollama misconfig falls back with a stable reason.
-  - Ollama success reports `generation_provider == "ollama"`.
+  - Ollama config resolves from env-backed settings.
+  - `gemma4:e4b` and `gemma4:26b` both resolve without code changes.
+  - Ollama misconfig falls back with stable reason.
+  - Ollama success reports `generation_provider == "ollama"` and configured model name.
 - [backend/tests/features/assistant/test_llm_generator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/features/assistant/test_llm_generator.py)
-  - Client/model builder uses the Ollama base URL correctly.
-  - Model settings remain compatible with local provider behavior.
-- Optional: [backend/tests/features/assistant/test_api.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/features/assistant/test_api.py)
-  - Summary route still returns deterministic fallback when the Ollama path fails.
+  - Client/model builder uses Ollama base URL correctly.
+  - Invocation path is model-agnostic and uses configured model name.
+  - Model settings remain compatible with Gemma 4 local behavior.
+  - Invalid model output fails validation safely.
+- [backend/tests/features/assistant/test_api.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/features/assistant/test_api.py)
+  - Summary route returns deterministic fallback when Ollama path fails.
+  - Summary route returns `generation_provider == "ollama"` and configured model on success.
+  - Response shape stays grounded and does not emit unsupported free-form fields.
 
 ### Commands to run
 
 - `make backend-test`
+- `make frontend-lint`
 - Optional focused loop:
-  - `uv run pytest backend/tests/core/test_config.py backend/tests/features/assistant/test_llm_generator.py backend/tests/features/assistant/test_orchestrator.py`
+  - `uv run pytest backend/tests/core/test_config.py backend/tests/features/assistant/test_llm_generator.py backend/tests/features/assistant/test_orchestrator.py backend/tests/features/assistant/test_api.py`
+
+## Acceptance criteria
+
+- `ollama` is supported as assistant provider and is selectable entirely through config.
+- Gemma 4 is documented as recommended Ollama model family for this prototype.
+- Plan clearly distinguishes:
+  - `gemma4:e4b` for fast development and prompt-contract iteration
+  - `gemma4:26b` for preferred summary quality testing
+  - `gemma4:31b` as optional higher-cost fallback
+- Backend can call Ollama successfully using configured base URL and model name.
+- Backend remains model-agnostic at adapter boundary and is not hardcoded to one Gemma 4 tag.
+- Invalid JSON, schema-invalid output, or unsupported grounded fields trigger deterministic fallback rather than unsafe persistence or partial success.
+- Generated summaries remain source-grounded and use explicit citation/source fields when retrieved context is included.
+- `generation_provider` contract includes `ollama` and frontend type mirror stays in sync.
+- `gemma4:e4b` and `gemma4:26b` can both be exercised in tests or local verification without code changes.
 
 ## Risk
 
-- Risk score: `4`
+- Ollama structured output behavior may differ from current hosted-provider path.
+- Smaller Gemma 4 variants may pass format checks but underperform on grounded summary quality.
+- `gemma4:26b` may be too heavy for some developer hardware, so docs must make `gemma4:e4b` first-run path explicit.
+- If validation is too weak, local models may generate plausible but unsupported claims.
+- If validation is too strict, fallback churn may hide useful outputs during prototype iteration.
 
-### Main failure modes
-
-- Ollama is not fully compatible with the current structured-output/client path.
-- Local models produce weaker schema adherence and trigger fallback churn.
-- Provider config grows too provider-specific if the abstraction is not kept tight.
-- Docs drift between local and Spin deployment setup.
-
-## Open Questions
+## Open questions
 
 None.

--- a/docs/ai-196-local-llm/README.md
+++ b/docs/ai-196-local-llm/README.md
@@ -1,0 +1,80 @@
+# AI-196 Local LLM Plan
+
+Issue: [#196](https://github.com/E3SM-Project/simboard/issues/196)
+
+## Task
+
+Add locally hosted LLM provider support, starting with Ollama, by extending the existing `dev-ai` assistant summary backend.
+
+## Scope
+
+### In scope
+
+- Extend assistant provider config and runtime selection in backend.
+- Add Ollama/local endpoint and model support for existing summary generation flow.
+- Update env templates and developer/deployment docs.
+- Add backend tests for config, provider resolution, client construction, and fallback behavior.
+
+### Out of scope
+
+- New frontend model or provider controls.
+- Shipping Ollama container manifests or Docker Compose setup.
+- Retrieval, tool use, or broader agent features beyond the current summary endpoint.
+
+## Approach
+
+1. Extend provider enums and config types in [backend/app/features/assistant/schemas.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/schemas.py) and [backend/app/core/config.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/core/config.py) to include `ollama`.
+2. Add Ollama settings in config and env docs:
+   - `ASSISTANT_OLLAMA_BASE_URL`
+   - `ASSISTANT_OLLAMA_MODEL`
+   - optional auth/header setting only if a real deployment needs it
+3. Refactor provider resolution in [backend/app/features/assistant/orchestrator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/orchestrator.py) so Ollama becomes one more supported provider without changing deterministic fallback behavior.
+4. Update [backend/app/features/assistant/llm_generator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/llm_generator.py) to build the Ollama/local client.
+5. Prefer the existing OpenAI-compatible path if Ollama works with the current `pydantic_ai` structured output contract; otherwise add the smallest provider-specific branch needed for Ollama.
+6. Keep the assistant API and response schema unchanged unless local-provider constraints force a change.
+7. Preserve current logging and fallback semantics:
+   - attempted provider/model logged
+   - deterministic fallback on misconfig, timeout, unreachable endpoint, or invalid structured output
+8. Update docs and examples in:
+   - [.envs/example/backend.env.example](/Users/vo13/Repositories/tomvothecoder/simboard/.envs/example/backend.env.example)
+   - [.envs/example/backend.production.env.example](/Users/vo13/Repositories/tomvothecoder/simboard/.envs/example/backend.production.env.example)
+   - [backend/README.md](/Users/vo13/Repositories/tomvothecoder/simboard/backend/README.md)
+   - [docs/developer/README.md](/Users/vo13/Repositories/tomvothecoder/simboard/docs/developer/README.md)
+   - [docs/deploy/spin.md](/Users/vo13/Repositories/tomvothecoder/simboard/docs/deploy/spin.md) if Spin secret/env guidance should mention assistant vars
+
+## Tests
+
+### Tests to add or update
+
+- [backend/tests/core/test_config.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/core/test_config.py)
+  - Ollama env vars load and normalize correctly.
+- [backend/tests/features/assistant/test_orchestrator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/features/assistant/test_orchestrator.py)
+  - Ollama config resolves.
+  - Ollama misconfig falls back with a stable reason.
+  - Ollama success reports `generation_provider == "ollama"`.
+- [backend/tests/features/assistant/test_llm_generator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/features/assistant/test_llm_generator.py)
+  - Client/model builder uses the Ollama base URL correctly.
+  - Model settings remain compatible with local provider behavior.
+- Optional: [backend/tests/features/assistant/test_api.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/features/assistant/test_api.py)
+  - Summary route still returns deterministic fallback when the Ollama path fails.
+
+### Commands to run
+
+- `make backend-test`
+- Optional focused loop:
+  - `uv run pytest backend/tests/core/test_config.py backend/tests/features/assistant/test_llm_generator.py backend/tests/features/assistant/test_orchestrator.py`
+
+## Risk
+
+- Risk score: `4`
+
+### Main failure modes
+
+- Ollama is not fully compatible with the current structured-output/client path.
+- Local models produce weaker schema adherence and trigger fallback churn.
+- Provider config grows too provider-specific if the abstraction is not kept tight.
+- Docs drift between local and Spin deployment setup.
+
+## Open Questions
+
+None.

--- a/docs/deploy/spin.md
+++ b/docs/deploy/spin.md
@@ -48,6 +48,26 @@ Environment variable keys:
 | `COOKIE_SAMESITE`            | Yes      | `lax`, `strict`, `none`                | `backend`, `migrate` |
 | `COOKIE_MAX_AGE`             | Yes      | seconds as integer                     | `backend`, `migrate` |
 
+Optional assistant summary keys for `simboard-backend-env` when enabling AI summaries:
+
+| Key                          | Required | Example/Allowed Value                  | Used By              |
+| ---------------------------- | -------- | -------------------------------------- | -------------------- |
+| `ASSISTANT_LLM_ENABLED`      | No       | `true` or `false`                      | `backend`, `migrate` |
+| `ASSISTANT_LLM_PROVIDER`     | No       | `ollama`, `openai`, `anthropic`, `livai` | `backend`, `migrate` |
+| `ASSISTANT_OLLAMA_BASE_URL`  | If using Ollama | `http://localhost:11434`         | `backend`, `migrate` |
+| `ASSISTANT_OLLAMA_MODEL`     | If using Ollama | `gemma4:26b`                     | `backend`, `migrate` |
+| `ASSISTANT_OLLAMA_API_KEY`   | No       | proxy auth token or blank              | `backend`, `migrate` |
+| `ASSISTANT_OPENAI_API_KEY`   | If using OpenAI | provider secret                   | `backend`, `migrate` |
+| `ASSISTANT_OPENAI_MODEL`     | If using OpenAI | provider model name               | `backend`, `migrate` |
+| `ASSISTANT_ANTHROPIC_API_KEY`| If using Anthropic | provider secret                | `backend`, `migrate` |
+| `ASSISTANT_ANTHROPIC_MODEL`  | If using Anthropic | provider model name            | `backend`, `migrate` |
+| `ASSISTANT_LIVAI_API_KEY`    | If using LivAI | provider secret                    | `backend`, `migrate` |
+| `ASSISTANT_LIVAI_MODEL`      | If using LivAI | provider model name                | `backend`, `migrate` |
+| `ASSISTANT_LIVAI_BASE_URL`   | If using LivAI | provider base URL                  | `backend`, `migrate` |
+| `ASSISTANT_LLM_TIMEOUT_SECONDS` | No    | `30`                                   | `backend`, `migrate` |
+| `ASSISTANT_LLM_TEMPERATURE`  | No       | `0.2`                                  | `backend`, `migrate` |
+| `ASSISTANT_LLM_MAX_TOKENS`   | No       | `2048`                                 | `backend`, `migrate` |
+
 `simboard-db`:
 
 | Key                 | Required | Example/Allowed Value             | Used By |

--- a/docs/deploy/spin.md
+++ b/docs/deploy/spin.md
@@ -50,19 +50,16 @@ Environment variable keys:
 
 Optional assistant summary keys for `simboard-backend-env` when enabling AI summaries:
 
-| Key                          | Required | Example/Allowed Value                  | Used By              |
-| ---------------------------- | -------- | -------------------------------------- | -------------------- |
-| `ASSISTANT_LLM_ENABLED`      | No       | `true` or `false`                      | `backend`, `migrate` |
-| `ASSISTANT_LLM_PROVIDER`     | No       | `ollama`, `livai`                   | `backend`, `migrate` |
-| `ASSISTANT_OLLAMA_BASE_URL`  | If using Ollama | `http://localhost:11434`         | `backend`, `migrate` |
-| `ASSISTANT_OLLAMA_MODEL`     | If using Ollama | `gemma4:26b`                     | `backend`, `migrate` |
-| `ASSISTANT_OLLAMA_API_KEY`   | No       | proxy auth token or blank              | `backend`, `migrate` |
-| `ASSISTANT_LIVAI_API_KEY`    | If using LivAI | provider secret                    | `backend`, `migrate` |
-| `ASSISTANT_LIVAI_MODEL`      | If using LivAI | provider model name                | `backend`, `migrate` |
-| `ASSISTANT_LIVAI_BASE_URL`   | If using LivAI | provider base URL                  | `backend`, `migrate` |
-| `ASSISTANT_LLM_TIMEOUT_SECONDS` | No    | `30`                                   | `backend`, `migrate` |
-| `ASSISTANT_LLM_TEMPERATURE`  | No       | `0.2`                                  | `backend`, `migrate` |
-| `ASSISTANT_LLM_MAX_TOKENS`   | No       | `2048`                                 | `backend`, `migrate` |
+| Key                             | Required        | Example/Allowed Value     | Used By              |
+| ------------------------------- | --------------- | ------------------------- | -------------------- |
+| `ASSISTANT_LLM_ENABLED`         | No              | `true` or `false`         | `backend`, `migrate` |
+| `ASSISTANT_LLM_PROVIDER`        | No              | `ollama`                  | `backend`, `migrate` |
+| `ASSISTANT_OLLAMA_BASE_URL`     | If using Ollama | `http://localhost:11434`  | `backend`, `migrate` |
+| `ASSISTANT_OLLAMA_MODEL`        | If using Ollama | `gemma4:26b`              | `backend`, `migrate` |
+| `ASSISTANT_OLLAMA_API_KEY`      | No              | proxy auth token or blank | `backend`, `migrate` |
+| `ASSISTANT_LLM_TIMEOUT_SECONDS` | No              | `30`                      | `backend`, `migrate` |
+| `ASSISTANT_LLM_TEMPERATURE`     | No              | `0.2`                     | `backend`, `migrate` |
+| `ASSISTANT_LLM_MAX_TOKENS`      | No              | `2048`                    | `backend`, `migrate` |
 
 `simboard-db`:
 
@@ -96,14 +93,14 @@ Workloads -> Deployments -> Create (top-right)
 
 Create a PersistentVolumeClaim volume for Postgres data.
 
-| Rancher field                | Value                                                  |
-| ---------------------------- | ------------------------------------------------------ |
-| Volume type                  | `PersistentVolumeClaim`                                |
-| Volume name                  | `db-data` (or your naming standard)                    |
-| Persistent Volume Claim Name | `pvc-simboard-db` (or existing claim)                  |
-| Access mode                  | `Single-Node Read/Write`                               |
-| Capacity                     | `1Gi` minimum (or larger per policy)                   |
-| Storage class                | Namespace/default class (example: `nfs-client-vast`)   |
+| Rancher field                | Value                                                |
+| ---------------------------- | ---------------------------------------------------- |
+| Volume type                  | `PersistentVolumeClaim`                              |
+| Volume name                  | `db-data` (or your naming standard)                  |
+| Persistent Volume Claim Name | `pvc-simboard-db` (or existing claim)                |
+| Access mode                  | `Single-Node Read/Write`                             |
+| Capacity                     | `1Gi` minimum (or larger per policy)                 |
+| Storage class                | Namespace/default class (example: `nfs-client-vast`) |
 
 #### 3. Container tab (`db`)
 

--- a/docs/deploy/spin.md
+++ b/docs/deploy/spin.md
@@ -53,14 +53,10 @@ Optional assistant summary keys for `simboard-backend-env` when enabling AI summ
 | Key                          | Required | Example/Allowed Value                  | Used By              |
 | ---------------------------- | -------- | -------------------------------------- | -------------------- |
 | `ASSISTANT_LLM_ENABLED`      | No       | `true` or `false`                      | `backend`, `migrate` |
-| `ASSISTANT_LLM_PROVIDER`     | No       | `ollama`, `openai`, `anthropic`, `livai` | `backend`, `migrate` |
+| `ASSISTANT_LLM_PROVIDER`     | No       | `ollama`, `livai`                   | `backend`, `migrate` |
 | `ASSISTANT_OLLAMA_BASE_URL`  | If using Ollama | `http://localhost:11434`         | `backend`, `migrate` |
 | `ASSISTANT_OLLAMA_MODEL`     | If using Ollama | `gemma4:26b`                     | `backend`, `migrate` |
 | `ASSISTANT_OLLAMA_API_KEY`   | No       | proxy auth token or blank              | `backend`, `migrate` |
-| `ASSISTANT_OPENAI_API_KEY`   | If using OpenAI | provider secret                   | `backend`, `migrate` |
-| `ASSISTANT_OPENAI_MODEL`     | If using OpenAI | provider model name               | `backend`, `migrate` |
-| `ASSISTANT_ANTHROPIC_API_KEY`| If using Anthropic | provider secret                | `backend`, `migrate` |
-| `ASSISTANT_ANTHROPIC_MODEL`  | If using Anthropic | provider model name            | `backend`, `migrate` |
 | `ASSISTANT_LIVAI_API_KEY`    | If using LivAI | provider secret                    | `backend`, `migrate` |
 | `ASSISTANT_LIVAI_MODEL`      | If using LivAI | provider model name                | `backend`, `migrate` |
 | `ASSISTANT_LIVAI_BASE_URL`   | If using LivAI | provider base URL                  | `backend`, `migrate` |

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -69,8 +69,8 @@ Canonical assistant env names:
 - `ASSISTANT_LLM_PROVIDER` with `ollama` or `livai`
 - `ASSISTANT_OLLAMA_API_KEY` / `ASSISTANT_OLLAMA_MODEL` / `ASSISTANT_OLLAMA_BASE_URL`
 - `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
-- `ASSISTANT_LLM_TEMPERATURE` default `0.2`
-- `ASSISTANT_LLM_MAX_TOKENS` default `2048`
+- `ASSISTANT_LLM_TEMPERATURE` runtime default `0.2`
+- `ASSISTANT_LLM_MAX_TOKENS` runtime default `2048`
 
 Recommended setup flow:
 
@@ -87,11 +87,13 @@ Recommended local default for this repo:
 ASSISTANT_LLM_ENABLED=true
 ASSISTANT_LLM_PROVIDER=ollama
 ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
-ASSISTANT_OLLAMA_MODEL=gemma4:26b
+ASSISTANT_OLLAMA_MODEL=llama3.1:8b
 ASSISTANT_OLLAMA_API_KEY=
 ASSISTANT_LLM_TEMPERATURE=0.2
-ASSISTANT_LLM_MAX_TOKENS=2048
+ASSISTANT_LLM_MAX_TOKENS=256
 ```
+
+`ASSISTANT_LLM_MAX_TOKENS=256` above is a repo-local recommendation for concise summaries on developer hardware. If unset, backend runtime default remains `2048`.
 
 Recommended Ollama workflow:
 
@@ -99,77 +101,23 @@ Recommended Ollama workflow:
 2. Pull models:
 
    ```bash
-   make ollama-pull-e4b  # gemma4:e4b for fast dev (~4GB)
-   make ollama-pull-26b  # gemma4:26b for quality (~26GB)
+   make ollama-pull-fast     # llama3.1:8b, faster local default
+   make ollama-pull-dev      # gemma4:e4b, stronger dev model
+   make ollama-pull-quality  # gemma4:26b, preferred quality model
    ```
 
-3. (Optional) Configure Ollama to keep models loaded indefinitely to eliminate reload latency on subsequent requests. By default, Ollama unloads models after 5 minutes of inactivity. To keep models resident:
-
-   **macOS:**
+3. Start Ollama in a separate terminal:
 
    ```bash
-   make ollama-setup-macos
+   make ollama-serve
    ```
 
-   This creates `~/Library/LaunchAgents/com.ollama.plist` with `OLLAMA_KEEP_ALIVE=-1` and loads it. To manually create or unload, see below.
-
-   <details>
-   <summary>Manual LaunchAgent setup</summary>
-
-   Create `~/Library/LaunchAgents/com.ollama.plist`:
-
-   ```xml
-   <?xml version="1.0" encoding="UTF-8"?>
-   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-   <plist version="1.0">
-   <dict>
-       <key>Label</key>
-       <string>com.ollama</string>
-       <key>ProgramArguments</key>
-       <array>
-           <string>/usr/local/bin/ollama</string>
-           <string>serve</string>
-       </array>
-       <key>EnvironmentVariables</key>
-       <dict>
-           <key>OLLAMA_KEEP_ALIVE</key>
-           <string>-1</string>
-       </dict>
-       <key>RunAtLoad</key>
-       <true/>
-       <key>KeepAlive</key>
-       <true/>
-       <key>StandardOutPath</key>
-       <string>/tmp/ollama.log</string>
-       <key>StandardErrorPath</key>
-       <string>/tmp/ollama.err</string>
-   </dict>
-   </plist>
-   ```
-
-   Replace `/usr/local/bin/ollama` with your Ollama path from `which ollama`. Then load:
-
-   ```bash
-   launchctl load ~/Library/LaunchAgents/com.ollama.plist
-   ```
-
-   </details>
-
-   **Linux (systemd):**
-
-   ```bash
-   sudo systemctl edit ollama
-   # Add under [Service]:
-   Environment="OLLAMA_KEEP_ALIVE=-1"
-
-   sudo systemctl restart ollama
-   ```
-
-   `OLLAMA_KEEP_ALIVE=-1` keeps models loaded indefinitely. Use `1h`, `30m`, etc., for time-based expiry. First API call loads model; subsequent calls instant.
+   This runs `ollama serve` with `OLLAMA_KEEP_ALIVE=-1`, so models stay loaded while that server process is running.
 
 4. Point `ASSISTANT_OLLAMA_BASE_URL` at your local runtime. SimBoard accepts `http://localhost:11434` and normalizes it to Ollama's OpenAI-compatible `/v1` endpoint internally. If your deployment already exposes `/v1`, that value also works unchanged.
 
 5. Switch `ASSISTANT_OLLAMA_MODEL` between:
+   - `llama3.1:8b` for faster local summaries on typical developer hardware
    - `gemma4:e4b` for fast prompt-contract iteration
    - `gemma4:26b` for preferred quality checks
    - `gemma4:31b` only if local hardware supports it

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -66,7 +66,8 @@ If you want the simulation details page to use LLM-backed summaries instead of d
 Canonical assistant env names:
 
 - `ASSISTANT_LLM_ENABLED`
-- `ASSISTANT_LLM_PROVIDER` with `openai`, `anthropic`, or `livai`
+- `ASSISTANT_LLM_PROVIDER` with `ollama`, `openai`, `anthropic`, or `livai`
+- `ASSISTANT_OLLAMA_API_KEY` / `ASSISTANT_OLLAMA_MODEL` / `ASSISTANT_OLLAMA_BASE_URL`
 - `ASSISTANT_OPENAI_API_KEY` / `ASSISTANT_OPENAI_MODEL`
 - `ASSISTANT_ANTHROPIC_API_KEY` / `ASSISTANT_ANTHROPIC_MODEL`
 - `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
@@ -83,6 +84,41 @@ Recommended setup flow:
 6. Generate an AI Summary from the simulation details page and confirm it does not fall back to deterministic mode.
 
 Recommended local default for this repo:
+
+```env
+ASSISTANT_LLM_ENABLED=true
+ASSISTANT_LLM_PROVIDER=ollama
+ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
+ASSISTANT_OLLAMA_MODEL=gemma4:26b
+ASSISTANT_OLLAMA_API_KEY=
+ASSISTANT_LLM_TEMPERATURE=0.2
+ASSISTANT_LLM_MAX_TOKENS=2048
+```
+
+Recommended Ollama workflow:
+
+1. On macOS, install Ollama natively using the official setup guide: https://docs.ollama.com/quickstart
+2. Pull `gemma4:e4b` for fast local iteration:
+
+   ```bash
+   ollama pull gemma4:e4b
+   ```
+
+3. Pull `gemma4:26b` for preferred summary quality checks:
+
+   ```bash
+   ollama pull gemma4:26b
+   ```
+
+4. Point `ASSISTANT_OLLAMA_BASE_URL` at your local runtime. SimBoard accepts `http://localhost:11434` and normalizes it to Ollama's OpenAI-compatible `/v1` endpoint internally. If your deployment already exposes `/v1`, that value also works unchanged.
+5. Switch `ASSISTANT_OLLAMA_MODEL` between:
+   - `gemma4:e4b` for fast prompt-contract iteration
+   - `gemma4:26b` for preferred quality checks
+   - `gemma4:31b` only if local hardware supports it
+
+For macOS developers, native Ollama is the recommended default. Ollama's official docs note that GPU acceleration is not available through Docker Desktop on macOS because GPU passthrough and emulation are not supported there. You can still run Ollama in Docker on macOS for CPU-only portability testing, but expect slower local inference than native install.
+
+LivAI setup:
 
 ```env
 ASSISTANT_LLM_ENABLED=true
@@ -107,11 +143,13 @@ ASSISTANT_LLM_MAX_TOKENS=2048
 
 If `ASSISTANT_LLM_ENABLED=false`, or the selected provider is misconfigured, the backend automatically returns the deterministic metadata summary instead of an LLM-generated one.
 
+For Ollama, `ASSISTANT_OLLAMA_BASE_URL` and `ASSISTANT_OLLAMA_MODEL` are required. `ASSISTANT_OLLAMA_API_KEY` is optional for local runs and can stay blank unless a proxy in front of Ollama requires auth.
 For LivAI, `ASSISTANT_LIVAI_API_KEY` and `ASSISTANT_LIVAI_BASE_URL` are the canonical names.
 For the current LivAI OpenAI-compatible chat endpoint, SimBoard omits `ASSISTANT_LLM_TEMPERATURE` for `gpt-5*` models because the endpoint rejects that parameter; `ASSISTANT_LLM_MAX_TOKENS` still applies.
 
 If summary generation still falls back:
 
+- `fallback_reason=ollama_misconfigured` means `ASSISTANT_OLLAMA_MODEL` or `ASSISTANT_OLLAMA_BASE_URL` is missing.
 - `fallback_reason=openai_misconfigured` means the backend is still configured for `openai`, but `ASSISTANT_OPENAI_API_KEY` or `ASSISTANT_OPENAI_MODEL` is missing.
 - `fallback_reason=anthropic_misconfigured` means `ASSISTANT_ANTHROPIC_API_KEY` or `ASSISTANT_ANTHROPIC_MODEL` is missing.
 - `fallback_reason=livai_misconfigured` means `ASSISTANT_LIVAI_API_KEY`, `ASSISTANT_LIVAI_MODEL`, or `ASSISTANT_LIVAI_BASE_URL` is missing.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -61,27 +61,20 @@ For token-based ingestion and service-account details, see [docs/hpc_api_token_a
 
 ## Assistant LLM Env Setup
 
-If you want the simulation details page to use LLM-backed summaries instead of deterministic fallback, configure the assistant env values in `.envs/local/backend.env`.
+Configure `.envs/local/backend.env` to enable LLM-backed summaries on the simulation details page. If LLM support is disabled or misconfigured, the backend falls back to the deterministic metadata summary.
 
-Canonical assistant env names:
+### Required settings
 
-- `ASSISTANT_LLM_ENABLED`
-- `ASSISTANT_LLM_PROVIDER` with `ollama` or `livai`
-- `ASSISTANT_OLLAMA_API_KEY` / `ASSISTANT_OLLAMA_MODEL` / `ASSISTANT_OLLAMA_BASE_URL`
-- `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
-- `ASSISTANT_LLM_TEMPERATURE` runtime default `0.2`
-- `ASSISTANT_LLM_MAX_TOKENS` runtime default `2048`
+```env
+ASSISTANT_LLM_ENABLED=true
+ASSISTANT_LLM_PROVIDER=ollama  # ollama or livai
+```
 
-Recommended setup flow:
+Use exactly one provider and configure only that provider's env vars.
 
-1. Open `.envs/local/backend.env`.
-2. Set `ASSISTANT_LLM_ENABLED=true`.
-3. Choose exactly one provider in `ASSISTANT_LLM_PROVIDER`.
-4. Fill only that provider's required env vars.
-5. Restart the backend with `make backend-run`.
-6. Generate an AI Summary from the simulation details page and confirm it does not fall back to deterministic mode.
+### Local Ollama setup
 
-Recommended local default for this repo:
+Recommended local default:
 
 ```env
 ASSISTANT_LLM_ENABLED=true
@@ -93,17 +86,17 @@ ASSISTANT_LLM_TEMPERATURE=0.2
 ASSISTANT_LLM_MAX_TOKENS=256
 ```
 
-`ASSISTANT_LLM_MAX_TOKENS=256` above is a repo-local recommendation for concise summaries on developer hardware. If unset, backend runtime default remains `2048`.
+`ASSISTANT_LLM_MAX_TOKENS=256` keeps local summaries concise on developer hardware. If unset, the backend runtime default is `2048`.
 
-Recommended Ollama workflow:
+Install and run Ollama:
 
-1. On macOS, install Ollama natively using the official setup guide: https://docs.ollama.com/quickstart
-2. Pull models:
+1. On macOS, install Ollama natively: https://docs.ollama.com/quickstart
+2. Pull a model:
 
    ```bash
    make ollama-pull-fast     # llama3.1:8b, faster local default
-   make ollama-pull-dev      # gemma4:e4b, stronger dev model
-   make ollama-pull-quality  # gemma4:26b, preferred quality model
+   make ollama-pull-dev      # gemma4:e4b, prompt-contract iteration
+   make ollama-pull-quality  # gemma4:26b, quality checks
    ```
 
 3. Start Ollama in a separate terminal:
@@ -112,19 +105,26 @@ Recommended Ollama workflow:
    make ollama-serve
    ```
 
-   This runs `ollama serve` with `OLLAMA_KEEP_ALIVE=-1`, so models stay loaded while that server process is running.
+   This runs `ollama serve` with `OLLAMA_KEEP_ALIVE=-1`, so models stay loaded while the server is running.
 
-4. Point `ASSISTANT_OLLAMA_BASE_URL` at your local runtime. SimBoard accepts `http://localhost:11434` and normalizes it to Ollama's OpenAI-compatible `/v1` endpoint internally. If your deployment already exposes `/v1`, that value also works unchanged.
+4. Restart the backend:
 
-5. Switch `ASSISTANT_OLLAMA_MODEL` between:
-   - `llama3.1:8b` for faster local summaries on typical developer hardware
-   - `gemma4:e4b` for fast prompt-contract iteration
-   - `gemma4:26b` for preferred quality checks
-   - `gemma4:31b` only if local hardware supports it
+   ```bash
+   make backend-run
+   ```
 
-For macOS developers, native Ollama is the recommended default. Ollama's official docs note that GPU acceleration is not available through Docker Desktop on macOS because GPU passthrough and emulation are not supported there. You can still run Ollama in Docker on macOS for CPU-only portability testing, but expect slower local inference than native install.
+Supported local model choices:
 
-LivAI setup:
+- `llama3.1:8b`: faster local summaries on typical developer hardware
+- `gemma4:e4b`: fast prompt-contract iteration
+- `gemma4:26b`: preferred quality checks
+- `gemma4:31b`: only for hardware that can support it
+
+`ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434` is accepted and normalized internally to Ollama's OpenAI-compatible `/v1` endpoint. Values that already include `/v1` also work.
+
+On macOS, native Ollama is recommended. Docker Desktop on macOS does not support Ollama GPU acceleration, so Docker-based Ollama is useful only for CPU-only portability testing.
+
+### LivAI setup
 
 ```env
 ASSISTANT_LLM_ENABLED=true
@@ -136,17 +136,24 @@ ASSISTANT_LLM_TEMPERATURE=0.2
 ASSISTANT_LLM_MAX_TOKENS=2048
 ```
 
-If `ASSISTANT_LLM_ENABLED=false`, or the selected provider is misconfigured, the backend automatically returns the deterministic metadata summary instead of an LLM-generated one.
+For LivAI, `ASSISTANT_LIVAI_API_KEY`, `ASSISTANT_LIVAI_MODEL`, and `ASSISTANT_LIVAI_BASE_URL` are required.
 
-For Ollama, `ASSISTANT_OLLAMA_BASE_URL` and `ASSISTANT_OLLAMA_MODEL` are required. `ASSISTANT_OLLAMA_API_KEY` is optional for local runs and can stay blank unless a proxy in front of Ollama requires auth.
-For LivAI, `ASSISTANT_LIVAI_API_KEY` and `ASSISTANT_LIVAI_BASE_URL` are the canonical names.
-For the current LivAI OpenAI-compatible chat endpoint, SimBoard omits `ASSISTANT_LLM_TEMPERATURE` for `gpt-5*` models because the endpoint rejects that parameter; `ASSISTANT_LLM_MAX_TOKENS` still applies.
+For current LivAI OpenAI-compatible chat endpoints, SimBoard omits `ASSISTANT_LLM_TEMPERATURE` for `gpt-5*` models because the endpoint rejects that parameter. `ASSISTANT_LLM_MAX_TOKENS` still applies.
 
-If summary generation still falls back:
+### Fallback troubleshooting
 
-- `fallback_reason=ollama_misconfigured` means `ASSISTANT_OLLAMA_MODEL` or `ASSISTANT_OLLAMA_BASE_URL` is missing.
-- `fallback_reason=livai_misconfigured` means `ASSISTANT_LIVAI_API_KEY`, `ASSISTANT_LIVAI_MODEL`, or `ASSISTANT_LIVAI_BASE_URL` is missing.
-- If you edit `.envs/local/backend.env`, restart `make backend-run` before testing again.
+After changing `.envs/local/backend.env`, restart the backend before testing again:
+
+```bash
+make backend-run
+```
+
+Common fallback reasons:
+
+- `fallback_reason=ollama_misconfigured`: missing `ASSISTANT_OLLAMA_MODEL` or `ASSISTANT_OLLAMA_BASE_URL`
+- `fallback_reason=livai_misconfigured`: missing `ASSISTANT_LIVAI_API_KEY`, `ASSISTANT_LIVAI_MODEL`, or `ASSISTANT_LIVAI_BASE_URL`
+
+For Ollama, `ASSISTANT_OLLAMA_API_KEY` is optional for local runs and can stay blank unless an auth proxy requires it.
 
 ## Architecture
 
@@ -228,10 +235,10 @@ After ingestion completes, the backend stores normalized cases, simulations, mac
 >
 > Referenced case directories under source archive locations are periodically cleaned up by scheduled site-side jobs outside of SimBoard to limit storage growth.
 
-| Site                 | Ingestion mode            | Source archive location                                                |
-| -------------------- | ------------------------- | ---------------------------------------------------------------------- |
-| NERSC / Perlmutter   | Path reference            | `/global/cfs/projectdirs/e3sm/performance_archive`                     |
-| LCRC / Chrysalis     | Archive upload            | `/lcrc/group/e3sm/PERF_Chrysalis/performance_archive`                  |
+| Site                 | Ingestion mode            | Source archive location                                                 |
+| -------------------- | ------------------------- | ----------------------------------------------------------------------- |
+| NERSC / Perlmutter   | Path reference            | `/global/cfs/projectdirs/e3sm/performance_archive`                      |
+| LCRC / Chrysalis     | Archive upload            | `/lcrc/group/e3sm/PERF_Chrysalis/performance_archive`                   |
 | Additional HPC sites | Archive upload by default | Site-specific `performance_archive` path, packaged by the ingestion job |
 
 ## Daily Workflow

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -66,10 +66,8 @@ If you want the simulation details page to use LLM-backed summaries instead of d
 Canonical assistant env names:
 
 - `ASSISTANT_LLM_ENABLED`
-- `ASSISTANT_LLM_PROVIDER` with `ollama`, `openai`, `anthropic`, or `livai`
+- `ASSISTANT_LLM_PROVIDER` with `ollama` or `livai`
 - `ASSISTANT_OLLAMA_API_KEY` / `ASSISTANT_OLLAMA_MODEL` / `ASSISTANT_OLLAMA_BASE_URL`
-- `ASSISTANT_OPENAI_API_KEY` / `ASSISTANT_OPENAI_MODEL`
-- `ASSISTANT_ANTHROPIC_API_KEY` / `ASSISTANT_ANTHROPIC_MODEL`
 - `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
 - `ASSISTANT_LLM_TEMPERATURE` default `0.2`
 - `ASSISTANT_LLM_MAX_TOKENS` default `2048`
@@ -98,19 +96,79 @@ ASSISTANT_LLM_MAX_TOKENS=2048
 Recommended Ollama workflow:
 
 1. On macOS, install Ollama natively using the official setup guide: https://docs.ollama.com/quickstart
-2. Pull `gemma4:e4b` for fast local iteration:
+2. Pull models:
 
    ```bash
-   ollama pull gemma4:e4b
+   make ollama-pull-e4b  # gemma4:e4b for fast dev (~4GB)
+   make ollama-pull-26b  # gemma4:26b for quality (~26GB)
    ```
 
-3. Pull `gemma4:26b` for preferred summary quality checks:
+3. (Optional) Configure Ollama to keep models loaded indefinitely to eliminate reload latency on subsequent requests. By default, Ollama unloads models after 5 minutes of inactivity. To keep models resident:
+
+   **macOS:**
 
    ```bash
-   ollama pull gemma4:26b
+   make ollama-setup-macos
    ```
+
+   This creates `~/Library/LaunchAgents/com.ollama.plist` with `OLLAMA_KEEP_ALIVE=-1` and loads it. To manually create or unload, see below.
+
+   <details>
+   <summary>Manual LaunchAgent setup</summary>
+
+   Create `~/Library/LaunchAgents/com.ollama.plist`:
+
+   ```xml
+   <?xml version="1.0" encoding="UTF-8"?>
+   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+   <plist version="1.0">
+   <dict>
+       <key>Label</key>
+       <string>com.ollama</string>
+       <key>ProgramArguments</key>
+       <array>
+           <string>/usr/local/bin/ollama</string>
+           <string>serve</string>
+       </array>
+       <key>EnvironmentVariables</key>
+       <dict>
+           <key>OLLAMA_KEEP_ALIVE</key>
+           <string>-1</string>
+       </dict>
+       <key>RunAtLoad</key>
+       <true/>
+       <key>KeepAlive</key>
+       <true/>
+       <key>StandardOutPath</key>
+       <string>/tmp/ollama.log</string>
+       <key>StandardErrorPath</key>
+       <string>/tmp/ollama.err</string>
+   </dict>
+   </plist>
+   ```
+
+   Replace `/usr/local/bin/ollama` with your Ollama path from `which ollama`. Then load:
+
+   ```bash
+   launchctl load ~/Library/LaunchAgents/com.ollama.plist
+   ```
+
+   </details>
+
+   **Linux (systemd):**
+
+   ```bash
+   sudo systemctl edit ollama
+   # Add under [Service]:
+   Environment="OLLAMA_KEEP_ALIVE=-1"
+
+   sudo systemctl restart ollama
+   ```
+
+   `OLLAMA_KEEP_ALIVE=-1` keeps models loaded indefinitely. Use `1h`, `30m`, etc., for time-based expiry. First API call loads model; subsequent calls instant.
 
 4. Point `ASSISTANT_OLLAMA_BASE_URL` at your local runtime. SimBoard accepts `http://localhost:11434` and normalizes it to Ollama's OpenAI-compatible `/v1` endpoint internally. If your deployment already exposes `/v1`, that value also works unchanged.
+
 5. Switch `ASSISTANT_OLLAMA_MODEL` between:
    - `gemma4:e4b` for fast prompt-contract iteration
    - `gemma4:26b` for preferred quality checks
@@ -130,17 +188,6 @@ ASSISTANT_LLM_TEMPERATURE=0.2
 ASSISTANT_LLM_MAX_TOKENS=2048
 ```
 
-Direct OpenAI setup:
-
-```env
-ASSISTANT_LLM_ENABLED=true
-ASSISTANT_LLM_PROVIDER=openai
-ASSISTANT_OPENAI_API_KEY=
-ASSISTANT_OPENAI_MODEL=
-ASSISTANT_LLM_TEMPERATURE=0.2
-ASSISTANT_LLM_MAX_TOKENS=2048
-```
-
 If `ASSISTANT_LLM_ENABLED=false`, or the selected provider is misconfigured, the backend automatically returns the deterministic metadata summary instead of an LLM-generated one.
 
 For Ollama, `ASSISTANT_OLLAMA_BASE_URL` and `ASSISTANT_OLLAMA_MODEL` are required. `ASSISTANT_OLLAMA_API_KEY` is optional for local runs and can stay blank unless a proxy in front of Ollama requires auth.
@@ -150,8 +197,6 @@ For the current LivAI OpenAI-compatible chat endpoint, SimBoard omits `ASSISTANT
 If summary generation still falls back:
 
 - `fallback_reason=ollama_misconfigured` means `ASSISTANT_OLLAMA_MODEL` or `ASSISTANT_OLLAMA_BASE_URL` is missing.
-- `fallback_reason=openai_misconfigured` means the backend is still configured for `openai`, but `ASSISTANT_OPENAI_API_KEY` or `ASSISTANT_OPENAI_MODEL` is missing.
-- `fallback_reason=anthropic_misconfigured` means `ASSISTANT_ANTHROPIC_API_KEY` or `ASSISTANT_ANTHROPIC_MODEL` is missing.
 - `fallback_reason=livai_misconfigured` means `ASSISTANT_LIVAI_API_KEY`, `ASSISTANT_LIVAI_MODEL`, or `ASSISTANT_LIVAI_BASE_URL` is missing.
 - If you edit `.envs/local/backend.env`, restart `make backend-run` before testing again.
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -130,13 +130,24 @@ On macOS, native Ollama is recommended. Docker Desktop on macOS does not support
 ASSISTANT_LLM_ENABLED=true
 ASSISTANT_LLM_PROVIDER=livai
 ASSISTANT_LIVAI_API_KEY=
-ASSISTANT_LIVAI_MODEL=
+ASSISTANT_LIVAI_MODEL=gpt-5.4
 ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
 ASSISTANT_LLM_TEMPERATURE=0.2
-ASSISTANT_LLM_MAX_TOKENS=2048
+ASSISTANT_LLM_MAX_TOKENS=8192
+ASSISTANT_SNAPSHOT_MAX_CHARS=12000
 ```
 
 For LivAI, `ASSISTANT_LIVAI_API_KEY`, `ASSISTANT_LIVAI_MODEL`, and `ASSISTANT_LIVAI_BASE_URL` are required.
+
+**Model selection:**
+
+- **Recommended:** `gpt-5.4` (full model) — reliable structured output completion, handles 8K+ token responses
+- **Avoid:** `gpt-5.4-mini` — may truncate structured responses before completing all required fields (`limitations`, `citations`, `suggested_followups`)
+
+**Token budget guidance:**
+
+- `ASSISTANT_LLM_MAX_TOKENS`: 4096-8192 for `gpt-5.4`; 2048 for mini models (if used despite limitations)
+- `ASSISTANT_SNAPSHOT_MAX_CHARS`: 12000-16000 balances detail vs token budget; reduce to 8000-10000 for mini models
 
 For current LivAI OpenAI-compatible chat endpoints, SimBoard omits `ASSISTANT_LLM_TEMPERATURE` for `gpt-5*` models because the endpoint rejects that parameter. `ASSISTANT_LLM_MAX_TOKENS` still applies.
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1467,8 +1467,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.8.16:
-    resolution: {integrity: sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==}
+  baseline-browser-mapping@2.10.31:
+    resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   binary-extensions@2.3.0:
@@ -1510,8 +1511,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001750:
-    resolution: {integrity: sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==}
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -4247,7 +4248,7 @@ snapshots:
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.26.3
-      caniuse-lite: 1.0.30001750
+      caniuse-lite: 1.0.30001793
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -4268,7 +4269,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.8.16: {}
+  baseline-browser-mapping@2.10.31: {}
 
   binary-extensions@2.3.0: {}
 
@@ -4287,8 +4288,8 @@ snapshots:
 
   browserslist@4.26.3:
     dependencies:
-      baseline-browser-mapping: 2.8.16
-      caniuse-lite: 1.0.30001750
+      baseline-browser-mapping: 2.10.31
+      caniuse-lite: 1.0.30001793
       electron-to-chromium: 1.5.237
       node-releases: 2.0.23
       update-browserslist-db: 1.1.3(browserslist@4.26.3)
@@ -4314,7 +4315,7 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001750: {}
+  caniuse-lite@1.0.30001793: {}
 
   chalk@4.1.2:
     dependencies:

--- a/frontend/src/features/simulations/SimulationDetailsPage.tsx
+++ b/frontend/src/features/simulations/SimulationDetailsPage.tsx
@@ -122,6 +122,8 @@ export const SimulationDetailsPage = () => {
       summaryLoading={summary.loading}
       summaryError={summary.error}
       summaryRequested={summary.requested}
+      summaryElapsedMs={summary.elapsedMs}
+      summaryLastDurationMs={summary.lastDurationMs}
       onGenerateSummary={summary.generate}
       canGenerateSummary={isAuthenticated}
       isCheckingAuth={authLoading}

--- a/frontend/src/features/simulations/api/api.ts
+++ b/frontend/src/features/simulations/api/api.ts
@@ -9,6 +9,7 @@ import type {
 export const SIMULATIONS_URL = '/simulations';
 export const CASES_URL = '/cases';
 export const PACE_URL = '/pace';
+const SUMMARY_REQUEST_TIMEOUT_MS = 120_000;
 
 export interface PaceResolutionOut {
   executionId: string;
@@ -40,7 +41,11 @@ export const getSimulationById = async (id: string): Promise<SimulationOut> => {
 export const generateSimulationSummary = async (
   id: string,
 ): Promise<SimulationSummaryResponseOut> => {
-  const res = await api.post<SimulationSummaryResponseOut>(`${SIMULATIONS_URL}/${id}/summary`);
+  const res = await api.post<SimulationSummaryResponseOut>(
+    `${SIMULATIONS_URL}/${id}/summary`,
+    undefined,
+    { timeout: SUMMARY_REQUEST_TIMEOUT_MS },
+  );
 
   return res.data;
 };

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -41,6 +41,8 @@ interface SimulationDetailsViewProps {
   summaryLoading?: boolean;
   summaryError?: string | null;
   summaryRequested?: boolean;
+  summaryElapsedMs?: number;
+  summaryLastDurationMs?: number | null;
   onGenerateSummary?: () => void | Promise<void>;
   canGenerateSummary?: boolean;
   isCheckingAuth?: boolean;
@@ -115,6 +117,8 @@ export const SimulationDetailsView = ({
   summaryLoading = false,
   summaryError = null,
   summaryRequested = false,
+  summaryElapsedMs = 0,
+  summaryLastDurationMs = null,
   onGenerateSummary,
   canGenerateSummary = false,
   isCheckingAuth = false,
@@ -235,6 +239,8 @@ export const SimulationDetailsView = ({
               summaryLoading={summaryLoading}
               summaryError={summaryError}
               summaryRequested={summaryRequested}
+              summaryElapsedMs={summaryElapsedMs}
+              summaryLastDurationMs={summaryLastDurationMs}
               onGenerateSummary={onGenerateSummary}
               canGenerateSummary={canGenerateSummary}
               isCheckingAuth={isCheckingAuth}
@@ -882,6 +888,8 @@ export const SimulationDetailsView = ({
                   summaryLoading={summaryLoading}
                   summaryError={summaryError}
                   summaryRequested={summaryRequested}
+                  summaryElapsedMs={summaryElapsedMs}
+                  summaryLastDurationMs={summaryLastDurationMs}
                   onGenerateSummary={onGenerateSummary}
                   canGenerateSummary={canGenerateSummary}
                   isCheckingAuth={isCheckingAuth}

--- a/frontend/src/features/simulations/components/SimulationSummaryPanel.tsx
+++ b/frontend/src/features/simulations/components/SimulationSummaryPanel.tsx
@@ -27,11 +27,25 @@ interface SimulationSummaryPanelProps {
   summaryLoading?: boolean;
   summaryError?: string | null;
   summaryRequested?: boolean;
+  summaryElapsedMs?: number;
+  summaryLastDurationMs?: number | null;
   onGenerateSummary?: () => void | Promise<void>;
   canGenerateSummary?: boolean;
   isCheckingAuth?: boolean;
   onLoginForSummary?: () => void;
 }
+
+const formatSummaryRuntime = (durationMs: number) => {
+  const totalSeconds = Math.max(1, Math.round(durationMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes === 0) {
+    return `${totalSeconds}s`;
+  }
+
+  return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+};
 
 const getSummaryActionLabel = ({
   summary,
@@ -223,6 +237,8 @@ const SummaryPanelBody = ({
   summaryLoading = false,
   summaryError = null,
   summaryRequested = false,
+  summaryElapsedMs = 0,
+  summaryLastDurationMs = null,
   canGenerateSummary = false,
   isCheckingAuth = false,
   scrollable = false,
@@ -233,6 +249,8 @@ const SummaryPanelBody = ({
   | 'summaryLoading'
   | 'summaryError'
   | 'summaryRequested'
+  | 'summaryElapsedMs'
+  | 'summaryLastDurationMs'
   | 'canGenerateSummary'
   | 'isCheckingAuth'
 > & {
@@ -263,15 +281,26 @@ const SummaryPanelBody = ({
 
       {summaryError && (
         <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {summaryError}
+          <div>{summaryError}</div>
+          {summaryLastDurationMs !== null && (
+            <div className="mt-1 text-xs text-red-600/80">
+              Latest attempt ran for {formatSummaryRuntime(summaryLastDurationMs)}.
+            </div>
+          )}
         </div>
       )}
 
       {summaryLoading && !summary && (
         <div className="flex min-h-[220px] items-center rounded-md border bg-white/80 px-4 py-5">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Spinner className="size-4" />
-            Generating summary from SimBoard metadata...
+          <div className="space-y-1 text-sm text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <Spinner className="size-4" />
+              Generating summary from SimBoard metadata...
+            </div>
+            <div className="pl-6 text-xs text-slate-500">
+              {formatSummaryRuntime(summaryElapsedMs)} elapsed. This can fall back to a
+              metadata-based summary if AI generation stalls or fails.
+            </div>
           </div>
         </div>
       )}
@@ -295,7 +324,19 @@ const SummaryPanelBody = ({
                 {summaryGenerationModel ? ` · ${summaryGenerationModel}` : ''}
               </span>
             )}
+            {summaryLastDurationMs !== null && (
+              <span className="text-sm text-muted-foreground">
+                Runtime: {formatSummaryRuntime(summaryLastDurationMs)}
+              </span>
+            )}
           </div>
+
+          {summaryGenerationMode !== 'llm' && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              AI generation did not complete for this attempt. Showing metadata-based summary
+              instead.
+            </div>
+          )}
 
           <div>
             <Label className="mb-2 block text-xs text-muted-foreground">Summary</Label>
@@ -329,6 +370,8 @@ export const SimulationSummaryRail = ({
   summaryLoading = false,
   summaryError = null,
   summaryRequested = false,
+  summaryElapsedMs = 0,
+  summaryLastDurationMs = null,
   onGenerateSummary,
   canGenerateSummary = false,
   isCheckingAuth = false,
@@ -361,6 +404,8 @@ export const SimulationSummaryRail = ({
         summaryLoading={summaryLoading}
         summaryError={summaryError}
         summaryRequested={summaryRequested}
+        summaryElapsedMs={summaryElapsedMs}
+        summaryLastDurationMs={summaryLastDurationMs}
         canGenerateSummary={canGenerateSummary}
         isCheckingAuth={isCheckingAuth}
         scrollable
@@ -374,6 +419,8 @@ export const SimulationSummaryLauncher = ({
   summaryLoading = false,
   summaryError = null,
   summaryRequested = false,
+  summaryElapsedMs = 0,
+  summaryLastDurationMs = null,
   onGenerateSummary,
   canGenerateSummary = false,
   isCheckingAuth = false,
@@ -402,11 +449,15 @@ export const SimulationSummaryLauncher = ({
         <CardContent className="flex items-center justify-between gap-3 pt-0">
           <p className="text-sm text-muted-foreground">
             {summary
-              ? 'Summary is ready to review.'
+              ? summaryLastDurationMs !== null
+                ? `Summary ready. Latest attempt took ${formatSummaryRuntime(summaryLastDurationMs)}.`
+                : 'Summary is ready to review.'
               : summaryError
-                ? 'Review the latest summary error.'
+                ? summaryLastDurationMs !== null
+                  ? `Latest summary attempt failed after ${formatSummaryRuntime(summaryLastDurationMs)}.`
+                  : 'Review the latest summary error.'
                 : summaryLoading
-                  ? 'Summary generation is in progress.'
+                  ? `Summary generation is in progress. ${formatSummaryRuntime(summaryElapsedMs)} elapsed.`
                   : canGenerateSummary
                     ? 'Generate a metadata-based summary when you need a quick overview.'
                     : 'Log in to generate a metadata-based summary for this run.'}
@@ -451,6 +502,8 @@ export const SimulationSummaryLauncher = ({
                 summaryLoading={summaryLoading}
                 summaryError={summaryError}
                 summaryRequested={summaryRequested}
+                summaryElapsedMs={summaryElapsedMs}
+                summaryLastDurationMs={summaryLastDurationMs}
                 canGenerateSummary={canGenerateSummary}
                 isCheckingAuth={isCheckingAuth}
               />

--- a/frontend/src/features/simulations/components/SimulationSummaryPanel.tsx
+++ b/frontend/src/features/simulations/components/SimulationSummaryPanel.tsx
@@ -258,6 +258,7 @@ const SummaryPanelBody = ({
   className?: string;
 }) => {
   const summaryGenerationMode = summary?.generationMode ?? 'deterministic';
+  const summaryFallbackUsed = summary?.fallbackUsed ?? false;
   const summaryGenerationProvider =
     summaryGenerationMode === 'llm' ? summary?.generationProvider ?? null : null;
   const summaryGenerationModel =
@@ -331,7 +332,7 @@ const SummaryPanelBody = ({
             )}
           </div>
 
-          {summaryGenerationMode !== 'llm' && (
+          {summaryFallbackUsed && (
             <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
               AI generation did not complete for this attempt. Showing metadata-based summary
               instead.

--- a/frontend/src/features/simulations/hooks/useSimulationSummary.ts
+++ b/frontend/src/features/simulations/hooks/useSimulationSummary.ts
@@ -9,6 +9,9 @@ export const useSimulationSummary = (simulationId: string) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [requested, setRequested] = useState(false);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [lastDurationMs, setLastDurationMs] = useState<number | null>(null);
+  const [activeRequestStartedAt, setActiveRequestStartedAt] = useState<number | null>(null);
   const currentSimulationIdRef = useRef(simulationId);
   const requestIdRef = useRef(0);
 
@@ -19,13 +22,35 @@ export const useSimulationSummary = (simulationId: string) => {
     setLoading(false);
     setError(null);
     setRequested(false);
+    setElapsedMs(0);
+    setLastDurationMs(null);
+    setActiveRequestStartedAt(null);
   }, [simulationId]);
+
+  useEffect(() => {
+    if (activeRequestStartedAt === null) {
+      setElapsedMs(0);
+      return;
+    }
+
+    const updateElapsed = () => {
+      setElapsedMs(Date.now() - activeRequestStartedAt);
+    };
+
+    updateElapsed();
+    const intervalId = window.setInterval(updateElapsed, 1000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [activeRequestStartedAt]);
 
   const generate = async () => {
     if (!simulationId) return;
 
     const requestedSimulationId = simulationId;
     const requestId = requestIdRef.current + 1;
+    const startTime = Date.now();
     requestIdRef.current = requestId;
     const isLatestRequest = () =>
       requestId === requestIdRef.current &&
@@ -34,6 +59,9 @@ export const useSimulationSummary = (simulationId: string) => {
     setRequested(true);
     setLoading(true);
     setError(null);
+    setElapsedMs(0);
+    setLastDurationMs(null);
+    setActiveRequestStartedAt(startTime);
 
     try {
       const result = await generateSimulationSummary(requestedSimulationId);
@@ -53,10 +81,12 @@ export const useSimulationSummary = (simulationId: string) => {
       }
     } finally {
       if (isLatestRequest()) {
+        setLastDurationMs(Date.now() - startTime);
+        setActiveRequestStartedAt(null);
         setLoading(false);
       }
     }
   };
 
-  return { data, loading, error, requested, generate };
+  return { data, loading, error, requested, elapsedMs, lastDurationMs, generate };
 };

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -30,7 +30,7 @@ export interface SimulationSummaryResponseOut {
   limitations: string[];
   suggestedFollowups: string[];
   generationMode?: 'llm' | 'deterministic';
-  generationProvider?: 'openai' | 'anthropic' | 'livai' | null;
+  generationProvider?: 'openai' | 'anthropic' | 'livai' | 'ollama' | null;
   generationModel?: string | null;
   traceId: string;
 }

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -30,7 +30,7 @@ export interface SimulationSummaryResponseOut {
   limitations: string[];
   suggestedFollowups: string[];
   generationMode?: 'llm' | 'deterministic';
-  generationProvider?: 'openai' | 'anthropic' | 'livai' | 'ollama' | null;
+  generationProvider?: 'livai' | 'ollama' | null;
   generationModel?: string | null;
   traceId: string;
 }

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -30,6 +30,7 @@ export interface SimulationSummaryResponseOut {
   limitations: string[];
   suggestedFollowups: string[];
   generationMode?: 'llm' | 'deterministic';
+  fallbackUsed?: boolean;
   generationProvider?: 'livai' | 'ollama' | null;
   generationModel?: string | null;
   traceId: string;


### PR DESCRIPTION
## Description

Add support for locally hosted LLM providers on top of `dev-ai`, starting with Ollama, so simulation summaries can run against internal or self-hosted inference endpoints.

This PR extends the assistant provider/configuration flow to support endpoint and model selection for local deployments, updates request handling and orchestration for local providers, adds backend test coverage for config and provider behavior, and documents local plus NERSC Spin setup.

It also narrows the assistant provider/configuration surface in the backend, keeps the internal OpenAI-compatible transport path needed by Ollama and LivAI, updates the frontend summary contract, removes unsupported environment variables from active templates, cleans up active setup/deployment docs, and refreshes backend dependency locking to drop Anthropic-specific dependency support.

Follow-up commits on this branch also harden LLM summary fallback behavior for local models by repairing missing follow-up fields and canonicalizing common shorthand citation paths, and improve the simulation summary UX by showing live generation runtime plus clearer deterministic-fallback messaging.

It also includes the implementation plan commit already present on this branch.

### What Changed
Closes #196

- limit `ASSISTANT_LLM_PROVIDER` to `ollama` and `livai`
- default assistant provider to `ollama`
- remove OpenAI and Anthropic config branches, env vars, and fallback reasons
- keep Ollama/LivAI transport on the OpenAI-compatible client path
- narrow `generation_provider` contract in frontend/backend types
- update active env templates and operator/developer docs
- refresh backend tests and `uv.lock`
- harden assistant summary fallback validation for local-model output drift
- repair missing LLM follow-ups with deterministic metadata follow-ups
- canonicalize unambiguous citation aliases and use `source_type` to disambiguate `name`
- show live summary runtime and clearer fallback/error messaging in simulation details UI

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [x] Tests added or updated (if needed)
- [x] All tests pass (locally and CI/CD)
- [x] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)

Configure local-provider environment variables for Ollama endpoint/model selection in environments that will use hosted local inference.

No database migration expected.

Environments that still set `ASSISTANT_OPENAI_*` or `ASSISTANT_ANTHROPIC_*` must remove those settings and use only the supported `ollama` or `livai` assistant configuration.

## Validation

- [x] `make backend-test`
- [x] `uv run pytest tests/features/assistant/test_orchestrator.py`
- [x] `make frontend-lint`
- [x] `pnpm --dir frontend run type-check`
