### PR TITLE
Add AI-backed simulation summaries and local LLM provider support

### DIFF
--- a/.envs/example/backend.env.example
+++ b/.envs/example/backend.env.example
@@ -71,3 +71,39 @@ COOKIE_HTTPONLY=true
 COOKIE_SAMESITE=lax
 # Seconds
 COOKIE_MAX_AGE=3600
+
+# -------------------------------------------------------------------
+# Assistant LLM Configuration
+# -------------------------------------------------------------------
+# Enable or disable the AI summary assistant feature.
+ASSISTANT_LLM_ENABLED=false
+
+# Provider selection: "livai" | "openai" | "anthropic"
+# Only configure the section for your chosen provider below.
+ASSISTANT_LLM_PROVIDER=livai
+
+# --- LivAI (LLNL-hosted) ---
+# Models: https://livai-tools.llnl.gov/models
+ASSISTANT_LIVAI_API_KEY=
+ASSISTANT_LIVAI_MODEL=
+ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
+
+# --- OpenAI ---
+# Models: https://platform.openai.com/docs/models
+ASSISTANT_OPENAI_API_KEY=
+ASSISTANT_OPENAI_MODEL=
+
+# --- Anthropic ---
+# Models: https://docs.anthropic.com/en/docs/about-claude/models
+ASSISTANT_ANTHROPIC_API_KEY=
+ASSISTANT_ANTHROPIC_MODEL=
+
+# --- Shared settings ---
+# Max seconds to wait for an LLM response before timing out.
+ASSISTANT_LLM_TIMEOUT_SECONDS=30
+# Sampling temperature for assistant LLM summaries.
+ASSISTANT_LLM_TEMPERATURE=0.2
+# Max tokens to allow in assistant LLM summary output.
+ASSISTANT_LLM_MAX_TOKENS=2048
+# Max characters from the simulation snapshot sent as LLM context.
+ASSISTANT_SNAPSHOT_MAX_CHARS=12000

--- a/.envs/example/backend.env.example
+++ b/.envs/example/backend.env.example
@@ -78,25 +78,22 @@ COOKIE_MAX_AGE=3600
 # Enable or disable the AI summary assistant feature.
 ASSISTANT_LLM_ENABLED=false
 
-# Provider selection: "livai" | "openai" | "anthropic"
+# Provider selection: "ollama" | "livai"
 # Only configure the section for your chosen provider below.
-ASSISTANT_LLM_PROVIDER=livai
+ASSISTANT_LLM_PROVIDER=ollama
+
+# --- Ollama (local OpenAI-compatible runtime) ---
+# SimBoard accepts the Ollama root URL and appends /v1 for OpenAI-compatible calls.
+ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
+ASSISTANT_OLLAMA_MODEL=llama3.1:8b
+# ASSISTANT_OLLAMA_API_KEY is optional for local runs and can stay blank unless an auth proxy requires it.
+ASSISTANT_OLLAMA_API_KEY=
 
 # --- LivAI (LLNL-hosted) ---
 # Models: https://livai-tools.llnl.gov/models
 ASSISTANT_LIVAI_API_KEY=
-ASSISTANT_LIVAI_MODEL=
+ASSISTANT_LIVAI_MODEL=gpt-5.4
 ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
-
-# --- OpenAI ---
-# Models: https://platform.openai.com/docs/models
-ASSISTANT_OPENAI_API_KEY=
-ASSISTANT_OPENAI_MODEL=
-
-# --- Anthropic ---
-# Models: https://docs.anthropic.com/en/docs/about-claude/models
-ASSISTANT_ANTHROPIC_API_KEY=
-ASSISTANT_ANTHROPIC_MODEL=
 
 # --- Shared settings ---
 # Max seconds to wait for an LLM response before timing out.
@@ -104,6 +101,8 @@ ASSISTANT_LLM_TIMEOUT_SECONDS=30
 # Sampling temperature for assistant LLM summaries.
 ASSISTANT_LLM_TEMPERATURE=0.2
 # Max tokens to allow in assistant LLM summary output.
-ASSISTANT_LLM_MAX_TOKENS=2048
+# Guidance: 4096-8192 for gpt-5.4; 2048 for mini models (if used despite limitations)
+ASSISTANT_LLM_MAX_TOKENS=4096
 # Max characters from the simulation snapshot sent as LLM context.
+# Guidance: 12000-16000 balances detail vs token budget; reduce to 8000-10000 for mini models
 ASSISTANT_SNAPSHOT_MAX_CHARS=12000

--- a/.envs/example/backend.production.env.example
+++ b/.envs/example/backend.production.env.example
@@ -87,25 +87,22 @@ COOKIE_MAX_AGE=3600
 # Enable or disable the AI summary assistant feature.
 ASSISTANT_LLM_ENABLED=false
 
-# Provider selection: "livai" | "openai" | "anthropic"
+# Provider selection: "ollama" | "livai"
 # Only configure the section for your chosen provider below.
-ASSISTANT_LLM_PROVIDER=livai
+ASSISTANT_LLM_PROVIDER=ollama
+
+# --- Ollama (OpenAI-compatible runtime) ---
+# SimBoard accepts the Ollama root URL and appends /v1 for OpenAI-compatible calls.
+ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
+ASSISTANT_OLLAMA_MODEL=gemma4:26b
+# ASSISTANT_OLLAMA_API_KEY is optional for local runs and can stay blank unless an auth proxy requires it.
+ASSISTANT_OLLAMA_API_KEY=
 
 # --- LivAI (LLNL-hosted) ---
 # Models: https://livai-tools.llnl.gov/models
 ASSISTANT_LIVAI_API_KEY=
-ASSISTANT_LIVAI_MODEL=
+ASSISTANT_LIVAI_MODEL=gpt-5.4
 ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
-
-# --- OpenAI ---
-# Models: https://platform.openai.com/docs/models
-ASSISTANT_OPENAI_API_KEY=
-ASSISTANT_OPENAI_MODEL=
-
-# --- Anthropic ---
-# Models: https://docs.anthropic.com/en/docs/about-claude/models
-ASSISTANT_ANTHROPIC_API_KEY=
-ASSISTANT_ANTHROPIC_MODEL=
 
 # --- Shared settings ---
 # Max seconds to wait for an LLM response before timing out.
@@ -113,6 +110,8 @@ ASSISTANT_LLM_TIMEOUT_SECONDS=30
 # Sampling temperature for assistant LLM summaries.
 ASSISTANT_LLM_TEMPERATURE=0.2
 # Max tokens to allow in assistant LLM summary output.
-ASSISTANT_LLM_MAX_TOKENS=2048
+# Guidance: 4096-8192 for gpt-5.4; 2048 for mini models (if used despite limitations)
+ASSISTANT_LLM_MAX_TOKENS=8192
 # Max characters from the simulation snapshot sent as LLM context.
+# Guidance: 12000-16000 balances detail vs token budget; reduce to 8000-10000 for mini models
 ASSISTANT_SNAPSHOT_MAX_CHARS=12000

--- a/.envs/example/backend.production.env.example
+++ b/.envs/example/backend.production.env.example
@@ -80,3 +80,39 @@ COOKIE_HTTPONLY=true
 COOKIE_SAMESITE=lax
 # Seconds
 COOKIE_MAX_AGE=3600
+
+# -------------------------------------------------------------------
+# Assistant LLM Configuration
+# -------------------------------------------------------------------
+# Enable or disable the AI summary assistant feature.
+ASSISTANT_LLM_ENABLED=false
+
+# Provider selection: "livai" | "openai" | "anthropic"
+# Only configure the section for your chosen provider below.
+ASSISTANT_LLM_PROVIDER=livai
+
+# --- LivAI (LLNL-hosted) ---
+# Models: https://livai-tools.llnl.gov/models
+ASSISTANT_LIVAI_API_KEY=
+ASSISTANT_LIVAI_MODEL=
+ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
+
+# --- OpenAI ---
+# Models: https://platform.openai.com/docs/models
+ASSISTANT_OPENAI_API_KEY=
+ASSISTANT_OPENAI_MODEL=
+
+# --- Anthropic ---
+# Models: https://docs.anthropic.com/en/docs/about-claude/models
+ASSISTANT_ANTHROPIC_API_KEY=
+ASSISTANT_ANTHROPIC_MODEL=
+
+# --- Shared settings ---
+# Max seconds to wait for an LLM response before timing out.
+ASSISTANT_LLM_TIMEOUT_SECONDS=30
+# Sampling temperature for assistant LLM summaries.
+ASSISTANT_LLM_TEMPERATURE=0.2
+# Max tokens to allow in assistant LLM summary output.
+ASSISTANT_LLM_MAX_TOKENS=2048
+# Max characters from the simulation snapshot sent as LLM context.
+ASSISTANT_SNAPSHOT_MAX_CHARS=12000

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,13 @@ help:
 	@echo "  make pre-commit-run                        # Run all pre-commit hooks"
 	@echo ""
 
+	@echo "$(BLUE)Ollama (Local LLM):$(NC)"
+	@echo "  make ollama-serve                          # Start Ollama server with OLLAMA_KEEP_ALIVE=-1"
+	@echo "  make ollama-pull-fast                      # Pull llama3.1:8b (fast dev model)"
+	@echo "  make ollama-pull-dev                       # Pull gemma4:e4b (stronger dev model)"
+	@echo "  make ollama-pull-quality                   # Pull gemma4:26b (quality model)"
+	@echo ""
+
 	@echo "$(BLUE)Docker Compose:$(NC)"
 	@echo "  make docker-build svc=<svc>                # Build Docker image(s)"
 	@echo "  make docker-rebuild svc=<svc>              # Build Docker image(s) without cache"
@@ -310,3 +317,37 @@ docker-ps:
 
 docker-config:
 	$(COMPOSE) config
+
+# ============================================================
+# 🤖 OLLAMA LOCAL LLM COMMANDS
+# ============================================================
+
+.PHONY: \
+	ollama-serve \
+	ollama-pull-fast \
+	ollama-pull-dev \
+	ollama-pull-quality \
+	ollama-pull-e4b \
+	ollama-pull-26b
+
+ollama-serve:
+	@echo "$(GREEN)🚀 Starting Ollama server with OLLAMA_KEEP_ALIVE=-1...$(NC)"
+	OLLAMA_KEEP_ALIVE=-1 ollama serve
+
+ollama-pull-fast:
+	@echo "$(GREEN)📥 Pulling llama3.1:8b (fast dev model)...$(NC)"
+	ollama pull llama3.1:8b
+
+ollama-pull-dev:
+	@echo "$(GREEN)📥 Pulling gemma4:e4b (stronger dev model)...$(NC)"
+	ollama pull gemma4:e4b
+
+ollama-pull-quality:
+	@echo "$(GREEN)📥 Pulling gemma4:26b (quality model)...$(NC)"
+	ollama pull gemma4:26b
+
+ollama-pull-e4b:
+	@$(MAKE) ollama-pull-dev
+
+ollama-pull-26b:
+	@$(MAKE) ollama-pull-quality

--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -23,6 +23,9 @@
   // Type checking
   // ===================
   "mypy-type-checker.args": ["--config=pyproject.toml"],
+  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.diagnosticMode": "workspace",
+  "python.analysis.autoImportCompletions": true,
 
   // ===================
   // Testing settings

--- a/backend/README.md
+++ b/backend/README.md
@@ -36,22 +36,8 @@ make backend-upgrade
 
 ## Configuration
 
-Backend env templates live in `.envs/example/backend.env.example` and local developer values live in `.envs/local/backend.env`.
+Backend env templates live in `.envs/example/backend.env.example`. Local developer values live in `.envs/local/backend.env`.
 
-Assistant summary configuration uses the `ASSISTANT_*` namespace:
+Restart the backend after changing local env values.
 
-- `ASSISTANT_LLM_ENABLED`
-- `ASSISTANT_LLM_PROVIDER` with `openai`, `anthropic`, or `livai`
-- `ASSISTANT_OPENAI_API_KEY` / `ASSISTANT_OPENAI_MODEL`
-- `ASSISTANT_ANTHROPIC_API_KEY` / `ASSISTANT_ANTHROPIC_MODEL`
-- `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
-- `ASSISTANT_LLM_TIMEOUT_SECONDS`
-- `ASSISTANT_LLM_TEMPERATURE`
-- `ASSISTANT_LLM_MAX_TOKENS`
-- `ASSISTANT_SNAPSHOT_MAX_CHARS`
-
-For LivAI, `ASSISTANT_LIVAI_*` names are canonical.
-For the current LivAI OpenAI-compatible chat path, SimBoard omits `temperature` for `gpt-5*` models because that endpoint rejects the parameter.
-For step-by-step local setup and provider examples, see [docs/developer/README.md](../docs/developer/README.md#assistant-llm-env-setup).
-
-For repo-wide setup and contributor workflow, see [docs/developer/README.md](../docs/developer/README.md).
+For repo-wide setup, assistant LLM configuration, and contributor workflow, see [docs/developer/README.md](../docs/developer/README.md).

--- a/backend/README.md
+++ b/backend/README.md
@@ -34,4 +34,24 @@ make backend-migrate m='message'
 make backend-upgrade
 ```
 
+## Configuration
+
+Backend env templates live in `.envs/example/backend.env.example` and local developer values live in `.envs/local/backend.env`.
+
+Assistant summary configuration uses the `ASSISTANT_*` namespace:
+
+- `ASSISTANT_LLM_ENABLED`
+- `ASSISTANT_LLM_PROVIDER` with `openai`, `anthropic`, or `livai`
+- `ASSISTANT_OPENAI_API_KEY` / `ASSISTANT_OPENAI_MODEL`
+- `ASSISTANT_ANTHROPIC_API_KEY` / `ASSISTANT_ANTHROPIC_MODEL`
+- `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
+- `ASSISTANT_LLM_TIMEOUT_SECONDS`
+- `ASSISTANT_LLM_TEMPERATURE`
+- `ASSISTANT_LLM_MAX_TOKENS`
+- `ASSISTANT_SNAPSHOT_MAX_CHARS`
+
+For LivAI, `ASSISTANT_LIVAI_*` names are canonical.
+For the current LivAI OpenAI-compatible chat path, SimBoard omits `temperature` for `gpt-5*` models because that endpoint rejects the parameter.
+For step-by-step local setup and provider examples, see [docs/developer/README.md](../docs/developer/README.md#assistant-llm-env-setup).
+
 For repo-wide setup and contributor workflow, see [docs/developer/README.md](../docs/developer/README.md).

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
-from pydantic import Field
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -139,6 +139,26 @@ class Settings(BaseSettings):
     cookie_httponly: bool = True
     cookie_samesite: Literal["lax", "strict", "none"] = "lax"
     cookie_max_age: int = 3600
+
+    # --- Assistant LLM config ---
+    assistant_llm_enabled: bool = False
+    assistant_llm_provider: Literal["openai", "anthropic", "livai"] = "openai"
+    assistant_openai_api_key: SecretStr | None = None
+    assistant_openai_model: str | None = None
+    assistant_anthropic_api_key: SecretStr | None = None
+    assistant_anthropic_model: str | None = None
+    assistant_livai_api_key: SecretStr | None = None
+    assistant_livai_model: str | None = None
+    assistant_livai_base_url: str = "https://livai-api.llnl.gov/"
+    assistant_llm_timeout_seconds: float = 30.0
+    assistant_llm_temperature: float = 0.2
+    assistant_llm_max_tokens: int = 2048
+    assistant_snapshot_max_chars: int = 12000
+
+    @field_validator("assistant_livai_base_url", mode="before")
+    @classmethod
+    def _strip_livai_base_url(cls, value: str) -> str:
+        return value.strip()
 
 
 settings = Settings()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -142,14 +142,13 @@ class Settings(BaseSettings):
 
     # --- Assistant LLM config ---
     assistant_llm_enabled: bool = False
-    assistant_llm_provider: Literal["openai", "anthropic", "livai"] = "openai"
-    assistant_openai_api_key: SecretStr | None = None
-    assistant_openai_model: str | None = None
-    assistant_anthropic_api_key: SecretStr | None = None
-    assistant_anthropic_model: str | None = None
+    assistant_llm_provider: Literal["livai", "ollama"] = "ollama"
     assistant_livai_api_key: SecretStr | None = None
     assistant_livai_model: str | None = None
     assistant_livai_base_url: str = "https://livai-api.llnl.gov/"
+    assistant_ollama_api_key: SecretStr | None = None
+    assistant_ollama_model: str | None = None
+    assistant_ollama_base_url: str = "http://localhost:11434"
     assistant_llm_timeout_seconds: float = 30.0
     assistant_llm_temperature: float = 0.2
     assistant_llm_max_tokens: int = 2048
@@ -159,6 +158,11 @@ class Settings(BaseSettings):
     @classmethod
     def _strip_livai_base_url(cls, value: str) -> str:
         return value.strip()
+
+    @field_validator("assistant_ollama_base_url", mode="before")
+    @classmethod
+    def _strip_ollama_base_url(cls, value: str) -> str:
+        return value.strip().rstrip("/")
 
 
 settings = Settings()

--- a/backend/app/features/assistant/__init__.py
+++ b/backend/app/features/assistant/__init__.py
@@ -1,0 +1,1 @@
+"""Assistant feature package."""

--- a/backend/app/features/assistant/api.py
+++ b/backend/app/features/assistant/api.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from time import perf_counter
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
+
+from app.core.database_async import get_async_session
+from app.core.logger import _setup_custom_logger
+from app.features.assistant.orchestrator import generate_simulation_summary
+from app.features.assistant.schemas import SimulationSummaryResponse
+from app.features.simulation.models import Simulation
+from app.features.user.manager import current_active_user
+from app.features.user.models import User
+
+router = APIRouter(prefix="/simulations", tags=["Simulation Assistant"])
+logger = _setup_custom_logger(__name__)
+
+
+@router.post(
+    "/{sim_id}/summary",
+    response_model=SimulationSummaryResponse,
+    responses={
+        200: {"description": "Simulation summary generated successfully."},
+        401: {"description": "Unauthorized."},
+        404: {"description": "Simulation not found."},
+    },
+)
+async def summarize_simulation(
+    sim_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> SimulationSummaryResponse:
+    """Generate a metadata-grounded read-only summary for one simulation."""
+
+    start = perf_counter()
+    trace_id = uuid4()
+
+    stmt = (
+        select(Simulation)
+        .options(
+            joinedload(Simulation.case),
+            joinedload(Simulation.machine),
+            selectinload(Simulation.artifacts),
+            selectinload(Simulation.links),
+        )
+        .where(Simulation.id == sim_id)
+    )
+    result = await db.execute(stmt)
+    simulation = result.scalars().unique().one_or_none()
+
+    if simulation is None:
+        duration_ms = (perf_counter() - start) * 1000
+        logger.info(
+            "simulation_summary trace_id=%s simulation_id=%s user_id=%s success=false "
+            "status=not_found latency_ms=%.2f llm_latency_ms=%.2f generation_mode=%s "
+            "generation_provider=%s generation_model=%s fallback_reason=%s "
+            "citation_count=0 caveat_count=0",
+            trace_id,
+            sim_id,
+            user.id,
+            duration_ms,
+            0.0,
+            "deterministic",
+            "null",
+            "null",
+            "simulation_not_found",
+        )
+        raise HTTPException(status_code=404, detail="Simulation not found")
+
+    generation = await generate_simulation_summary(simulation)
+    summary = generation.summary.model_copy(update={"trace_id": trace_id})
+
+    duration_ms = (perf_counter() - start) * 1000
+    logger.info(
+        "simulation_summary trace_id=%s simulation_id=%s user_id=%s success=true "
+        "latency_ms=%.2f llm_latency_ms=%.2f generation_mode=%s generation_provider=%s "
+        "generation_model=%s fallback_reason=%s citation_count=%d caveat_count=%d",
+        trace_id,
+        simulation.id,
+        user.id,
+        duration_ms,
+        generation.llm_latency_ms,
+        summary.generation_mode,
+        generation.attempted_provider or "null",
+        generation.attempted_model or "null",
+        generation.fallback_reason or "null",
+        len(summary.citations),
+        len(summary.caveats),
+    )
+
+    return summary

--- a/backend/app/features/assistant/api.py
+++ b/backend/app/features/assistant/api.py
@@ -56,7 +56,7 @@ async def summarize_simulation(
         duration_ms = (perf_counter() - start) * 1000
         logger.info(
             "simulation_summary trace_id=%s simulation_id=%s user_id=%s success=false "
-            "status=not_found latency_ms=%.2f llm_latency_ms=%.2f generation_mode=%s "
+            "status=not_found llm_success=false fallback_used=false latency_ms=%.2f llm_latency_ms=%.2f generation_mode=%s "
             "generation_provider=%s generation_model=%s fallback_reason=%s "
             "citation_count=0 caveat_count=0",
             trace_id,
@@ -72,16 +72,29 @@ async def summarize_simulation(
         raise HTTPException(status_code=404, detail="Simulation not found")
 
     generation = await generate_simulation_summary(simulation)
-    summary = generation.summary.model_copy(update={"trace_id": trace_id})
+    llm_success = generation.summary.generation_mode == "llm"
+    fallback_used = (
+        not llm_success
+        and generation.fallback_reason is not None
+        and generation.fallback_reason != "llm_disabled"
+    )
+    summary = generation.summary.model_copy(
+        update={
+            "trace_id": trace_id,
+            "fallback_used": fallback_used,
+        }
+    )
 
     duration_ms = (perf_counter() - start) * 1000
     logger.info(
         "simulation_summary trace_id=%s simulation_id=%s user_id=%s success=true "
-        "latency_ms=%.2f llm_latency_ms=%.2f generation_mode=%s generation_provider=%s "
-        "generation_model=%s fallback_reason=%s citation_count=%d caveat_count=%d",
+        "llm_success=%s fallback_used=%s latency_ms=%.2f llm_latency_ms=%.2f generation_mode=%s "
+        "generation_provider=%s generation_model=%s fallback_reason=%s citation_count=%d caveat_count=%d",
         trace_id,
         simulation.id,
         user.id,
+        str(llm_success).lower(),
+        str(fallback_used).lower(),
         duration_ms,
         generation.llm_latency_ms,
         summary.generation_mode,

--- a/backend/app/features/assistant/llm_generator.py
+++ b/backend/app/features/assistant/llm_generator.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 from httpx import AsyncClient
+from openai import AsyncOpenAI
 from pydantic import SecretStr
 from pydantic_ai import Agent
-from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.openai import OpenAIChatModel
-from pydantic_ai.providers.anthropic import AnthropicProvider
+from pydantic_ai.output import PromptedOutput
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.settings import ModelSettings
 
@@ -28,15 +29,28 @@ Rules:
 - If metadata is missing or truncated, say so in caveats.
 - Keep claims grounded in citations.
 - Use only allowed citation paths and source types provided in prompt.
+- Every `citations.path` value must exactly match one allowed path string.
+- Never shorten or rewrite citation paths. For example, use `simulation.status`, `case.name`, and `machine.name`, not `status` or `name`.
+- If you cannot cite a claim with an exact allowed path, omit that claim instead of inventing a citation path.
 - Produce concise, factual output for all structured fields.
+- Return every structured field required by schema, even when brief.
+- `suggested_followups` must contain at least one concrete item.
+- Keep `answer` to 2-4 short sentences and under 120 words.
+- Prioritize the few most decision-useful facts: status, case/campaign, configuration, machine, and notable provenance or timing only when material.
+- Do not enumerate every available field.
+- Do not repeat raw citation paths or add inline bracketed citations such as `[simulation.status]` inside the answer text.
+- Put evidence only in the structured `citations` field, not inline in prose.
+- Prefer natural language over field-by-field narration.
 """.strip()
+
+_OLLAMA_PLACEHOLDER_API_KEY = "api-key-not-set"
 
 
 @dataclass(frozen=True)
 class AssistantLLMConfig:
     provider: SummaryGenerationProvider
     model_name: str
-    api_key: SecretStr
+    api_key: SecretStr | None
     timeout_seconds: float
     temperature: float
     max_tokens: int
@@ -48,45 +62,108 @@ class SummaryLLMGenerator:
         self.config = config
 
     async def generate(self, snapshot: SimulationSnapshot) -> SimulationSummaryContent:
+        """
+        Generates a simulation summary from the given snapshot using the
+        configured LLM provider.
+
+        Parameters
+        ----------
+        snapshot : SimulationSnapshot
+            The simulation snapshot containing metadata to summarize.
+
+        Returns
+        -------
+        SimulationSummaryContent
+            The generated simulation summary content.
+        """
         async with AsyncClient(timeout=self.config.timeout_seconds) as http_client:
             model = self._build_model(http_client)
             agent = Agent(
                 model,
-                output_type=SimulationSummaryContent,
+                output_type=self._build_output_type(),
                 system_prompt=SUMMARY_SYSTEM_PROMPT,
                 model_settings=self._build_model_settings(),
             )
+
             result = await agent.run(self._build_user_prompt(snapshot))
             return result.output
 
-    def _build_model(
-        self, http_client: AsyncClient
-    ) -> OpenAIChatModel | AnthropicModel:
-        api_key = self.config.api_key.get_secret_value()
-        if self.config.provider in {"openai", "livai"}:
-            return OpenAIChatModel(
-                self.config.model_name,
-                provider=OpenAIProvider(
-                    api_key=api_key,
-                    base_url=self.config.base_url,
-                    http_client=http_client,
-                ),
-            )
-        return AnthropicModel(
-            self.config.model_name,
-            provider=AnthropicProvider(api_key=api_key, http_client=http_client),
+    def _build_model(self, http_client: AsyncClient) -> OpenAIChatModel:
+        """Builds the OpenAIChatModel based on the configuration and HTTP client.
+
+        For Ollama, if the API key is not set, it uses a placeholder value to
+        allow the client to initialize without credentials, since Ollama can run
+        without an API key.
+
+        Parameters
+        ----------
+        http_client : AsyncClient
+            The HTTP client to use for making requests to the LLM provider.
+
+        Returns
+        -------
+        OpenAIChatModel
+            The initialized OpenAIChatModel ready for generating summaries.
+        """
+        api_key = (
+            self.config.api_key.get_secret_value()
+            if self.config.api_key is not None
+            else None
         )
+
+        if self.config.provider == "ollama":
+            api_key = api_key or _OLLAMA_PLACEHOLDER_API_KEY
+
+        provider_kwargs = {
+            "api_key": api_key,
+            "base_url": self._resolve_base_url(),
+            "http_client": http_client,
+        }
+        if self.config.provider == "ollama":
+            provider_kwargs = {
+                "openai_client": AsyncOpenAI(
+                    **provider_kwargs,
+                    max_retries=0,
+                    timeout=self.config.timeout_seconds,
+                    _enforce_credentials=False,
+                )
+            }
+
+        model = OpenAIChatModel(
+            self.config.model_name, provider=OpenAIProvider(**provider_kwargs)
+        )
+        return model
+
+    def _resolve_base_url(self) -> str | None:
+        if self.config.provider != "ollama" or self.config.base_url is None:
+            return self.config.base_url
+
+        parsed = urlparse(self.config.base_url)
+        if parsed.path not in {"", "/"}:
+            return self.config.base_url
+
+        return f"{self.config.base_url.rstrip('/')}/v1"
 
     def _build_model_settings(self) -> ModelSettings | None:
         settings: ModelSettings = {
             "max_tokens": self.config.max_tokens,
         }
+
         if not (
             self.config.provider == "livai"
             and self.config.model_name.startswith("gpt-5")
         ):
             settings["temperature"] = self.config.temperature
+
         return settings or None
+
+    def _build_output_type(
+        self,
+    ) -> type[SimulationSummaryContent] | PromptedOutput[SimulationSummaryContent]:
+        if self.config.provider == "ollama":
+            return PromptedOutput(SimulationSummaryContent)
+
+        return SimulationSummaryContent
 
     def _build_user_prompt(self, snapshot: SimulationSnapshot) -> str:
         allowed_citations = "\n".join(
@@ -94,6 +171,7 @@ class SummaryLLMGenerator:
             for path, entry in sorted(CITATION_REGISTRY.items())
         )
         snapshot_json = snapshot.model_dump_json(indent=2, exclude_none=True)
+
         return (
             "Simulation metadata snapshot:\n"
             f"{snapshot_json}\n\n"

--- a/backend/app/features/assistant/llm_generator.py
+++ b/backend/app/features/assistant/llm_generator.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from httpx import AsyncClient
+from pydantic import SecretStr
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.anthropic import AnthropicProvider
+from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.settings import ModelSettings
+
+from app.features.assistant.registry import CITATION_REGISTRY
+from app.features.assistant.schemas import (
+    SimulationSummaryContent,
+    SummaryGenerationProvider,
+)
+from app.features.assistant.snapshot import SimulationSnapshot
+
+SUMMARY_SYSTEM_PROMPT = """
+You generate structured SimBoard simulation summaries from provided metadata only.
+
+Rules:
+- Use only snapshot metadata supplied in prompt.
+- Do not use external knowledge, retrieval, or unstated assumptions.
+- Do not interpret diagnostics or scientific results beyond what metadata explicitly says.
+- If metadata is missing or truncated, say so in caveats.
+- Keep claims grounded in citations.
+- Use only allowed citation paths and source types provided in prompt.
+- Produce concise, factual output for all structured fields.
+""".strip()
+
+
+@dataclass(frozen=True)
+class AssistantLLMConfig:
+    provider: SummaryGenerationProvider
+    model_name: str
+    api_key: SecretStr
+    timeout_seconds: float
+    temperature: float
+    max_tokens: int
+    base_url: str | None = None
+
+
+class SummaryLLMGenerator:
+    def __init__(self, config: AssistantLLMConfig) -> None:
+        self.config = config
+
+    async def generate(self, snapshot: SimulationSnapshot) -> SimulationSummaryContent:
+        async with AsyncClient(timeout=self.config.timeout_seconds) as http_client:
+            model = self._build_model(http_client)
+            agent = Agent(
+                model,
+                output_type=SimulationSummaryContent,
+                system_prompt=SUMMARY_SYSTEM_PROMPT,
+                model_settings=self._build_model_settings(),
+            )
+            result = await agent.run(self._build_user_prompt(snapshot))
+            return result.output
+
+    def _build_model(
+        self, http_client: AsyncClient
+    ) -> OpenAIChatModel | AnthropicModel:
+        api_key = self.config.api_key.get_secret_value()
+        if self.config.provider in {"openai", "livai"}:
+            return OpenAIChatModel(
+                self.config.model_name,
+                provider=OpenAIProvider(
+                    api_key=api_key,
+                    base_url=self.config.base_url,
+                    http_client=http_client,
+                ),
+            )
+        return AnthropicModel(
+            self.config.model_name,
+            provider=AnthropicProvider(api_key=api_key, http_client=http_client),
+        )
+
+    def _build_model_settings(self) -> ModelSettings | None:
+        settings: ModelSettings = {
+            "max_tokens": self.config.max_tokens,
+        }
+        if not (
+            self.config.provider == "livai"
+            and self.config.model_name.startswith("gpt-5")
+        ):
+            settings["temperature"] = self.config.temperature
+        return settings or None
+
+    def _build_user_prompt(self, snapshot: SimulationSnapshot) -> str:
+        allowed_citations = "\n".join(
+            f"- {path} ({entry.source_type})"
+            for path, entry in sorted(CITATION_REGISTRY.items())
+        )
+        snapshot_json = snapshot.model_dump_json(indent=2, exclude_none=True)
+        return (
+            "Simulation metadata snapshot:\n"
+            f"{snapshot_json}\n\n"
+            "Allowed citation paths:\n"
+            f"{allowed_citations}\n"
+        )

--- a/backend/app/features/assistant/orchestrator.py
+++ b/backend/app/features/assistant/orchestrator.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import json
+import re
 from dataclasses import dataclass
 from time import perf_counter
 
 from pydantic import ValidationError
+from pydantic_ai.exceptions import (
+    ModelAPIError,
+    ModelHTTPError,
+    UnexpectedModelBehavior,
+)
 
 from app.core.config import settings
 from app.features.assistant.llm_generator import AssistantLLMConfig, SummaryLLMGenerator
@@ -60,6 +67,12 @@ _SNAPSHOT_PATH_ACCESSORS = {
     else None,
 }
 
+_INLINE_CITATION_RE = re.compile(
+    r"\s*\[(?:simulation|case|machine|artifacts|links)[^\]]+\]"
+)
+_MULTISPACE_RE = re.compile(r"\s+")
+_SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([,.;:])")
+
 
 @dataclass(frozen=True)
 class SummaryGenerationResult:
@@ -70,112 +83,118 @@ class SummaryGenerationResult:
     attempted_model: str | None
 
 
-def _standardize_citations(
-    citations: list[SummaryCitationOut],
-    snapshot: SimulationSnapshot,
-) -> list[SummaryCitationOut]:
-    normalized: list[SummaryCitationOut] = []
-    for citation in citations:
-        if citation.path not in VALID_CITATION_PATHS:
-            raise ValueError(f"invalid_citation_path:{citation.path}")
-        if not snapshot_has_citation_path(snapshot, citation.path):
-            raise ValueError(f"missing_citation_path:{citation.path}")
-        entry = get_citation_entry(citation.path)
-        normalized.append(
-            SummaryCitationOut(
-                source_type=entry.source_type,
-                path=citation.path,
-                label=entry.label,
-            )
+async def generate_simulation_summary(
+    simulation: Simulation,
+) -> SummaryGenerationResult:
+    attempted_provider: SummaryGenerationProvider | None = None
+    attempted_model: str | None = None
+
+    if settings.assistant_llm_enabled:
+        attempted_provider = settings.assistant_llm_provider
+        attempted_model = _configured_model_name(settings.assistant_llm_provider)
+
+    try:
+        snapshot = build_simulation_snapshot(simulation)
+    except SnapshotBudgetExceededError as exc:
+        result = SummaryGenerationResult(
+            summary=_build_deterministic_response(
+                exc.snapshot,
+                include_fallback_caveat=settings.assistant_llm_enabled,
+            ).model_copy(update={"fallback_used": settings.assistant_llm_enabled}),
+            fallback_reason=str(exc)
+            if settings.assistant_llm_enabled
+            else "llm_disabled",
+            llm_latency_ms=0.0,
+            attempted_provider=attempted_provider,
+            attempted_model=attempted_model,
         )
-    return normalized
 
+        return result
 
-def _merge_unique_strings(*groups: list[str]) -> list[str]:
-    seen: set[str] = set()
-    merged: list[str] = []
-    for group in groups:
-        for item in group:
-            if item not in seen:
-                seen.add(item)
-                merged.append(item)
-    return merged
-
-
-def _validate_llm_content(
-    content: SimulationSummaryContent,
-    snapshot: SimulationSnapshot,
-) -> SimulationSummaryContent:
-    if not content.answer.strip():
-        raise ValueError("empty_answer")
-    if not content.citations:
-        raise ValueError("missing_citations")
-    if not content.limitations:
-        raise ValueError("missing_limitations")
-    if not content.suggested_followups:
-        raise ValueError("missing_followups")
-
-    return content.model_copy(
-        update={
-            "citations": _standardize_citations(content.citations, snapshot),
-            "caveats": _merge_unique_strings(
-                snapshot.snapshot_caveats, content.caveats
+    if not settings.assistant_llm_enabled:
+        result = SummaryGenerationResult(
+            summary=_build_deterministic_response(
+                snapshot,
+                include_fallback_caveat=False,
             ),
-            "limitations": _merge_unique_strings(content.limitations, LLM_LIMITATIONS),
-        }
+            fallback_reason="llm_disabled",
+            llm_latency_ms=0.0,
+            attempted_provider=None,
+            attempted_model=None,
+        )
+
+        return result
+
+    try:
+        config = _resolve_llm_config()
+        attempted_provider = config.provider
+        attempted_model = config.model_name
+        generator = SummaryLLMGenerator(config)
+    except ValueError as exc:
+        result = SummaryGenerationResult(
+            summary=_build_deterministic_response(
+                snapshot,
+                include_fallback_caveat=True,
+            ).model_copy(update={"fallback_used": True}),
+            fallback_reason=str(exc),
+            llm_latency_ms=0.0,
+            attempted_provider=attempted_provider,
+            attempted_model=attempted_model,
+        )
+
+        return result
+
+    start = perf_counter()
+    try:
+        llm_content = await generator.generate(snapshot)
+        llm_content = _fill_missing_llm_followups(llm_content, snapshot)
+        validated = _validate_llm_content(llm_content, snapshot)
+
+        response = SimulationSummaryResponse(
+            **validated.model_dump(),
+            generation_mode="llm",
+            fallback_used=False,
+            generation_provider=config.provider,
+            generation_model=config.model_name,
+            trace_id="00000000-0000-0000-0000-000000000000",
+        )
+        result = SummaryGenerationResult(
+            summary=response,
+            fallback_reason=None,
+            llm_latency_ms=(perf_counter() - start) * 1000,
+            attempted_provider=config.provider,
+            attempted_model=config.model_name,
+        )
+
+        return result
+    except (ValidationError, ValueError) as exc:
+        fallback_reason = getattr(exc, "args", ["llm_validation_failed"])[0]
+    except Exception as exc:  # pragma: no cover - exercised via patched tests
+        fallback_reason = _format_model_error(exc)
+
+    result = SummaryGenerationResult(
+        summary=_build_deterministic_response(
+            snapshot,
+            include_fallback_caveat=True,
+        ).model_copy(update={"fallback_used": True}),
+        fallback_reason=str(fallback_reason),
+        llm_latency_ms=(perf_counter() - start) * 1000,
+        attempted_provider=config.provider,
+        attempted_model=config.model_name,
     )
 
+    return result
 
-def _build_deterministic_response(
-    snapshot: SimulationSnapshot,
-    *,
-    include_fallback_caveat: bool,
-) -> SimulationSummaryResponse:
-    base = build_simulation_summary(
-        snapshot,
-        include_fallback_caveat=include_fallback_caveat,
-    )
-    return base.model_copy(
-        update={
-            "generation_mode": "deterministic",
-            "generation_provider": None,
-            "generation_model": None,
-        }
-    )
+
+def _configured_model_name(provider: SummaryGenerationProvider) -> str | None:
+    if provider == "livai":
+        return settings.assistant_livai_model
+
+    return settings.assistant_ollama_model
 
 
 def _resolve_llm_config() -> AssistantLLMConfig:
     provider = settings.assistant_llm_provider
-    if provider == "openai":
-        if (
-            settings.assistant_openai_api_key is None
-            or not settings.assistant_openai_model
-        ):
-            raise ValueError("openai_misconfigured")
-        return AssistantLLMConfig(
-            provider="openai",
-            model_name=settings.assistant_openai_model,
-            api_key=settings.assistant_openai_api_key,
-            timeout_seconds=settings.assistant_llm_timeout_seconds,
-            temperature=settings.assistant_llm_temperature,
-            max_tokens=settings.assistant_llm_max_tokens,
-        )
-
-    if provider == "anthropic":
-        if (
-            settings.assistant_anthropic_api_key is None
-            or not settings.assistant_anthropic_model
-        ):
-            raise ValueError("anthropic_misconfigured")
-        return AssistantLLMConfig(
-            provider="anthropic",
-            model_name=settings.assistant_anthropic_model,
-            api_key=settings.assistant_anthropic_api_key,
-            timeout_seconds=settings.assistant_llm_timeout_seconds,
-            temperature=settings.assistant_llm_temperature,
-            max_tokens=settings.assistant_llm_max_tokens,
-        )
-
     if provider == "livai":
         if (
             settings.assistant_livai_api_key is None
@@ -193,115 +212,201 @@ def _resolve_llm_config() -> AssistantLLMConfig:
             base_url=settings.assistant_livai_base_url,
         )
 
+    if provider == "ollama":
+        if (
+            not settings.assistant_ollama_model
+            or not settings.assistant_ollama_base_url
+        ):
+            raise ValueError("ollama_misconfigured")
+        return AssistantLLMConfig(
+            provider="ollama",
+            model_name=settings.assistant_ollama_model,
+            api_key=settings.assistant_ollama_api_key,
+            timeout_seconds=settings.assistant_llm_timeout_seconds,
+            temperature=settings.assistant_llm_temperature,
+            max_tokens=settings.assistant_llm_max_tokens,
+            base_url=settings.assistant_ollama_base_url,
+        )
+
     raise ValueError("unsupported_provider")
 
 
-def _configured_model_name(provider: SummaryGenerationProvider) -> str | None:
-    if provider == "openai":
-        return settings.assistant_openai_model
-    if provider == "anthropic":
-        return settings.assistant_anthropic_model
-    return settings.assistant_livai_model
+def _standardize_citations(
+    citations: list[SummaryCitationOut],
+    snapshot: SimulationSnapshot,
+) -> list[SummaryCitationOut]:
+    normalized: list[SummaryCitationOut] = []
 
-
-async def generate_simulation_summary(
-    simulation: Simulation,
-) -> SummaryGenerationResult:
-    attempted_provider: SummaryGenerationProvider | None = None
-    attempted_model: str | None = None
-
-    if settings.assistant_llm_enabled:
-        attempted_provider = settings.assistant_llm_provider
-        attempted_model = _configured_model_name(settings.assistant_llm_provider)
-
-    try:
-        snapshot = build_simulation_snapshot(simulation)
-    except SnapshotBudgetExceededError as exc:
-        return SummaryGenerationResult(
-            summary=_build_deterministic_response(
-                exc.snapshot,
-                include_fallback_caveat=settings.assistant_llm_enabled,
-            ),
-            fallback_reason=str(exc)
-            if settings.assistant_llm_enabled
-            else "llm_disabled",
-            llm_latency_ms=0.0,
-            attempted_provider=attempted_provider,
-            attempted_model=attempted_model,
+    for citation in citations:
+        canonical_path = _canonicalize_citation_path(
+            citation.path,
+            citation.source_type,
         )
 
-    if not settings.assistant_llm_enabled:
-        return SummaryGenerationResult(
-            summary=_build_deterministic_response(
-                snapshot,
-                include_fallback_caveat=False,
-            ),
-            fallback_reason="llm_disabled",
-            llm_latency_ms=0.0,
-            attempted_provider=None,
-            attempted_model=None,
+        if not _snapshot_has_citation_path(snapshot, canonical_path):
+            raise ValueError(f"missing_citation_path:{canonical_path}")
+
+        entry = get_citation_entry(canonical_path)
+
+        normalized.append(
+            SummaryCitationOut(
+                source_type=entry.source_type,
+                path=canonical_path,
+                label=entry.label,
+            )
         )
-
-    try:
-        config = _resolve_llm_config()
-        attempted_provider = config.provider
-        attempted_model = config.model_name
-        generator = SummaryLLMGenerator(config)
-    except ValueError as exc:
-        return SummaryGenerationResult(
-            summary=_build_deterministic_response(
-                snapshot,
-                include_fallback_caveat=True,
-            ),
-            fallback_reason=str(exc),
-            llm_latency_ms=0.0,
-            attempted_provider=attempted_provider,
-            attempted_model=attempted_model,
-        )
-
-    start = perf_counter()
-    try:
-        llm_content = await generator.generate(snapshot)
-        validated = _validate_llm_content(llm_content, snapshot)
-        response = SimulationSummaryResponse(
-            **validated.model_dump(),
-            generation_mode="llm",
-            generation_provider=config.provider,
-            generation_model=config.model_name,
-            trace_id="00000000-0000-0000-0000-000000000000",
-        )
-        return SummaryGenerationResult(
-            summary=response,
-            fallback_reason=None,
-            llm_latency_ms=(perf_counter() - start) * 1000,
-            attempted_provider=config.provider,
-            attempted_model=config.model_name,
-        )
-    except (ValidationError, ValueError) as exc:
-        fallback_reason = getattr(exc, "args", ["llm_validation_failed"])[0]
-    except Exception as exc:  # pragma: no cover - exercised via patched tests
-        fallback_reason = exc.__class__.__name__
-
-    return SummaryGenerationResult(
-        summary=_build_deterministic_response(
-            snapshot,
-            include_fallback_caveat=True,
-        ),
-        fallback_reason=str(fallback_reason),
-        llm_latency_ms=(perf_counter() - start) * 1000,
-        attempted_provider=config.provider,
-        attempted_model=config.model_name,
-    )
+    return normalized
 
 
-def snapshot_has_citation_path(snapshot: SimulationSnapshot, path: str) -> bool:
+def _canonicalize_citation_path(path: str, source_type: str | None = None) -> str:
+    normalized = path.strip()
+
+    if normalized in VALID_CITATION_PATHS:
+        return normalized
+
+    matches = [
+        candidate
+        for candidate in VALID_CITATION_PATHS
+        if candidate.endswith(f".{normalized}")
+    ]
+
+    if source_type is not None:
+        typed_matches = [
+            candidate
+            for candidate in matches
+            if get_citation_entry(candidate).source_type == source_type
+        ]
+
+        if len(typed_matches) == 1:
+            return typed_matches[0]
+
+    if len(matches) == 1:
+        return matches[0]
+
+    raise ValueError(f"invalid_citation_path:{path}")
+
+
+def _snapshot_has_citation_path(snapshot: SimulationSnapshot, path: str) -> bool:
     accessor = _SNAPSHOT_PATH_ACCESSORS.get(path)
+
     if accessor is not None:
         return bool(accessor(snapshot))
+
     if path.startswith("artifacts[kind="):
         kind = path[len("artifacts[kind=") : -1]
+
         return any(item.kind == kind for item in snapshot.artifacts)
     if path.startswith("links[kind="):
         kind = path[len("links[kind=") : -1]
+
         return any(item.kind == kind for item in snapshot.links)
+
     return False
+
+
+def _merge_unique_strings(*groups: list[str]) -> list[str]:
+    seen: set[str] = set()
+    merged: list[str] = []
+
+    for group in groups:
+        for item in group:
+            if item not in seen:
+                seen.add(item)
+                merged.append(item)
+
+    return merged
+
+
+def _validate_llm_content(
+    content: SimulationSummaryContent,
+    snapshot: SimulationSnapshot,
+) -> SimulationSummaryContent:
+    normalized_answer = _normalize_llm_answer(content.answer)
+
+    if not normalized_answer:
+        raise ValueError("empty_answer")
+    if not content.citations:
+        raise ValueError("missing_citations")
+    if not content.limitations:
+        raise ValueError("missing_limitations")
+    if not content.suggested_followups:
+        raise ValueError("missing_followups")
+
+    return content.model_copy(
+        update={
+            "answer": normalized_answer,
+            "citations": _standardize_citations(content.citations, snapshot),
+            "caveats": _merge_unique_strings(
+                snapshot.snapshot_caveats, content.caveats
+            ),
+            "limitations": _merge_unique_strings(content.limitations, LLM_LIMITATIONS),
+        }
+    )
+
+
+def _normalize_llm_answer(answer: str) -> str:
+    cleaned = _INLINE_CITATION_RE.sub("", answer)
+    cleaned = _MULTISPACE_RE.sub(" ", cleaned).strip()
+    cleaned = _SPACE_BEFORE_PUNCT_RE.sub(r"\1", cleaned)
+
+    return cleaned
+
+
+def _build_deterministic_response(
+    snapshot: SimulationSnapshot,
+    *,
+    include_fallback_caveat: bool,
+) -> SimulationSummaryResponse:
+    base = build_simulation_summary(
+        snapshot,
+        include_fallback_caveat=include_fallback_caveat,
+    )
+
+    return base.model_copy(
+        update={
+            "generation_mode": "deterministic",
+            "generation_provider": None,
+            "generation_model": None,
+        }
+    )
+
+
+def _fill_missing_llm_followups(
+    content: SimulationSummaryContent,
+    snapshot: SimulationSnapshot,
+) -> SimulationSummaryContent:
+    if content.suggested_followups:
+        return content
+
+    fallback_summary = build_simulation_summary(snapshot)
+
+    return content.model_copy(
+        update={"suggested_followups": fallback_summary.suggested_followups}
+    )
+
+
+def _format_model_error(exc: Exception) -> str:
+    if isinstance(exc, ModelHTTPError):
+        body = exc.body
+
+        if body is not None and not isinstance(body, str):
+            body = json.dumps(body, sort_keys=True)
+        return _trim_fallback_reason(
+            f"{exc.__class__.__name__}: status_code={exc.status_code}; body={body}"
+        )
+
+    if isinstance(exc, (ModelAPIError, UnexpectedModelBehavior)):
+        return _trim_fallback_reason(f"{exc.__class__.__name__}: {exc}")
+
+    message = str(exc).strip()
+    if not message:
+        return exc.__class__.__name__
+
+    return _trim_fallback_reason(f"{exc.__class__.__name__}: {message}")
+
+
+def _trim_fallback_reason(value: str, limit: int = 500) -> str:
+    if len(value) <= limit:
+        return value
+
+    return f"{value[: limit - 3]}..."

--- a/backend/app/features/assistant/orchestrator.py
+++ b/backend/app/features/assistant/orchestrator.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+
+from pydantic import ValidationError
+
+from app.core.config import settings
+from app.features.assistant.llm_generator import AssistantLLMConfig, SummaryLLMGenerator
+from app.features.assistant.registry import VALID_CITATION_PATHS, get_citation_entry
+from app.features.assistant.schemas import (
+    SimulationSummaryContent,
+    SimulationSummaryResponse,
+    SummaryCitationOut,
+    SummaryGenerationProvider,
+)
+from app.features.assistant.service import (
+    LLM_LIMITATIONS,
+    build_simulation_summary,
+)
+from app.features.assistant.snapshot import (
+    SimulationSnapshot,
+    SnapshotBudgetExceededError,
+    build_simulation_snapshot,
+)
+from app.features.simulation.models import Simulation
+
+_SNAPSHOT_PATH_ACCESSORS = {
+    "simulation.id": lambda snapshot: snapshot.simulation.id,
+    "simulation.execution_id": lambda snapshot: snapshot.simulation.execution_id,
+    "simulation.description": lambda snapshot: snapshot.simulation.description,
+    "simulation.compset": lambda snapshot: snapshot.simulation.compset,
+    "simulation.compset_alias": lambda snapshot: snapshot.simulation.compset_alias,
+    "simulation.grid_name": lambda snapshot: snapshot.simulation.grid_name,
+    "simulation.grid_resolution": lambda snapshot: snapshot.simulation.grid_resolution,
+    "simulation.simulation_type": lambda snapshot: snapshot.simulation.simulation_type,
+    "simulation.status": lambda snapshot: snapshot.simulation.status,
+    "simulation.campaign": lambda snapshot: snapshot.simulation.campaign,
+    "simulation.experiment_type": lambda snapshot: snapshot.simulation.experiment_type,
+    "simulation.initialization_type": lambda snapshot: snapshot.simulation.initialization_type,
+    "simulation.simulation_start_date": lambda snapshot: snapshot.simulation.simulation_start_date,
+    "simulation.simulation_end_date": lambda snapshot: snapshot.simulation.simulation_end_date,
+    "simulation.run_start_date": lambda snapshot: snapshot.simulation.run_start_date,
+    "simulation.run_end_date": lambda snapshot: snapshot.simulation.run_end_date,
+    "simulation.compiler": lambda snapshot: snapshot.simulation.compiler,
+    "simulation.key_features": lambda snapshot: snapshot.simulation.key_features,
+    "simulation.known_issues": lambda snapshot: snapshot.simulation.known_issues,
+    "simulation.notes_markdown": lambda snapshot: snapshot.simulation.notes_markdown,
+    "simulation.git_repository_url": lambda snapshot: snapshot.simulation.git_repository_url,
+    "simulation.git_branch": lambda snapshot: snapshot.simulation.git_branch,
+    "simulation.git_tag": lambda snapshot: snapshot.simulation.git_tag,
+    "simulation.git_commit_hash": lambda snapshot: snapshot.simulation.git_commit_hash,
+    "simulation.extra": lambda snapshot: snapshot.simulation.extra,
+    "simulation.run_config_deltas": lambda snapshot: snapshot.simulation.run_config_deltas,
+    "case.name": lambda snapshot: snapshot.case.name,
+    "case.case_group": lambda snapshot: snapshot.case.case_group,
+    "case.reference_simulation_id": lambda snapshot: snapshot.case.reference_simulation_id,
+    "machine.name": lambda snapshot: snapshot.machine.name
+    if snapshot.machine
+    else None,
+}
+
+
+@dataclass(frozen=True)
+class SummaryGenerationResult:
+    summary: SimulationSummaryResponse
+    fallback_reason: str | None
+    llm_latency_ms: float
+    attempted_provider: SummaryGenerationProvider | None
+    attempted_model: str | None
+
+
+def _standardize_citations(
+    citations: list[SummaryCitationOut],
+    snapshot: SimulationSnapshot,
+) -> list[SummaryCitationOut]:
+    normalized: list[SummaryCitationOut] = []
+    for citation in citations:
+        if citation.path not in VALID_CITATION_PATHS:
+            raise ValueError(f"invalid_citation_path:{citation.path}")
+        if not snapshot_has_citation_path(snapshot, citation.path):
+            raise ValueError(f"missing_citation_path:{citation.path}")
+        entry = get_citation_entry(citation.path)
+        normalized.append(
+            SummaryCitationOut(
+                source_type=entry.source_type,
+                path=citation.path,
+                label=entry.label,
+            )
+        )
+    return normalized
+
+
+def _merge_unique_strings(*groups: list[str]) -> list[str]:
+    seen: set[str] = set()
+    merged: list[str] = []
+    for group in groups:
+        for item in group:
+            if item not in seen:
+                seen.add(item)
+                merged.append(item)
+    return merged
+
+
+def _validate_llm_content(
+    content: SimulationSummaryContent,
+    snapshot: SimulationSnapshot,
+) -> SimulationSummaryContent:
+    if not content.answer.strip():
+        raise ValueError("empty_answer")
+    if not content.citations:
+        raise ValueError("missing_citations")
+    if not content.limitations:
+        raise ValueError("missing_limitations")
+    if not content.suggested_followups:
+        raise ValueError("missing_followups")
+
+    return content.model_copy(
+        update={
+            "citations": _standardize_citations(content.citations, snapshot),
+            "caveats": _merge_unique_strings(
+                snapshot.snapshot_caveats, content.caveats
+            ),
+            "limitations": _merge_unique_strings(content.limitations, LLM_LIMITATIONS),
+        }
+    )
+
+
+def _build_deterministic_response(
+    snapshot: SimulationSnapshot,
+    *,
+    include_fallback_caveat: bool,
+) -> SimulationSummaryResponse:
+    base = build_simulation_summary(
+        snapshot,
+        include_fallback_caveat=include_fallback_caveat,
+    )
+    return base.model_copy(
+        update={
+            "generation_mode": "deterministic",
+            "generation_provider": None,
+            "generation_model": None,
+        }
+    )
+
+
+def _resolve_llm_config() -> AssistantLLMConfig:
+    provider = settings.assistant_llm_provider
+    if provider == "openai":
+        if (
+            settings.assistant_openai_api_key is None
+            or not settings.assistant_openai_model
+        ):
+            raise ValueError("openai_misconfigured")
+        return AssistantLLMConfig(
+            provider="openai",
+            model_name=settings.assistant_openai_model,
+            api_key=settings.assistant_openai_api_key,
+            timeout_seconds=settings.assistant_llm_timeout_seconds,
+            temperature=settings.assistant_llm_temperature,
+            max_tokens=settings.assistant_llm_max_tokens,
+        )
+
+    if provider == "anthropic":
+        if (
+            settings.assistant_anthropic_api_key is None
+            or not settings.assistant_anthropic_model
+        ):
+            raise ValueError("anthropic_misconfigured")
+        return AssistantLLMConfig(
+            provider="anthropic",
+            model_name=settings.assistant_anthropic_model,
+            api_key=settings.assistant_anthropic_api_key,
+            timeout_seconds=settings.assistant_llm_timeout_seconds,
+            temperature=settings.assistant_llm_temperature,
+            max_tokens=settings.assistant_llm_max_tokens,
+        )
+
+    if provider == "livai":
+        if (
+            settings.assistant_livai_api_key is None
+            or not settings.assistant_livai_model
+            or not settings.assistant_livai_base_url
+        ):
+            raise ValueError("livai_misconfigured")
+        return AssistantLLMConfig(
+            provider="livai",
+            model_name=settings.assistant_livai_model,
+            api_key=settings.assistant_livai_api_key,
+            timeout_seconds=settings.assistant_llm_timeout_seconds,
+            temperature=settings.assistant_llm_temperature,
+            max_tokens=settings.assistant_llm_max_tokens,
+            base_url=settings.assistant_livai_base_url,
+        )
+
+    raise ValueError("unsupported_provider")
+
+
+def _configured_model_name(provider: SummaryGenerationProvider) -> str | None:
+    if provider == "openai":
+        return settings.assistant_openai_model
+    if provider == "anthropic":
+        return settings.assistant_anthropic_model
+    return settings.assistant_livai_model
+
+
+async def generate_simulation_summary(
+    simulation: Simulation,
+) -> SummaryGenerationResult:
+    attempted_provider: SummaryGenerationProvider | None = None
+    attempted_model: str | None = None
+
+    if settings.assistant_llm_enabled:
+        attempted_provider = settings.assistant_llm_provider
+        attempted_model = _configured_model_name(settings.assistant_llm_provider)
+
+    try:
+        snapshot = build_simulation_snapshot(simulation)
+    except SnapshotBudgetExceededError as exc:
+        return SummaryGenerationResult(
+            summary=_build_deterministic_response(
+                exc.snapshot,
+                include_fallback_caveat=settings.assistant_llm_enabled,
+            ),
+            fallback_reason=str(exc)
+            if settings.assistant_llm_enabled
+            else "llm_disabled",
+            llm_latency_ms=0.0,
+            attempted_provider=attempted_provider,
+            attempted_model=attempted_model,
+        )
+
+    if not settings.assistant_llm_enabled:
+        return SummaryGenerationResult(
+            summary=_build_deterministic_response(
+                snapshot,
+                include_fallback_caveat=False,
+            ),
+            fallback_reason="llm_disabled",
+            llm_latency_ms=0.0,
+            attempted_provider=None,
+            attempted_model=None,
+        )
+
+    try:
+        config = _resolve_llm_config()
+        attempted_provider = config.provider
+        attempted_model = config.model_name
+        generator = SummaryLLMGenerator(config)
+    except ValueError as exc:
+        return SummaryGenerationResult(
+            summary=_build_deterministic_response(
+                snapshot,
+                include_fallback_caveat=True,
+            ),
+            fallback_reason=str(exc),
+            llm_latency_ms=0.0,
+            attempted_provider=attempted_provider,
+            attempted_model=attempted_model,
+        )
+
+    start = perf_counter()
+    try:
+        llm_content = await generator.generate(snapshot)
+        validated = _validate_llm_content(llm_content, snapshot)
+        response = SimulationSummaryResponse(
+            **validated.model_dump(),
+            generation_mode="llm",
+            generation_provider=config.provider,
+            generation_model=config.model_name,
+            trace_id="00000000-0000-0000-0000-000000000000",
+        )
+        return SummaryGenerationResult(
+            summary=response,
+            fallback_reason=None,
+            llm_latency_ms=(perf_counter() - start) * 1000,
+            attempted_provider=config.provider,
+            attempted_model=config.model_name,
+        )
+    except (ValidationError, ValueError) as exc:
+        fallback_reason = getattr(exc, "args", ["llm_validation_failed"])[0]
+    except Exception as exc:  # pragma: no cover - exercised via patched tests
+        fallback_reason = exc.__class__.__name__
+
+    return SummaryGenerationResult(
+        summary=_build_deterministic_response(
+            snapshot,
+            include_fallback_caveat=True,
+        ),
+        fallback_reason=str(fallback_reason),
+        llm_latency_ms=(perf_counter() - start) * 1000,
+        attempted_provider=config.provider,
+        attempted_model=config.model_name,
+    )
+
+
+def snapshot_has_citation_path(snapshot: SimulationSnapshot, path: str) -> bool:
+    accessor = _SNAPSHOT_PATH_ACCESSORS.get(path)
+    if accessor is not None:
+        return bool(accessor(snapshot))
+    if path.startswith("artifacts[kind="):
+        kind = path[len("artifacts[kind=") : -1]
+        return any(item.kind == kind for item in snapshot.artifacts)
+    if path.startswith("links[kind="):
+        kind = path[len("links[kind=") : -1]
+        return any(item.kind == kind for item in snapshot.links)
+    return False

--- a/backend/app/features/assistant/registry.py
+++ b/backend/app/features/assistant/registry.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal
+
+CitationSource = Literal[
+    "simulation_field",
+    "case_field",
+    "machine_field",
+    "artifact",
+    "external_link",
+]
+
+
+@dataclass(frozen=True)
+class CitationRegistryEntry:
+    source_type: CitationSource
+    label: str
+
+
+_CITATION_REGISTRY = {
+    "simulation.id": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Simulation ID",
+    ),
+    "simulation.execution_id": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Execution ID",
+    ),
+    "simulation.description": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Description",
+    ),
+    "simulation.compset": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Compset",
+    ),
+    "simulation.compset_alias": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Compset alias",
+    ),
+    "simulation.grid_name": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Grid name",
+    ),
+    "simulation.grid_resolution": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Grid resolution",
+    ),
+    "simulation.simulation_type": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Simulation type",
+    ),
+    "simulation.status": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Simulation status",
+    ),
+    "simulation.campaign": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Campaign",
+    ),
+    "simulation.experiment_type": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Experiment type",
+    ),
+    "simulation.initialization_type": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Initialization type",
+    ),
+    "simulation.simulation_start_date": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Simulation start date",
+    ),
+    "simulation.simulation_end_date": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Simulation end date",
+    ),
+    "simulation.run_start_date": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Run start date",
+    ),
+    "simulation.run_end_date": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Run end date",
+    ),
+    "simulation.compiler": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Compiler",
+    ),
+    "simulation.key_features": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Key features",
+    ),
+    "simulation.known_issues": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Known issues",
+    ),
+    "simulation.notes_markdown": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Notes",
+    ),
+    "simulation.git_repository_url": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Git repository URL",
+    ),
+    "simulation.git_branch": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Git branch",
+    ),
+    "simulation.git_tag": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Git tag",
+    ),
+    "simulation.git_commit_hash": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Git commit hash",
+    ),
+    "simulation.extra": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Extra metadata",
+    ),
+    "simulation.run_config_deltas": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Configuration deltas",
+    ),
+    "case.name": CitationRegistryEntry(
+        source_type="case_field",
+        label="Case name",
+    ),
+    "case.case_group": CitationRegistryEntry(
+        source_type="case_field",
+        label="Case group",
+    ),
+    "case.reference_simulation_id": CitationRegistryEntry(
+        source_type="case_field",
+        label="Reference simulation",
+    ),
+    "machine.name": CitationRegistryEntry(
+        source_type="machine_field",
+        label="Machine name",
+    ),
+    "artifacts[kind=output]": CitationRegistryEntry(
+        source_type="artifact",
+        label="Output artifacts",
+    ),
+    "artifacts[kind=archive]": CitationRegistryEntry(
+        source_type="artifact",
+        label="Archive artifacts",
+    ),
+    "artifacts[kind=run_script]": CitationRegistryEntry(
+        source_type="artifact",
+        label="Run script artifacts",
+    ),
+    "artifacts[kind=postprocessing_script]": CitationRegistryEntry(
+        source_type="artifact",
+        label="Postprocessing script artifacts",
+    ),
+    "links[kind=diagnostic]": CitationRegistryEntry(
+        source_type="external_link",
+        label="Diagnostic links",
+    ),
+    "links[kind=performance]": CitationRegistryEntry(
+        source_type="external_link",
+        label="Performance links",
+    ),
+    "links[kind=docs]": CitationRegistryEntry(
+        source_type="external_link",
+        label="Documentation links",
+    ),
+    "links[kind=other]": CitationRegistryEntry(
+        source_type="external_link",
+        label="Other links",
+    ),
+}
+
+CITATION_REGISTRY = MappingProxyType(_CITATION_REGISTRY)
+VALID_CITATION_PATHS = frozenset(CITATION_REGISTRY)
+
+
+def get_citation_entry(path: str) -> CitationRegistryEntry:
+    return CITATION_REGISTRY[path]

--- a/backend/app/features/assistant/schemas.py
+++ b/backend/app/features/assistant/schemas.py
@@ -1,0 +1,73 @@
+from typing import Literal
+from uuid import UUID
+
+from pydantic import Field
+
+from app.common.schemas.base import CamelOutBaseModel
+
+
+class SummaryCitationOut(CamelOutBaseModel):
+    """Metadata citation for a simulation summary."""
+
+    source_type: Literal[
+        "simulation_field",
+        "case_field",
+        "machine_field",
+        "artifact",
+        "external_link",
+    ] = Field(..., description="Kind of SimBoard record referenced by the summary.")
+    path: str = Field(
+        ...,
+        description="Stable field path or related-record selector used by the summary.",
+    )
+    label: str = Field(..., description="Human-readable label for the cited source.")
+
+
+SummaryGenerationMode = Literal["llm", "deterministic"]
+SummaryGenerationProvider = Literal["openai", "anthropic", "livai"]
+
+
+class SimulationSummaryContent(CamelOutBaseModel):
+    """Structured simulation summary content."""
+
+    answer: str = Field(
+        ..., description="Metadata-grounded summary prose for the simulation."
+    )
+    citations: list[SummaryCitationOut] = Field(
+        default_factory=list,
+        description="Metadata citations backing claims in the answer.",
+    )
+    assumptions: list[str] = Field(
+        default_factory=list,
+        description="Explicit assumptions used by the formatter.",
+    )
+    caveats: list[str] = Field(
+        default_factory=list,
+        description="Missing-data or weak-signal warnings for the summary.",
+    )
+    limitations: list[str] = Field(
+        default_factory=list,
+        description="Known limits of this deterministic summary implementation.",
+    )
+    suggested_followups: list[str] = Field(
+        default_factory=list,
+        description="Non-agentic follow-up checks derived from available metadata.",
+    )
+
+
+class SimulationSummaryResponse(SimulationSummaryContent):
+    """Structured response returned by the simulation summary endpoint."""
+
+    generation_mode: SummaryGenerationMode = Field(
+        ...,
+        description="Whether the summary came from the LLM path or deterministic fallback.",
+    )
+    generation_provider: SummaryGenerationProvider | None = Field(
+        ...,
+        description="Provider name when LLM generation succeeds; otherwise null.",
+    )
+    generation_model: str | None = Field(
+        ...,
+        description="Configured provider model when LLM generation succeeds; otherwise null.",
+    )
+    trace_id: UUID = Field(..., description="Trace ID for request review and logs.")

--- a/backend/app/features/assistant/schemas.py
+++ b/backend/app/features/assistant/schemas.py
@@ -24,7 +24,7 @@ class SummaryCitationOut(CamelOutBaseModel):
 
 
 SummaryGenerationMode = Literal["llm", "deterministic"]
-SummaryGenerationProvider = Literal["openai", "anthropic", "livai"]
+SummaryGenerationProvider = Literal["livai", "ollama"]
 
 
 class SimulationSummaryContent(CamelOutBaseModel):
@@ -61,6 +61,10 @@ class SimulationSummaryResponse(SimulationSummaryContent):
     generation_mode: SummaryGenerationMode = Field(
         ...,
         description="Whether the summary came from the LLM path or deterministic fallback.",
+    )
+    fallback_used: bool = Field(
+        default=False,
+        description="Whether this summary came from an attempted LLM generation that fell back to deterministic output.",
     )
     generation_provider: SummaryGenerationProvider | None = Field(
         ...,

--- a/backend/app/features/assistant/service.py
+++ b/backend/app/features/assistant/service.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from app.features.assistant.registry import get_citation_entry
+from app.features.assistant.schemas import (
+    SimulationSummaryResponse,
+    SummaryCitationOut,
+)
+from app.features.assistant.snapshot import (
+    SimulationSnapshot,
+    build_simulation_snapshot,
+)
+
+DETERMINISTIC_LIMITATIONS = [
+    "This summary uses only metadata already stored in SimBoard. It does not use retrieval, diagnostics interpretation, or LLM reasoning."
+]
+LLM_LIMITATIONS = [
+    "This summary is grounded only in metadata already stored in SimBoard. It does not use retrieval or scientific interpretation beyond the provided metadata."
+]
+LLM_FALLBACK_CAVEAT = "This summary was generated using the deterministic fallback because the LLM path was unavailable."
+
+
+class SummaryDraft:
+    """Mutable collector used while assembling deterministic summary output."""
+
+    def __init__(self) -> None:
+        self.sentences: list[str] = []
+        self.caveats: list[str] = []
+        self.followups: list[str] = []
+        self.citations: OrderedDict[str, SummaryCitationOut] = OrderedDict()
+
+    def add_citation(self, path: str) -> None:
+        entry = get_citation_entry(path)
+        self.citations[path] = SummaryCitationOut(
+            source_type=entry.source_type,
+            path=path,
+            label=entry.label,
+        )
+
+
+def _add_identity_and_status(
+    snapshot: SimulationSnapshot,
+    draft: SummaryDraft,
+) -> None:
+    change_count = (
+        len(snapshot.simulation.run_config_deltas)
+        if snapshot.simulation.run_config_deltas
+        else 0
+    )
+
+    draft.add_citation("simulation.execution_id")
+    draft.add_citation("case.name")
+    draft.sentences.append(
+        f"Simulation {snapshot.simulation.execution_id} belongs to case {snapshot.case.name}."
+    )
+
+    type_bits = [snapshot.simulation.simulation_type]
+    if snapshot.case.reference_simulation_id:
+        draft.add_citation("case.reference_simulation_id")
+
+    if (
+        snapshot.case.reference_simulation_id
+        and snapshot.case.reference_simulation_id == snapshot.simulation.id
+    ):
+        type_bits.append("reference")
+    else:
+        type_bits.append("non-reference")
+        if snapshot.simulation.run_config_deltas:
+            draft.sentences.append(
+                f"It is a non-reference run with {change_count} recorded "
+                "configuration change(s) versus the case reference simulation."
+            )
+            draft.add_citation("simulation.run_config_deltas")
+        else:
+            draft.sentences.append(
+                "It is a non-reference run, but SimBoard does not currently record "
+                "any configuration deltas for it."
+            )
+            draft.caveats.append(
+                "This non-reference simulation has no recorded configuration deltas in SimBoard metadata."
+            )
+
+    if snapshot.machine and snapshot.machine.name:
+        draft.sentences.append(
+            f"It is recorded as a {' '.join(type_bits)} simulation on machine "
+            f"{snapshot.machine.name} with status {snapshot.simulation.status}."
+        )
+        draft.add_citation("machine.name")
+    else:
+        draft.sentences.append(
+            f"It is recorded as a {' '.join(type_bits)} simulation with status "
+            f"{snapshot.simulation.status}."
+        )
+        draft.caveats.append("Machine information is not recorded for this simulation.")
+
+    draft.add_citation("simulation.simulation_type")
+    draft.add_citation("simulation.status")
+
+
+def _add_configuration(snapshot: SimulationSnapshot, draft: SummaryDraft) -> None:
+    draft.sentences.append(
+        f"It uses compset {snapshot.simulation.compset} ({snapshot.simulation.compset_alias}) "
+        f"on grid {snapshot.simulation.grid_name} at {snapshot.simulation.grid_resolution} "
+        f"resolution with {snapshot.simulation.initialization_type} initialization."
+    )
+    draft.add_citation("simulation.compset")
+    draft.add_citation("simulation.compset_alias")
+    draft.add_citation("simulation.grid_name")
+    draft.add_citation("simulation.grid_resolution")
+    draft.add_citation("simulation.initialization_type")
+
+
+def _add_version_metadata(snapshot: SimulationSnapshot, draft: SummaryDraft) -> None:
+    version_bits: list[str] = []
+    if snapshot.simulation.git_tag:
+        version_bits.append(f"tag {snapshot.simulation.git_tag}")
+        draft.add_citation("simulation.git_tag")
+    if snapshot.simulation.git_branch:
+        version_bits.append(f"branch {snapshot.simulation.git_branch}")
+        draft.add_citation("simulation.git_branch")
+    if snapshot.simulation.git_commit_hash:
+        version_bits.append(f"commit {snapshot.simulation.git_commit_hash}")
+        draft.add_citation("simulation.git_commit_hash")
+
+    if version_bits:
+        draft.sentences.append(
+            "Recorded version metadata includes " + ", ".join(version_bits) + "."
+        )
+    else:
+        draft.caveats.append("Version metadata is not recorded for this simulation.")
+
+
+def _add_timeline_metadata(snapshot: SimulationSnapshot, draft: SummaryDraft) -> None:
+    start_date = snapshot.simulation.simulation_start_date
+    end_date = snapshot.simulation.simulation_end_date
+
+    if start_date and end_date:
+        draft.sentences.append(
+            f"The recorded simulation period runs from {start_date[:10]} to {end_date[:10]}."
+        )
+        draft.add_citation("simulation.simulation_start_date")
+        draft.add_citation("simulation.simulation_end_date")
+        return
+
+    if start_date:
+        draft.sentences.append(
+            f"The recorded simulation period starts on {start_date[:10]}, and no end "
+            "date is stored in SimBoard metadata."
+        )
+        draft.add_citation("simulation.simulation_start_date")
+        draft.caveats.append(
+            "Simulation end date is not recorded in SimBoard metadata."
+        )
+        return
+
+    draft.caveats.append("Simulation start date is not recorded in SimBoard metadata.")
+
+
+def _add_optional_metadata(snapshot: SimulationSnapshot, draft: SummaryDraft) -> None:
+    if snapshot.simulation.campaign:
+        draft.sentences.append(
+            f"Campaign metadata identifies this run as {snapshot.simulation.campaign}."
+        )
+        draft.add_citation("simulation.campaign")
+    else:
+        draft.caveats.append("Campaign metadata is not recorded for this simulation.")
+
+    if snapshot.simulation.experiment_type:
+        draft.sentences.append(
+            f"Experiment type metadata records {snapshot.simulation.experiment_type}."
+        )
+        draft.add_citation("simulation.experiment_type")
+    else:
+        draft.caveats.append(
+            "Experiment type metadata is not recorded for this simulation."
+        )
+
+    if snapshot.simulation.description:
+        draft.sentences.append(
+            f"Recorded description: {snapshot.simulation.description.strip()}"
+        )
+        draft.add_citation("simulation.description")
+    if snapshot.simulation.key_features:
+        draft.sentences.append(
+            f"Key features: {snapshot.simulation.key_features.strip()}"
+        )
+        draft.add_citation("simulation.key_features")
+    if snapshot.simulation.known_issues:
+        draft.sentences.append(
+            f"Known issues: {snapshot.simulation.known_issues.strip()}"
+        )
+        draft.add_citation("simulation.known_issues")
+    if snapshot.simulation.notes_markdown:
+        draft.sentences.append("Additional notes are recorded for this simulation.")
+        draft.add_citation("simulation.notes_markdown")
+
+
+def _add_diagnostics_and_followups(
+    snapshot: SimulationSnapshot,
+    draft: SummaryDraft,
+) -> None:
+    diagnostic_links = [link for link in snapshot.links if link.kind == "diagnostic"]
+    if diagnostic_links:
+        draft.sentences.append(
+            f"SimBoard records {len(diagnostic_links)} diagnostic link(s) for this "
+            "run, but this summary does not interpret diagnostic outputs."
+        )
+        draft.add_citation("links[kind=diagnostic]")
+        draft.followups.append(
+            "Open the recorded diagnostic links to review supporting context for this run."
+        )
+    else:
+        draft.caveats.append(
+            "No diagnostic links are recorded for this simulation in SimBoard."
+        )
+
+    if snapshot.simulation.run_config_deltas:
+        draft.followups.append(
+            "Compare this run against the case reference simulation to review the recorded configuration deltas."
+        )
+
+    if snapshot.simulation.known_issues:
+        draft.followups.append(
+            "Review the recorded known issues before using this simulation as a baseline."
+        )
+
+    output_artifacts = [
+        artifact for artifact in snapshot.artifacts if artifact.kind == "output"
+    ]
+    if output_artifacts:
+        draft.add_citation("artifacts[kind=output]")
+        draft.followups.append(
+            "Open the recorded output artifacts if you need run outputs beyond the metadata summary."
+        )
+
+    if not draft.followups:
+        draft.followups.append(
+            "Review the simulation detail page metadata for additional provenance and run context."
+        )
+
+
+def build_simulation_summary(
+    simulation_or_snapshot,
+    *,
+    include_fallback_caveat: bool = False,
+) -> SimulationSummaryResponse:
+    """Build a deterministic summary from authoritative SimBoard metadata."""
+
+    snapshot = (
+        simulation_or_snapshot
+        if isinstance(simulation_or_snapshot, SimulationSnapshot)
+        else build_simulation_snapshot(simulation_or_snapshot)
+    )
+    draft = SummaryDraft()
+    draft.caveats.extend(snapshot.snapshot_caveats)
+    _add_identity_and_status(snapshot, draft)
+    _add_configuration(snapshot, draft)
+    _add_version_metadata(snapshot, draft)
+    _add_timeline_metadata(snapshot, draft)
+    _add_optional_metadata(snapshot, draft)
+    _add_diagnostics_and_followups(snapshot, draft)
+
+    if include_fallback_caveat and LLM_FALLBACK_CAVEAT not in draft.caveats:
+        draft.caveats.append(LLM_FALLBACK_CAVEAT)
+
+    return SimulationSummaryResponse(
+        answer=" ".join(draft.sentences),
+        citations=list(draft.citations.values()),
+        assumptions=[],
+        caveats=draft.caveats,
+        limitations=DETERMINISTIC_LIMITATIONS,
+        suggested_followups=draft.followups,
+        generation_mode="deterministic",
+        generation_provider=None,
+        generation_model=None,
+        trace_id="00000000-0000-0000-0000-000000000000",
+    )

--- a/backend/app/features/assistant/service.py
+++ b/backend/app/features/assistant/service.py
@@ -272,6 +272,7 @@ def build_simulation_summary(
         limitations=DETERMINISTIC_LIMITATIONS,
         suggested_followups=draft.followups,
         generation_mode="deterministic",
+        fallback_used=False,
         generation_provider=None,
         generation_model=None,
         trace_id="00000000-0000-0000-0000-000000000000",

--- a/backend/app/features/assistant/snapshot.py
+++ b/backend/app/features/assistant/snapshot.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.core.config import settings
+from app.features.simulation.models import Artifact, ExternalLink, Simulation
+
+SNAPSHOT_TRUNCATED_CAVEAT = (
+    "The metadata snapshot was truncated to fit the assistant size budget. "
+    "Some artifacts, links, or long text fields were omitted."
+)
+
+
+def _enum_value(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, Enum):
+        return value.value
+    return str(value)
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.isoformat()
+
+
+class SnapshotArtifact(BaseModel):
+    kind: str
+    uri: str
+    label: str | None = None
+
+
+class SnapshotLink(BaseModel):
+    kind: str
+    url: str
+    label: str | None = None
+
+
+class SnapshotSimulationFields(BaseModel):
+    id: str
+    execution_id: str
+    description: str | None = None
+    compset: str
+    compset_alias: str
+    grid_name: str
+    grid_resolution: str
+    simulation_type: str
+    status: str
+    campaign: str | None = None
+    experiment_type: str | None = None
+    initialization_type: str
+    simulation_start_date: str | None = None
+    simulation_end_date: str | None = None
+    run_start_date: str | None = None
+    run_end_date: str | None = None
+    compiler: str | None = None
+    key_features: str | None = None
+    known_issues: str | None = None
+    notes_markdown: str | None = None
+    git_repository_url: str | None = None
+    git_branch: str | None = None
+    git_tag: str | None = None
+    git_commit_hash: str | None = None
+    extra: dict[str, Any] = Field(default_factory=dict)
+    run_config_deltas: dict[str, Any] | None = None
+
+
+class SnapshotCaseFields(BaseModel):
+    name: str
+    case_group: str | None = None
+    reference_simulation_id: str | None = None
+
+
+class SnapshotMachineFields(BaseModel):
+    name: str
+
+
+class SimulationSnapshot(BaseModel):
+    simulation: SnapshotSimulationFields
+    case: SnapshotCaseFields
+    machine: SnapshotMachineFields | None = None
+    artifacts: list[SnapshotArtifact] = Field(default_factory=list)
+    links: list[SnapshotLink] = Field(default_factory=list)
+    snapshot_caveats: list[str] = Field(default_factory=list)
+
+
+class SnapshotBudgetExceededError(ValueError):
+    def __init__(self, snapshot: SimulationSnapshot, max_chars: int) -> None:
+        size = _snapshot_size(snapshot)
+        super().__init__(
+            f"Snapshot size {size} exceeds budget {max_chars} even after all "
+            "trimming. Required fields are too large to fit within the configured "
+            "limit."
+        )
+        self.snapshot = snapshot
+        self.max_chars = max_chars
+
+
+@dataclass(frozen=True)
+class _SnapshotSizeBudget:
+    max_chars: int
+
+
+def _sorted_artifacts(items: Iterable[Artifact]) -> list[SnapshotArtifact]:
+    return sorted(
+        [
+            SnapshotArtifact(
+                kind=_enum_value(item.kind) or "unknown",
+                uri=item.uri,
+                label=item.label,
+            )
+            for item in items
+        ],
+        key=lambda item: (item.kind, item.label or "", item.uri),
+    )
+
+
+def _sorted_links(items: Iterable[ExternalLink]) -> list[SnapshotLink]:
+    return sorted(
+        [
+            SnapshotLink(
+                kind=_enum_value(item.kind) or "unknown",
+                url=item.url,
+                label=item.label,
+            )
+            for item in items
+        ],
+        key=lambda item: (item.kind, item.label or "", item.url),
+    )
+
+
+def _snapshot_size(snapshot: SimulationSnapshot) -> int:
+    return len(snapshot.model_dump_json(exclude_none=True))
+
+
+def _add_truncation_caveat(snapshot: SimulationSnapshot) -> SimulationSnapshot:
+    if SNAPSHOT_TRUNCATED_CAVEAT in snapshot.snapshot_caveats:
+        return snapshot
+    return snapshot.model_copy(
+        update={
+            "snapshot_caveats": [*snapshot.snapshot_caveats, SNAPSHOT_TRUNCATED_CAVEAT]
+        }
+    )
+
+
+def _trim_snapshot_strings(snapshot: SimulationSnapshot) -> SimulationSnapshot:
+    simulation = snapshot.simulation.model_copy(
+        update={
+            "notes_markdown": None,
+            "description": None,
+            "key_features": None,
+            "known_issues": None,
+            "extra": {},
+            "run_config_deltas": None,
+        }
+    )
+    return snapshot.model_copy(update={"simulation": simulation})
+
+
+def _apply_size_budget(
+    snapshot: SimulationSnapshot,
+    budget: _SnapshotSizeBudget,
+) -> SimulationSnapshot:
+    if _snapshot_size(snapshot) <= budget.max_chars:
+        return snapshot
+
+    trimmed = snapshot.model_copy(deep=True)
+
+    while _snapshot_size(trimmed) > budget.max_chars and (
+        trimmed.artifacts or trimmed.links
+    ):
+        if len(trimmed.artifacts) >= len(trimmed.links) and trimmed.artifacts:
+            trimmed = trimmed.model_copy(update={"artifacts": trimmed.artifacts[:-1]})
+        elif trimmed.links:
+            trimmed = trimmed.model_copy(update={"links": trimmed.links[:-1]})
+
+    if _snapshot_size(trimmed) > budget.max_chars:
+        trimmed = _trim_snapshot_strings(trimmed)
+
+    if _snapshot_size(trimmed) > budget.max_chars and trimmed.artifacts:
+        trimmed = trimmed.model_copy(update={"artifacts": []})
+
+    if _snapshot_size(trimmed) > budget.max_chars and trimmed.links:
+        trimmed = trimmed.model_copy(update={"links": []})
+
+    trimmed = _add_truncation_caveat(trimmed)
+
+    if _snapshot_size(trimmed) > budget.max_chars:
+        raise SnapshotBudgetExceededError(trimmed, budget.max_chars)
+
+    return trimmed
+
+
+def build_simulation_snapshot(
+    simulation: Simulation,
+    *,
+    max_chars: int | None = None,
+) -> SimulationSnapshot:
+    snapshot = SimulationSnapshot(
+        simulation=SnapshotSimulationFields(
+            id=str(simulation.id),
+            execution_id=simulation.execution_id,
+            description=simulation.description,
+            compset=simulation.compset,
+            compset_alias=simulation.compset_alias,
+            grid_name=simulation.grid_name,
+            grid_resolution=simulation.grid_resolution,
+            simulation_type=_enum_value(simulation.simulation_type) or "unknown",
+            status=_enum_value(simulation.status) or "unknown",
+            campaign=simulation.campaign,
+            experiment_type=simulation.experiment_type,
+            initialization_type=simulation.initialization_type,
+            simulation_start_date=_isoformat(simulation.simulation_start_date),
+            simulation_end_date=_isoformat(simulation.simulation_end_date),
+            run_start_date=_isoformat(simulation.run_start_date),
+            run_end_date=_isoformat(simulation.run_end_date),
+            compiler=simulation.compiler,
+            key_features=simulation.key_features,
+            known_issues=simulation.known_issues,
+            notes_markdown=simulation.notes_markdown,
+            git_repository_url=simulation.git_repository_url,
+            git_branch=simulation.git_branch,
+            git_tag=simulation.git_tag,
+            git_commit_hash=simulation.git_commit_hash,
+            extra=dict(simulation.extra or {}),
+            run_config_deltas=simulation.run_config_deltas,
+        ),
+        case=SnapshotCaseFields(
+            name=simulation.case.name,
+            case_group=simulation.case.case_group,
+            reference_simulation_id=(
+                str(simulation.case.reference_simulation_id)
+                if simulation.case.reference_simulation_id
+                else None
+            ),
+        ),
+        machine=(
+            SnapshotMachineFields(name=simulation.machine.name)
+            if simulation.machine is not None
+            else None
+        ),
+        artifacts=_sorted_artifacts(simulation.artifacts),
+        links=_sorted_links(simulation.links),
+        snapshot_caveats=[],
+    )
+
+    size_budget = _SnapshotSizeBudget(
+        max_chars=max_chars or settings.assistant_snapshot_max_chars
+    )
+    return _apply_size_budget(snapshot, size_budget)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from app.api.version import API_BASE
 from app.core.config import settings
 from app.core.exceptions import register_exception_handlers
 from app.core.logger import _setup_root_logger
+from app.features.assistant.api import router as assistant_router
 from app.features.ingestion.api import router as ingestion_router
 from app.features.machine.api import router as machine_router
 from app.features.pace.api import router as pace_router
@@ -35,6 +36,7 @@ def create_app() -> FastAPI:
 
     # Register routers.
     app.include_router(simulation_router, prefix=API_BASE)
+    app.include_router(assistant_router, prefix=API_BASE)
     app.include_router(case_router, prefix=API_BASE)
     app.include_router(machine_router, prefix=API_BASE)
     app.include_router(pace_router, prefix=API_BASE)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "pydantic-settings>=2.4.0",
   "python-dotenv>=1.0.1",
   "python-dateutil>=2.8.2,<3.0.0",
-  "pydantic-ai-slim[anthropic,openai]>=1.0.0,<2.0.0",
+  "pydantic-ai-slim[openai]>=1.0.0,<2.0.0",
 
   # --- Authentication / Authorization ---
   "fastapi-users[sqlalchemy,oauth]>=14.0.0,<15.0.0",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "pydantic-settings>=2.4.0",
   "python-dotenv>=1.0.1",
   "python-dateutil>=2.8.2,<3.0.0",
+  "pydantic-ai-slim[anthropic,openai]>=1.0.0,<2.0.0",
 
   # --- Authentication / Authorization ---
   "fastapi-users[sqlalchemy,oauth]>=14.0.0,<15.0.0",

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -166,6 +166,61 @@ class TestSettings:
         assert configured.assistant_livai_api_key is not None
         assert configured.assistant_livai_api_key.get_secret_value() == "livai-key"
 
+    def test_assistant_llm_provider_defaults_to_ollama(self):
+        configured = Settings(
+            _env_file=None,
+            FRONTEND_ORIGIN="http://localhost:3000",
+            FRONTEND_AUTH_REDIRECT_URL="http://localhost:3000/auth/callback",
+            FRONTEND_ORIGINS="http://localhost:3000",
+            database_url="postgresql+psycopg://user:password@localhost/simboard",
+            test_database_url="postgresql+psycopg://user:password@localhost/simboard_test",
+            github_client_id="github-client-id",
+            github_client_secret="github-client-secret",
+            github_redirect_url="http://localhost:8000/auth/github/callback",
+            github_state_secret_key="state-secret",
+        )
+
+        assert configured.assistant_llm_provider == "ollama"
+
+    def test_assistant_ollama_env_names_are_canonical_and_strip_whitespace(self):
+        configured = Settings(
+            _env_file=None,
+            FRONTEND_ORIGIN="http://localhost:3000",
+            FRONTEND_AUTH_REDIRECT_URL="http://localhost:3000/auth/callback",
+            FRONTEND_ORIGINS="http://localhost:3000",
+            database_url="postgresql+psycopg://user:password@localhost/simboard",
+            test_database_url="postgresql+psycopg://user:password@localhost/simboard_test",
+            github_client_id="github-client-id",
+            github_client_secret="github-client-secret",
+            github_redirect_url="http://localhost:8000/auth/github/callback",
+            github_state_secret_key="state-secret",
+            assistant_ollama_base_url=" http://localhost:11434/  ",
+            assistant_ollama_api_key="ollama-key",
+            assistant_ollama_model="gemma4:26b",
+        )
+
+        assert configured.assistant_ollama_base_url == "http://localhost:11434"
+        assert configured.assistant_ollama_model == "gemma4:26b"
+        assert configured.assistant_ollama_api_key is not None
+        assert configured.assistant_ollama_api_key.get_secret_value() == "ollama-key"
+
+    def test_assistant_ollama_model_accepts_arbitrary_string(self):
+        configured = Settings(
+            _env_file=None,
+            FRONTEND_ORIGIN="http://localhost:3000",
+            FRONTEND_AUTH_REDIRECT_URL="http://localhost:3000/auth/callback",
+            FRONTEND_ORIGINS="http://localhost:3000",
+            database_url="postgresql+psycopg://user:password@localhost/simboard",
+            test_database_url="postgresql+psycopg://user:password@localhost/simboard_test",
+            github_client_id="github-client-id",
+            github_client_secret="github-client-secret",
+            github_redirect_url="http://localhost:8000/auth/github/callback",
+            github_state_secret_key="state-secret",
+            assistant_ollama_model="gemma4:26b-q4_K_M",
+        )
+
+        assert configured.assistant_ollama_model == "gemma4:26b-q4_K_M"
+
     def test_assistant_llm_tuning_env_values_load_from_settings(self):
         configured = Settings(
             _env_file=None,

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from app.core.config import get_env_file, settings
+from app.core.config import Settings, get_env_file, settings
 
 
 class TestGetEnvFile:
@@ -145,3 +145,42 @@ class TestSettings:
             "https://example1.com",
             "https://example2.com",
         ]
+
+    def test_assistant_livai_env_names_are_canonical_and_strip_whitespace(self):
+        configured = Settings(
+            _env_file=None,
+            FRONTEND_ORIGIN="http://localhost:3000",
+            FRONTEND_AUTH_REDIRECT_URL="http://localhost:3000/auth/callback",
+            FRONTEND_ORIGINS="http://localhost:3000",
+            database_url="postgresql+psycopg://user:password@localhost/simboard",
+            test_database_url="postgresql+psycopg://user:password@localhost/simboard_test",
+            github_client_id="github-client-id",
+            github_client_secret="github-client-secret",
+            github_redirect_url="http://localhost:8000/auth/github/callback",
+            github_state_secret_key="state-secret",
+            assistant_livai_base_url=" https://livai-api.llnl.gov/  ",
+            assistant_livai_api_key="livai-key",
+        )
+
+        assert configured.assistant_livai_base_url == "https://livai-api.llnl.gov/"
+        assert configured.assistant_livai_api_key is not None
+        assert configured.assistant_livai_api_key.get_secret_value() == "livai-key"
+
+    def test_assistant_llm_tuning_env_values_load_from_settings(self):
+        configured = Settings(
+            _env_file=None,
+            FRONTEND_ORIGIN="http://localhost:3000",
+            FRONTEND_AUTH_REDIRECT_URL="http://localhost:3000/auth/callback",
+            FRONTEND_ORIGINS="http://localhost:3000",
+            database_url="postgresql+psycopopg://user:password@localhost/simboard",
+            test_database_url="postgresql+psycopg://user:password@localhost/simboard_test",
+            github_client_id="github-client-id",
+            github_client_secret="github-client-secret",
+            github_redirect_url="http://localhost:8000/auth/github/callback",
+            github_state_secret_key="state-secret",
+            ASSISTANT_LLM_TEMPERATURE="0.2",
+            ASSISTANT_LLM_MAX_TOKENS="2048",
+        )
+
+        assert configured.assistant_llm_temperature == 0.2
+        assert configured.assistant_llm_max_tokens == 2048

--- a/backend/tests/features/assistant/__init__.py
+++ b/backend/tests/features/assistant/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for assistant feature."""

--- a/backend/tests/features/assistant/test_api.py
+++ b/backend/tests/features/assistant/test_api.py
@@ -1,0 +1,287 @@
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.version import API_BASE
+from app.core.config import settings
+from app.features.assistant import api as assistant_api
+from app.features.assistant.schemas import SimulationSummaryResponse
+from app.features.ingestion.enums import IngestionSourceType, IngestionStatus
+from app.features.ingestion.models import Ingestion
+from app.features.machine.models import Machine
+from app.features.simulation.models import Case, Simulation
+from app.features.user.manager import current_active_user
+from app.features.user.models import User, UserRole
+from app.main import app
+
+
+@pytest.fixture
+def authenticated_client(async_client: AsyncClient, normal_user):
+    def fake_current_user():
+        return User(
+            id=UUID(normal_user["id"]),
+            email=normal_user["email"],
+            is_active=True,
+            is_verified=True,
+            role=UserRole.USER,
+        )
+
+    app.dependency_overrides[current_active_user] = fake_current_user
+    return async_client
+
+
+async def _create_case(db: AsyncSession, name: str = "assistant_api_case") -> Case:
+    case = Case(name=name)
+    db.add(case)
+    await db.flush()
+    return case
+
+
+async def _create_simulation(
+    db: AsyncSession,
+    normal_user: dict[str, str],
+    admin_user: dict[str, str],
+    *,
+    execution_id: str = "assistant-api-exec-1",
+) -> Simulation:
+    machine = (await db.execute(select(Machine))).scalars().first()
+    assert machine is not None
+
+    case = await _create_case(db)
+    ingestion = Ingestion(
+        source_type=IngestionSourceType.BROWSER_UPLOAD,
+        source_reference=execution_id,
+        machine_id=machine.id,
+        triggered_by=UUID(normal_user["id"]),
+        status=IngestionStatus.SUCCESS,
+        created_count=1,
+        duplicate_count=0,
+        error_count=0,
+    )
+    db.add(ingestion)
+    await db.flush()
+
+    simulation = Simulation(
+        case_id=case.id,
+        execution_id=execution_id,
+        compset="AQUAPLANET",
+        compset_alias="QPC4",
+        grid_name="f19_f19",
+        grid_resolution="1.9x2.5",
+        simulation_type="experimental",
+        status="completed",
+        initialization_type="startup",
+        machine_id=machine.id,
+        simulation_start_date="2023-01-01T00:00:00Z",
+        git_tag="v2.0.0",
+        created_by=UUID(normal_user["id"]),
+        last_updated_by=UUID(admin_user["id"]),
+        ingestion_id=ingestion.id,
+    )
+    db.add(simulation)
+    await db.flush()
+    case.reference_simulation_id = simulation.id
+    await db.commit()
+    await db.refresh(simulation)
+    return simulation
+
+
+class TestSummarizeSimulationEndpoint:
+    @pytest.fixture(autouse=True)
+    def _force_deterministic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "assistant_llm_enabled", False)
+
+    @pytest.mark.asyncio
+    async def test_authenticated_request_returns_summary_contract(
+        self,
+        authenticated_client: AsyncClient,
+        async_db: AsyncSession,
+        normal_user,
+        admin_user,
+    ) -> None:
+        simulation = await _create_simulation(
+            async_db,
+            normal_user,
+            admin_user,
+        )
+
+        response = await authenticated_client.post(
+            f"{API_BASE}/simulations/{simulation.id}/summary"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert (
+            "Simulation assistant-api-exec-1 belongs to case assistant_api_case."
+            in data["answer"]
+        )
+        assert isinstance(data["citations"], list)
+        assert data["assumptions"] == []
+        assert isinstance(data["caveats"], list)
+        assert data["limitations"] == [
+            "This summary uses only metadata already stored in SimBoard. It does not use retrieval, diagnostics interpretation, or LLM reasoning."
+        ]
+        assert isinstance(data["suggestedFollowups"], list)
+        assert UUID(data["traceId"])
+        assert {citation["path"] for citation in data["citations"]} >= {
+            "simulation.execution_id",
+            "case.name",
+        }
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_request_returns_401(
+        self,
+        async_client: AsyncClient,
+        async_db: AsyncSession,
+        normal_user,
+        admin_user,
+    ) -> None:
+        simulation = await _create_simulation(
+            async_db,
+            normal_user,
+            admin_user,
+        )
+
+        response = await async_client.post(
+            f"{API_BASE}/simulations/{simulation.id}/summary"
+        )
+
+        assert response.status_code == 401
+        assert response.json() == {"detail": "Not authenticated"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_simulation_returns_404(
+        self, authenticated_client: AsyncClient
+    ) -> None:
+        response = await authenticated_client.post(
+            f"{API_BASE}/simulations/{uuid4()}/summary"
+        )
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Simulation not found"}
+
+
+class _FakeScalarResult:
+    def __init__(self, simulation) -> None:
+        self._simulation = simulation
+
+    def unique(self):
+        return self
+
+    def one_or_none(self):
+        return self._simulation
+
+
+class _FakeExecuteResult:
+    def __init__(self, simulation) -> None:
+        self._simulation = simulation
+
+    def scalars(self):
+        return _FakeScalarResult(self._simulation)
+
+
+class _FakeAsyncSession:
+    def __init__(self, simulation) -> None:
+        self._simulation = simulation
+
+    async def execute(self, stmt):
+        self.statement = stmt
+        return _FakeExecuteResult(self._simulation)
+
+
+class TestSummarizeSimulationUnit:
+    @pytest.mark.asyncio
+    async def test_summarize_simulation_returns_generation_summary(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sim_id = uuid4()
+        trace_id = uuid4()
+        user = User(
+            id=uuid4(),
+            email="user@example.com",
+            is_active=True,
+            is_verified=True,
+            role=UserRole.USER,
+        )
+        db = _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})())
+        summary = SimulationSummaryResponse(
+            answer="Deterministic assistant summary.",
+            citations=[],
+            assumptions=[],
+            caveats=[],
+            limitations=["limit"],
+            suggested_followups=["follow up"],
+            generation_mode="deterministic",
+            generation_provider=None,
+            generation_model=None,
+            trace_id=uuid4(),
+        )
+        logged: list[tuple[str, tuple[object, ...]]] = []
+
+        async def fake_generate(simulation):
+            assert simulation.id == sim_id
+            return type(
+                "GenerationResult",
+                (),
+                {
+                    "summary": summary,
+                    "fallback_reason": None,
+                    "llm_latency_ms": 12.5,
+                    "attempted_provider": "livai",
+                    "attempted_model": "livai-model",
+                },
+            )()
+
+        monkeypatch.setattr(assistant_api, "generate_simulation_summary", fake_generate)
+        monkeypatch.setattr(assistant_api, "uuid4", lambda: trace_id)
+        monkeypatch.setattr(
+            assistant_api.logger,
+            "info",
+            lambda message, *args: logged.append((message, args)),
+        )
+
+        response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)  # type: ignore[arg-type]
+
+        assert response.answer == "Deterministic assistant summary."
+        assert response.trace_id == trace_id
+        assert logged
+        assert "success=true" in logged[0][0]
+        assert logged[0][1][0] == trace_id
+        assert logged[0][1][1] == sim_id
+        assert logged[0][1][2] == user.id
+
+    @pytest.mark.asyncio
+    async def test_summarize_simulation_raises_404_for_missing_simulation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sim_id = uuid4()
+        trace_id = uuid4()
+        user = User(
+            id=uuid4(),
+            email="user@example.com",
+            is_active=True,
+            is_verified=True,
+            role=UserRole.USER,
+        )
+        db = _FakeAsyncSession(None)
+        logged: list[tuple[str, tuple[object, ...]]] = []
+
+        monkeypatch.setattr(assistant_api, "uuid4", lambda: trace_id)
+        monkeypatch.setattr(
+            assistant_api.logger,
+            "info",
+            lambda message, *args: logged.append((message, args)),
+        )
+
+        with pytest.raises(assistant_api.HTTPException) as exc_info:
+            await assistant_api.summarize_simulation(sim_id, db=db, user=user)  # type: ignore[arg-type]
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Simulation not found"
+        assert logged
+        assert "status=not_found" in logged[0][0]
+        assert logged[0][1][0] == trace_id
+        assert logged[0][1][1] == sim_id

--- a/backend/tests/features/assistant/test_api.py
+++ b/backend/tests/features/assistant/test_api.py
@@ -1,3 +1,4 @@
+from typing import cast
 from uuid import UUID, uuid4
 
 import pytest
@@ -207,7 +208,10 @@ class TestSummarizeSimulationUnit:
             is_verified=True,
             role=UserRole.USER,
         )
-        db = _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})())
+        db = cast(
+            AsyncSession,
+            _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})()),
+        )
         summary = SimulationSummaryResponse(
             answer="Deterministic assistant summary.",
             citations=[],
@@ -272,7 +276,10 @@ class TestSummarizeSimulationUnit:
             is_verified=True,
             role=UserRole.USER,
         )
-        db = _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})())
+        db = cast(
+            AsyncSession,
+            _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})()),
+        )
         summary = SimulationSummaryResponse(
             answer="Deterministic fallback summary.",
             citations=[],
@@ -334,7 +341,10 @@ class TestSummarizeSimulationUnit:
             is_verified=True,
             role=UserRole.USER,
         )
-        db = _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})())
+        db = cast(
+            AsyncSession,
+            _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})()),
+        )
         summary = SimulationSummaryResponse(
             answer="LLM assistant summary.",
             citations=[],
@@ -397,7 +407,7 @@ class TestSummarizeSimulationUnit:
             is_verified=True,
             role=UserRole.USER,
         )
-        db = _FakeAsyncSession(None)
+        db = cast(AsyncSession, _FakeAsyncSession(None))
         logged: list[tuple[str, tuple[object, ...]]] = []
 
         monkeypatch.setattr(assistant_api, "uuid4", lambda: trace_id)

--- a/backend/tests/features/assistant/test_api.py
+++ b/backend/tests/features/assistant/test_api.py
@@ -126,6 +126,7 @@ class TestSummarizeSimulationEndpoint:
         ]
         assert isinstance(data["suggestedFollowups"], list)
         assert UUID(data["traceId"])
+        assert data["fallbackUsed"] is False
         assert {citation["path"] for citation in data["citations"]} >= {
             "simulation.execution_id",
             "case.name",
@@ -243,15 +244,145 @@ class TestSummarizeSimulationUnit:
             lambda message, *args: logged.append((message, args)),
         )
 
-        response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)  # type: ignore[arg-type]
+        response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)
 
         assert response.answer == "Deterministic assistant summary."
+        assert response.fallback_used is False
         assert response.trace_id == trace_id
         assert logged
         assert "success=true" in logged[0][0]
+        assert "llm_success=%s" in logged[0][0]
+        assert "fallback_used=%s" in logged[0][0]
         assert logged[0][1][0] == trace_id
         assert logged[0][1][1] == sim_id
         assert logged[0][1][2] == user.id
+        assert logged[0][1][3] == "false"
+        assert logged[0][1][4] == "false"
+
+    @pytest.mark.asyncio
+    async def test_summarize_simulation_logs_true_fallback_when_llm_attempt_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sim_id = uuid4()
+        trace_id = uuid4()
+        user = User(
+            id=uuid4(),
+            email="user@example.com",
+            is_active=True,
+            is_verified=True,
+            role=UserRole.USER,
+        )
+        db = _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})())
+        summary = SimulationSummaryResponse(
+            answer="Deterministic fallback summary.",
+            citations=[],
+            assumptions=[],
+            caveats=[],
+            limitations=["limit"],
+            suggested_followups=["follow up"],
+            generation_mode="deterministic",
+            generation_provider=None,
+            generation_model=None,
+            trace_id=uuid4(),
+        )
+        logged: list[tuple[str, tuple[object, ...]]] = []
+
+        async def fake_generate(simulation):
+            assert simulation.id == sim_id
+            return type(
+                "GenerationResult",
+                (),
+                {
+                    "summary": summary,
+                    "fallback_reason": "ModelHTTPError",
+                    "llm_latency_ms": 12.5,
+                    "attempted_provider": "ollama",
+                    "attempted_model": "gemma4:3b",
+                },
+            )()
+
+        monkeypatch.setattr(assistant_api, "generate_simulation_summary", fake_generate)
+        monkeypatch.setattr(assistant_api, "uuid4", lambda: trace_id)
+        monkeypatch.setattr(
+            assistant_api.logger,
+            "info",
+            lambda message, *args: logged.append((message, args)),
+        )
+
+        response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)
+
+        assert response.answer == "Deterministic fallback summary."
+        assert response.fallback_used is True
+        assert response.trace_id == trace_id
+        assert logged
+        assert "success=true" in logged[0][0]
+        assert "llm_success=%s" in logged[0][0]
+        assert "fallback_used=%s" in logged[0][0]
+        assert logged[0][1][3] == "false"
+        assert logged[0][1][4] == "true"
+
+    @pytest.mark.asyncio
+    async def test_summarize_simulation_returns_ollama_generation_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sim_id = uuid4()
+        trace_id = uuid4()
+        user = User(
+            id=uuid4(),
+            email="user@example.com",
+            is_active=True,
+            is_verified=True,
+            role=UserRole.USER,
+        )
+        db = _FakeAsyncSession(type("SimulationStub", (), {"id": sim_id})())
+        summary = SimulationSummaryResponse(
+            answer="LLM assistant summary.",
+            citations=[],
+            assumptions=[],
+            caveats=[],
+            limitations=["limit"],
+            suggested_followups=["follow up"],
+            generation_mode="llm",
+            generation_provider="ollama",
+            generation_model="gemma4:26b",
+            trace_id=uuid4(),
+        )
+        logged: list[tuple[str, tuple[object, ...]]] = []
+
+        async def fake_generate(simulation):
+            assert simulation.id == sim_id
+            return type(
+                "GenerationResult",
+                (),
+                {
+                    "summary": summary,
+                    "fallback_reason": None,
+                    "llm_latency_ms": 9.0,
+                    "attempted_provider": "ollama",
+                    "attempted_model": "gemma4:26b",
+                },
+            )()
+
+        monkeypatch.setattr(assistant_api, "generate_simulation_summary", fake_generate)
+        monkeypatch.setattr(assistant_api, "uuid4", lambda: trace_id)
+        monkeypatch.setattr(
+            assistant_api.logger,
+            "info",
+            lambda message, *args: logged.append((message, args)),
+        )
+
+        response = await assistant_api.summarize_simulation(sim_id, db=db, user=user)
+
+        assert response.generation_mode == "llm"
+        assert response.fallback_used is False
+        assert response.generation_provider == "ollama"
+        assert response.generation_model == "gemma4:26b"
+        assert response.trace_id == trace_id
+        assert logged
+        assert "llm_success=%s" in logged[0][0]
+        assert "fallback_used=%s" in logged[0][0]
+        assert logged[0][1][3] == "true"
+        assert logged[0][1][4] == "false"
 
     @pytest.mark.asyncio
     async def test_summarize_simulation_raises_404_for_missing_simulation(
@@ -277,11 +408,13 @@ class TestSummarizeSimulationUnit:
         )
 
         with pytest.raises(assistant_api.HTTPException) as exc_info:
-            await assistant_api.summarize_simulation(sim_id, db=db, user=user)  # type: ignore[arg-type]
+            await assistant_api.summarize_simulation(sim_id, db=db, user=user)
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Simulation not found"
         assert logged
         assert "status=not_found" in logged[0][0]
+        assert "llm_success=false" in logged[0][0]
+        assert "fallback_used=false" in logged[0][0]
         assert logged[0][1][0] == trace_id
         assert logged[0][1][1] == sim_id

--- a/backend/tests/features/assistant/test_llm_generator.py
+++ b/backend/tests/features/assistant/test_llm_generator.py
@@ -1,0 +1,187 @@
+from types import SimpleNamespace
+
+import pytest
+from httpx import AsyncClient
+from pydantic import SecretStr
+
+from app.features.assistant import llm_generator
+from app.features.assistant.llm_generator import AssistantLLMConfig, SummaryLLMGenerator
+from app.features.assistant.schemas import SimulationSummaryContent, SummaryCitationOut
+from app.features.assistant.snapshot import (
+    SimulationSnapshot,
+    SnapshotCaseFields,
+    SnapshotSimulationFields,
+)
+
+
+def _make_snapshot() -> SimulationSnapshot:
+    return SimulationSnapshot(
+        simulation=SnapshotSimulationFields(
+            id="simulation-1",
+            execution_id="assistant-llm-exec",
+            compset="AQUAPLANET",
+            compset_alias="QPC4",
+            grid_name="f19_f19",
+            grid_resolution="1.9x2.5",
+            simulation_type="experimental",
+            status="completed",
+            initialization_type="startup",
+        ),
+        case=SnapshotCaseFields(name="assistant_case"),
+    )
+
+
+class TestSummaryLLMGenerator:
+    @pytest.mark.asyncio
+    async def test_build_model_uses_livai_base_url_for_openai_compatible_provider(
+        self,
+    ):
+        config = AssistantLLMConfig(
+            provider="livai",
+            model_name="livai-model",
+            api_key=SecretStr("livai-key"),
+            timeout_seconds=30.0,
+            temperature=0.2,
+            max_tokens=2048,
+            base_url="https://example.livai.test/v1",
+        )
+
+        async with AsyncClient() as http_client:
+            model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
+
+        assert str(model.client.base_url) == "https://example.livai.test/v1/"
+
+    @pytest.mark.asyncio
+    async def test_build_model_uses_anthropic_provider(self) -> None:
+        config = AssistantLLMConfig(
+            provider="anthropic",
+            model_name="claude-test",
+            api_key=SecretStr("anthropic-key"),
+            timeout_seconds=30.0,
+            temperature=0.2,
+            max_tokens=2048,
+        )
+
+        async with AsyncClient() as http_client:
+            model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
+
+        assert model.__class__.__name__ == "AnthropicModel"
+
+    def test_build_model_settings_omits_temperature_for_livai_gpt5(self) -> None:
+        config = AssistantLLMConfig(
+            provider="livai",
+            model_name="gpt-5.4-mini",
+            api_key=SecretStr("livai-key"),
+            timeout_seconds=30.0,
+            temperature=0.2,
+            max_tokens=2048,
+            base_url="https://example.livai.test/v1",
+        )
+
+        assert SummaryLLMGenerator(config)._build_model_settings() == {
+            "max_tokens": 2048,
+        }
+
+    def test_build_model_settings_keeps_tuning_for_non_gpt5_livai(self) -> None:
+        config = AssistantLLMConfig(
+            provider="livai",
+            model_name="gpt-4.1-mini",
+            api_key=SecretStr("livai-key"),
+            timeout_seconds=30.0,
+            temperature=0.2,
+            max_tokens=2048,
+            base_url="https://example.livai.test/v1",
+        )
+
+        assert SummaryLLMGenerator(config)._build_model_settings() == {
+            "temperature": 0.2,
+            "max_tokens": 2048,
+        }
+
+    def test_build_model_settings_includes_tuning_for_openai(self) -> None:
+        config = AssistantLLMConfig(
+            provider="openai",
+            model_name="gpt-test",
+            api_key=SecretStr("openai-key"),
+            timeout_seconds=30.0,
+            temperature=0.2,
+            max_tokens=2048,
+        )
+
+        assert SummaryLLMGenerator(config)._build_model_settings() == {
+            "temperature": 0.2,
+            "max_tokens": 2048,
+        }
+
+    def test_build_user_prompt_includes_snapshot_and_allowed_citations(self) -> None:
+        prompt = SummaryLLMGenerator(
+            AssistantLLMConfig(
+                provider="openai",
+                model_name="gpt-test",
+                api_key=SecretStr("openai-key"),
+                timeout_seconds=30.0,
+                temperature=0.2,
+                max_tokens=2048,
+            )
+        )._build_user_prompt(_make_snapshot())
+
+        assert "assistant-llm-exec" in prompt
+        assert "simulation.execution_id (simulation_field)" in prompt
+        assert "case.name (case_field)" in prompt
+
+    @pytest.mark.asyncio
+    async def test_generate_returns_agent_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        expected = SimulationSummaryContent(
+            answer="Generated summary.",
+            citations=[
+                SummaryCitationOut(
+                    source_type="simulation_field",
+                    path="simulation.execution_id",
+                    label="Execution ID",
+                )
+            ],
+            assumptions=[],
+            caveats=[],
+            limitations=["limit"],
+            suggested_followups=["follow up"],
+        )
+        captured: dict[str, object] = {}
+
+        class FakeAgent:
+            def __init__(
+                self, model, output_type, system_prompt, model_settings=None
+            ) -> None:
+                captured["model"] = model
+                captured["output_type"] = output_type
+                captured["system_prompt"] = system_prompt
+                captured["model_settings"] = model_settings
+
+            async def run(self, prompt: str):
+                captured["prompt"] = prompt
+                return SimpleNamespace(output=expected)
+
+        monkeypatch.setattr(llm_generator, "Agent", FakeAgent)
+
+        generator = SummaryLLMGenerator(
+            AssistantLLMConfig(
+                provider="openai",
+                model_name="gpt-test",
+                api_key=SecretStr("openai-key"),
+                timeout_seconds=30.0,
+                temperature=0.2,
+                max_tokens=2048,
+            )
+        )
+
+        result = await generator.generate(_make_snapshot())
+
+        assert result == expected
+        assert captured["output_type"] is SimulationSummaryContent
+        assert captured["system_prompt"] == llm_generator.SUMMARY_SYSTEM_PROMPT
+        assert captured["model_settings"] == {
+            "temperature": 0.2,
+            "max_tokens": 2048,
+        }
+        assert "Allowed citation paths:" in str(captured["prompt"])

--- a/backend/tests/features/assistant/test_llm_generator.py
+++ b/backend/tests/features/assistant/test_llm_generator.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 from httpx import AsyncClient
 from pydantic import SecretStr
+from pydantic_ai.output import PromptedOutput
 
 from app.features.assistant import llm_generator
 from app.features.assistant.llm_generator import AssistantLLMConfig, SummaryLLMGenerator
@@ -52,20 +53,57 @@ class TestSummaryLLMGenerator:
         assert str(model.client.base_url) == "https://example.livai.test/v1/"
 
     @pytest.mark.asyncio
-    async def test_build_model_uses_anthropic_provider(self) -> None:
+    async def test_build_model_normalizes_ollama_root_url_to_v1(self) -> None:
         config = AssistantLLMConfig(
-            provider="anthropic",
-            model_name="claude-test",
-            api_key=SecretStr("anthropic-key"),
+            provider="ollama",
+            model_name="gemma4:26b",
+            api_key=None,
             timeout_seconds=30.0,
             temperature=0.2,
             max_tokens=2048,
+            base_url="http://localhost:11434",
         )
 
         async with AsyncClient() as http_client:
             model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
 
-        assert model.__class__.__name__ == "AnthropicModel"
+        assert str(model.client.base_url) == "http://localhost:11434/v1/"
+        assert model.client.api_key == "api-key-not-set"
+
+    @pytest.mark.asyncio
+    async def test_build_model_preserves_explicit_ollama_v1_base_url(self) -> None:
+        config = AssistantLLMConfig(
+            provider="ollama",
+            model_name="gemma4:e4b",
+            api_key=SecretStr("ollama-key"),
+            timeout_seconds=30.0,
+            temperature=0.2,
+            max_tokens=2048,
+            base_url="http://localhost:11434/v1",
+        )
+
+        async with AsyncClient() as http_client:
+            model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
+
+        assert str(model.client.base_url) == "http://localhost:11434/v1/"
+        assert model.client.max_retries == 0
+
+    @pytest.mark.asyncio
+    async def test_build_model_keeps_default_retries_for_livai(self) -> None:
+        config = AssistantLLMConfig(
+            provider="livai",
+            model_name="livai-model",
+            api_key=SecretStr("livai-key"),
+            timeout_seconds=30.0,
+            temperature=0.2,
+            max_tokens=2048,
+            base_url="https://example.livai.test/v1",
+        )
+
+        async with AsyncClient() as http_client:
+            model = SummaryLLMGenerator(config)._build_model(http_client=http_client)
+
+        assert model.client.max_retries == 2
 
     def test_build_model_settings_omits_temperature_for_livai_gpt5(self) -> None:
         config = AssistantLLMConfig(
@@ -98,14 +136,15 @@ class TestSummaryLLMGenerator:
             "max_tokens": 2048,
         }
 
-    def test_build_model_settings_includes_tuning_for_openai(self) -> None:
+    def test_build_model_settings_includes_tuning_for_ollama(self) -> None:
         config = AssistantLLMConfig(
-            provider="openai",
-            model_name="gpt-test",
-            api_key=SecretStr("openai-key"),
+            provider="ollama",
+            model_name="gemma4:26b",
+            api_key=None,
             timeout_seconds=30.0,
             temperature=0.2,
             max_tokens=2048,
+            base_url="http://localhost:11434",
         )
 
         assert SummaryLLMGenerator(config)._build_model_settings() == {
@@ -116,18 +155,72 @@ class TestSummaryLLMGenerator:
     def test_build_user_prompt_includes_snapshot_and_allowed_citations(self) -> None:
         prompt = SummaryLLMGenerator(
             AssistantLLMConfig(
-                provider="openai",
-                model_name="gpt-test",
-                api_key=SecretStr("openai-key"),
+                provider="livai",
+                model_name="livai-model",
+                api_key=SecretStr("livai-key"),
                 timeout_seconds=30.0,
                 temperature=0.2,
                 max_tokens=2048,
+                base_url="https://example.livai.test/v1",
             )
         )._build_user_prompt(_make_snapshot())
 
         assert "assistant-llm-exec" in prompt
         assert "simulation.execution_id (simulation_field)" in prompt
         assert "case.name (case_field)" in prompt
+
+    def test_summary_system_prompt_enforces_short_natural_answer_shape(self) -> None:
+        assert (
+            "Keep `answer` to 2-4 short sentences"
+            in llm_generator.SUMMARY_SYSTEM_PROMPT
+        )
+        assert (
+            "Do not enumerate every available field."
+            in llm_generator.SUMMARY_SYSTEM_PROMPT
+        )
+        assert "Do not repeat raw citation paths" in llm_generator.SUMMARY_SYSTEM_PROMPT
+        assert (
+            "Every `citations.path` value must exactly match one allowed path string."
+            in (llm_generator.SUMMARY_SYSTEM_PROMPT)
+        )
+        assert (
+            "use `simulation.status`, `case.name`, and `machine.name`, not `status` or `name`."
+            in llm_generator.SUMMARY_SYSTEM_PROMPT
+        )
+        assert "`suggested_followups` must contain at least one concrete item." in (
+            llm_generator.SUMMARY_SYSTEM_PROMPT
+        )
+
+    def test_build_output_type_uses_prompted_output_for_ollama(self) -> None:
+        output_type = SummaryLLMGenerator(
+            AssistantLLMConfig(
+                provider="ollama",
+                model_name="gemma4:e4b",
+                api_key=None,
+                timeout_seconds=30.0,
+                temperature=0.2,
+                max_tokens=2048,
+                base_url="http://localhost:11434",
+            )
+        )._build_output_type()
+
+        assert isinstance(output_type, PromptedOutput)
+        assert output_type.outputs is SimulationSummaryContent
+
+    def test_build_output_type_keeps_native_type_for_livai(self) -> None:
+        output_type = SummaryLLMGenerator(
+            AssistantLLMConfig(
+                provider="livai",
+                model_name="livai-model",
+                api_key=SecretStr("livai-key"),
+                timeout_seconds=30.0,
+                temperature=0.2,
+                max_tokens=2048,
+                base_url="https://example.livai.test/v1",
+            )
+        )._build_output_type()
+
+        assert output_type is SimulationSummaryContent
 
     @pytest.mark.asyncio
     async def test_generate_returns_agent_output(
@@ -166,12 +259,13 @@ class TestSummaryLLMGenerator:
 
         generator = SummaryLLMGenerator(
             AssistantLLMConfig(
-                provider="openai",
-                model_name="gpt-test",
-                api_key=SecretStr("openai-key"),
+                provider="livai",
+                model_name="livai-model",
+                api_key=SecretStr("livai-key"),
                 timeout_seconds=30.0,
                 temperature=0.2,
                 max_tokens=2048,
+                base_url="https://example.livai.test/v1",
             )
         )
 
@@ -185,3 +279,55 @@ class TestSummaryLLMGenerator:
             "max_tokens": 2048,
         }
         assert "Allowed citation paths:" in str(captured["prompt"])
+
+    @pytest.mark.asyncio
+    async def test_generate_uses_prompted_output_for_ollama(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        expected = SimulationSummaryContent(
+            answer="Generated summary.",
+            citations=[
+                SummaryCitationOut(
+                    source_type="simulation_field",
+                    path="simulation.execution_id",
+                    label="Execution ID",
+                )
+            ],
+            assumptions=[],
+            caveats=[],
+            limitations=["limit"],
+            suggested_followups=["follow up"],
+        )
+        captured: dict[str, object] = {}
+
+        class FakeAgent:
+            def __init__(
+                self, model, output_type, system_prompt, model_settings=None
+            ) -> None:
+                captured["model"] = model
+                captured["output_type"] = output_type
+                captured["system_prompt"] = system_prompt
+                captured["model_settings"] = model_settings
+
+            async def run(self, prompt: str):
+                captured["prompt"] = prompt
+                return SimpleNamespace(output=expected)
+
+        monkeypatch.setattr(llm_generator, "Agent", FakeAgent)
+
+        generator = SummaryLLMGenerator(
+            AssistantLLMConfig(
+                provider="ollama",
+                model_name="gemma4:e4b",
+                api_key=None,
+                timeout_seconds=30.0,
+                temperature=0.2,
+                max_tokens=2048,
+                base_url="http://localhost:11434",
+            )
+        )
+
+        result = await generator.generate(_make_snapshot())
+
+        assert result == expected
+        assert isinstance(captured["output_type"], PromptedOutput)

--- a/backend/tests/features/assistant/test_orchestrator.py
+++ b/backend/tests/features/assistant/test_orchestrator.py
@@ -2,10 +2,15 @@ from typing import cast
 
 import pytest
 from pydantic import SecretStr
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 
 from app.core.config import settings
 from app.features.assistant import orchestrator
-from app.features.assistant.schemas import SimulationSummaryContent, SummaryCitationOut
+from app.features.assistant.schemas import (
+    SimulationSummaryContent,
+    SummaryCitationOut,
+    SummaryGenerationProvider,
+)
 from app.features.assistant.service import LLM_FALLBACK_CAVEAT
 from app.features.assistant.snapshot import (
     SimulationSnapshot,
@@ -13,6 +18,7 @@ from app.features.assistant.snapshot import (
     SnapshotBudgetExceededError,
     SnapshotCaseFields,
     SnapshotLink,
+    SnapshotMachineFields,
     SnapshotSimulationFields,
 )
 from app.features.simulation.models import Simulation
@@ -89,27 +95,25 @@ def _set_livai_settings(
     monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
 
 
+def _set_ollama_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enabled: bool = True,
+    api_key: SecretStr | None = None,
+    model: str | None = "gemma4:26b",
+    base_url: str = "http://localhost:11434",
+) -> None:
+    monkeypatch.setattr(settings, "assistant_llm_enabled", enabled)
+    monkeypatch.setattr(settings, "assistant_llm_provider", "ollama")
+    monkeypatch.setattr(settings, "assistant_ollama_api_key", api_key)
+    monkeypatch.setattr(settings, "assistant_ollama_model", model)
+    monkeypatch.setattr(settings, "assistant_ollama_base_url", base_url)
+    monkeypatch.setattr(settings, "assistant_llm_timeout_seconds", 30.0)
+    monkeypatch.setattr(settings, "assistant_llm_temperature", 0.2)
+    monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
+
+
 class TestResolveLLMConfig:
-    def test_resolve_llm_config_for_openai_returns_expected_config(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(settings, "assistant_llm_provider", "openai")
-        monkeypatch.setattr(
-            settings, "assistant_openai_api_key", SecretStr("openai-key")
-        )
-        monkeypatch.setattr(settings, "assistant_openai_model", "gpt-test")
-        monkeypatch.setattr(settings, "assistant_llm_timeout_seconds", 20.0)
-        monkeypatch.setattr(settings, "assistant_llm_temperature", 0.2)
-        monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
-
-        config = orchestrator._resolve_llm_config()
-
-        assert config.provider == "openai"
-        assert config.model_name == "gpt-test"
-        assert config.api_key.get_secret_value() == "openai-key"
-        assert config.temperature == 0.2
-        assert config.max_tokens == 2048
-
     def test_resolve_llm_config_for_livai_uses_wrapper_key_and_base_url(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -119,47 +123,39 @@ class TestResolveLLMConfig:
 
         assert config.provider == "livai"
         assert config.model_name == "livai-model"
+        assert config.api_key is not None
         assert config.api_key.get_secret_value() == "livai-key"
         assert config.base_url == "https://api.livai.llnl.gov/v1"
 
-    def test_resolve_llm_config_for_anthropic_returns_expected_config(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize("model_name", ["gemma4:e4b", "gemma4:26b"])
+    def test_resolve_llm_config_for_ollama_uses_configured_model_and_base_url(
+        self, monkeypatch: pytest.MonkeyPatch, model_name: str
     ) -> None:
-        monkeypatch.setattr(settings, "assistant_llm_provider", "anthropic")
-        monkeypatch.setattr(
-            settings, "assistant_anthropic_api_key", SecretStr("anthropic-key")
-        )
-        monkeypatch.setattr(settings, "assistant_anthropic_model", "claude-test")
-        monkeypatch.setattr(settings, "assistant_llm_timeout_seconds", 15.0)
-        monkeypatch.setattr(settings, "assistant_llm_temperature", 0.2)
-        monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
+        _set_ollama_settings(monkeypatch, model=model_name)
 
         config = orchestrator._resolve_llm_config()
 
-        assert config.provider == "anthropic"
-        assert config.model_name == "claude-test"
-        assert config.api_key.get_secret_value() == "anthropic-key"
-        assert config.temperature == 0.2
-        assert config.max_tokens == 2048
+        assert config.provider == "ollama"
+        assert config.model_name == model_name
+        assert config.api_key is None
+        assert config.base_url == "http://localhost:11434"
 
-    def test_resolve_llm_config_rejects_openai_misconfiguration(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize(
+        ("model", "base_url"),
+        [
+            (None, "http://localhost:11434"),
+            ("gemma4:26b", ""),
+        ],
+    )
+    def test_resolve_llm_config_rejects_ollama_misconfiguration(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        model: str | None,
+        base_url: str,
     ) -> None:
-        monkeypatch.setattr(settings, "assistant_llm_provider", "openai")
-        monkeypatch.setattr(settings, "assistant_openai_api_key", None)
-        monkeypatch.setattr(settings, "assistant_openai_model", "gpt-test")
+        _set_ollama_settings(monkeypatch, model=model, base_url=base_url)
 
-        with pytest.raises(ValueError, match="openai_misconfigured"):
-            orchestrator._resolve_llm_config()
-
-    def test_resolve_llm_config_rejects_anthropic_misconfiguration(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(settings, "assistant_llm_provider", "anthropic")
-        monkeypatch.setattr(settings, "assistant_anthropic_api_key", None)
-        monkeypatch.setattr(settings, "assistant_anthropic_model", "claude-test")
-
-        with pytest.raises(ValueError, match="anthropic_misconfigured"):
+        with pytest.raises(ValueError, match="ollama_misconfigured"):
             orchestrator._resolve_llm_config()
 
     def test_resolve_llm_config_rejects_unsupported_provider(
@@ -173,32 +169,33 @@ class TestResolveLLMConfig:
     @pytest.mark.parametrize(
         ("provider", "expected"),
         [
-            ("openai", "gpt-test"),
-            ("anthropic", "claude-test"),
             ("livai", "livai-model"),
+            ("ollama", "gemma4:26b"),
         ],
     )
     def test_configured_model_name_uses_provider_setting(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        provider: str,
+        provider: SummaryGenerationProvider,
         expected: str,
     ) -> None:
-        from app.features.assistant.schemas import SummaryGenerationProvider
-
-        monkeypatch.setattr(settings, "assistant_openai_model", "gpt-test")
-        monkeypatch.setattr(settings, "assistant_anthropic_model", "claude-test")
         monkeypatch.setattr(settings, "assistant_livai_model", "livai-model")
+        monkeypatch.setattr(settings, "assistant_ollama_model", "gemma4:26b")
 
-        assert (
-            orchestrator._configured_model_name(
-                cast(SummaryGenerationProvider, provider)
-            )
-            == expected
-        )
+        assert orchestrator._configured_model_name(provider) == expected
 
 
 class TestValidationHelpers:
+    def test_normalize_llm_answer_strips_inline_citation_markers(self) -> None:
+        answer = (
+            "This simulation completed [simulation.status]. It ran on chrysalis "
+            "[machine.name] and used WCYCL20TR [simulation.compset]."
+        )
+
+        assert orchestrator._normalize_llm_answer(answer) == (
+            "This simulation completed. It ran on chrysalis and used WCYCL20TR."
+        )
+
     def test_standardize_citations_rejects_invalid_path(self) -> None:
         with pytest.raises(ValueError, match="invalid_citation_path:invalid.path"):
             orchestrator._standardize_citations(
@@ -211,6 +208,92 @@ class TestValidationHelpers:
                 ],
                 _make_snapshot(),
             )
+
+    def test_standardize_citations_canonicalizes_unambiguous_suffix_path(self) -> None:
+        result = orchestrator._standardize_citations(
+            [
+                SummaryCitationOut(
+                    source_type="simulation_field",
+                    path="status",
+                    label="Status",
+                )
+            ],
+            _make_snapshot(),
+        )
+
+        assert result == [
+            SummaryCitationOut(
+                source_type="simulation_field",
+                path="simulation.status",
+                label="Simulation status",
+            )
+        ]
+
+    def test_canonicalize_citation_path_uses_unique_suffix_without_source_type(
+        self,
+    ) -> None:
+        assert orchestrator._canonicalize_citation_path("status") == "simulation.status"
+
+    def test_standardize_citations_rejects_ambiguous_suffix_path(self) -> None:
+        with pytest.raises(ValueError, match="invalid_citation_path:name"):
+            orchestrator._standardize_citations(
+                [
+                    SummaryCitationOut(
+                        source_type="simulation_field",
+                        path="name",
+                        label="Name",
+                    )
+                ],
+                _make_snapshot(),
+            )
+
+    def test_standardize_citations_uses_source_type_to_disambiguate_suffix_path(
+        self,
+    ) -> None:
+        result = orchestrator._standardize_citations(
+            [
+                SummaryCitationOut(
+                    source_type="case_field",
+                    path="name",
+                    label="Name",
+                )
+            ],
+            _make_snapshot(),
+        )
+
+        assert result == [
+            SummaryCitationOut(
+                source_type="case_field",
+                path="case.name",
+                label="Case name",
+            )
+        ]
+
+    def test_standardize_citations_uses_source_type_for_machine_name_suffix_path(
+        self,
+    ) -> None:
+        snapshot = _make_snapshot().model_copy(
+            update={"machine": SnapshotMachineFields(name="perlmutter")}
+        )
+
+        result = orchestrator._standardize_citations(
+            [
+                SummaryCitationOut(
+                    source_type="machine_field",
+                    path="name",
+                    label="Name",
+                )
+            ],
+            snapshot,
+        )
+
+        assert result == [
+            SummaryCitationOut(
+                source_type="machine_field",
+                path="machine.name",
+                label="Machine name",
+            )
+        ]
 
     def test_standardize_citations_rejects_missing_snapshot_path(self) -> None:
         with pytest.raises(ValueError, match="missing_citation_path:machine.name"):
@@ -245,6 +328,33 @@ class TestValidationHelpers:
                 _make_snapshot(),
             )
 
+    def test_validate_llm_content_normalizes_inline_citation_markers(self) -> None:
+        result = orchestrator._validate_llm_content(
+            _make_llm_content(
+                answer=(
+                    "Simulation assistant-livai-exec belongs to case "
+                    "assistant_livai_case [case.name]."
+                )
+            ),
+            _make_snapshot(),
+        )
+
+        assert result.answer == (
+            "Simulation assistant-livai-exec belongs to case assistant_livai_case."
+        )
+
+    def test_fill_missing_llm_followups_uses_deterministic_followups(self) -> None:
+        snapshot = _make_snapshot()
+
+        result = orchestrator._fill_missing_llm_followups(
+            _make_llm_content(suggested_followups=[]),
+            snapshot,
+        )
+
+        assert result.suggested_followups == (
+            orchestrator.build_simulation_summary(snapshot).suggested_followups
+        )
+
     def test_snapshot_has_citation_path_supports_related_record_selectors(self) -> None:
         snapshot = _make_snapshot().model_copy(
             update={
@@ -255,14 +365,22 @@ class TestValidationHelpers:
             }
         )
 
-        assert orchestrator.snapshot_has_citation_path(
+        assert orchestrator._snapshot_has_citation_path(
             snapshot, "artifacts[kind=output]"
         )
-        assert orchestrator.snapshot_has_citation_path(
+        assert orchestrator._snapshot_has_citation_path(
             snapshot, "links[kind=diagnostic]"
         )
-        assert not orchestrator.snapshot_has_citation_path(snapshot, "links[kind=docs]")
-        assert not orchestrator.snapshot_has_citation_path(snapshot, "invalid.path")
+        assert not orchestrator._snapshot_has_citation_path(
+            snapshot, "links[kind=docs]"
+        )
+        assert not orchestrator._snapshot_has_citation_path(snapshot, "invalid.path")
+
+    def test_format_model_error_uses_exception_name_when_message_blank(self) -> None:
+        assert orchestrator._format_model_error(Exception()) == "Exception"
+
+    def test_trim_fallback_reason_adds_ellipsis_when_limit_exceeded(self) -> None:
+        assert orchestrator._trim_fallback_reason("abcdef", limit=5) == "ab..."
 
 
 class TestGenerateSimulationSummary:
@@ -282,6 +400,7 @@ class TestGenerateSimulationSummary:
 
         assert result.fallback_reason == "llm_disabled"
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is False
         assert result.attempted_provider is None
         assert result.attempted_model is None
 
@@ -334,6 +453,37 @@ class TestGenerateSimulationSummary:
         assert result.attempted_model == "livai-model"
 
     @pytest.mark.asyncio
+    async def test_generate_simulation_summary_returns_ollama_provider_on_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model="gemma4:26b")
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            return _make_llm_content()
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason is None
+        assert result.summary.generation_mode == "llm"
+        assert result.summary.fallback_used is False
+        assert result.summary.generation_provider == "ollama"
+        assert result.summary.generation_model == "gemma4:26b"
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model == "gemma4:26b"
+
+    @pytest.mark.asyncio
     async def test_generate_simulation_summary_falls_back_for_livai_misconfiguration(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -353,6 +503,29 @@ class TestGenerateSimulationSummary:
         assert result.summary.generation_model is None
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"
+        assert LLM_FALLBACK_CAVEAT in result.summary.caveats
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_falls_back_for_ollama_misconfiguration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model=None)
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == "ollama_misconfigured"
+        assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is True
+        assert result.summary.generation_provider is None
+        assert result.summary.generation_model is None
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model is None
         assert LLM_FALLBACK_CAVEAT in result.summary.caveats
 
     @pytest.mark.asyncio
@@ -376,6 +549,7 @@ class TestGenerateSimulationSummary:
         assert result.fallback_reason is not None
         assert result.fallback_reason.startswith("Snapshot size ")
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is True
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"
         assert LLM_FALLBACK_CAVEAT in result.summary.caveats
@@ -400,6 +574,7 @@ class TestGenerateSimulationSummary:
 
         assert result.fallback_reason == "llm_disabled"
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is False
         assert result.attempted_provider is None
         assert result.attempted_model is None
         assert LLM_FALLBACK_CAVEAT not in result.summary.caveats
@@ -429,9 +604,133 @@ class TestGenerateSimulationSummary:
 
         assert result.fallback_reason == "missing_limitations"
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is True
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"
         assert LLM_FALLBACK_CAVEAT in result.summary.caveats
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_keeps_llm_mode_when_followups_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_livai_settings(monkeypatch)
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            return _make_llm_content(suggested_followups=[])
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason is None
+        assert result.summary.generation_mode == "llm"
+        assert result.summary.generation_provider == "livai"
+        assert result.summary.generation_model == "livai-model"
+        assert result.summary.suggested_followups == (
+            orchestrator.build_simulation_summary(snapshot).suggested_followups
+        )
+        assert result.attempted_provider == "livai"
+        assert result.attempted_model == "livai-model"
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_canonicalizes_unambiguous_citation_alias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model="llama3.1:8b")
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            return _make_llm_content(
+                citations=[
+                    SummaryCitationOut(
+                        source_type="simulation_field",
+                        path="status",
+                        label="Status",
+                    )
+                ]
+            )
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason is None
+        assert result.summary.generation_mode == "llm"
+        assert result.summary.generation_provider == "ollama"
+        assert result.summary.generation_model == "llama3.1:8b"
+        assert result.summary.citations == [
+            SummaryCitationOut(
+                source_type="simulation_field",
+                path="simulation.status",
+                label="Simulation status",
+            )
+        ]
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model == "llama3.1:8b"
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_uses_source_type_to_fix_name_alias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model="llama3.1:8b")
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            return _make_llm_content(
+                citations=[
+                    SummaryCitationOut(
+                        source_type="case_field",
+                        path="name",
+                        label="Name",
+                    )
+                ]
+            )
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason is None
+        assert result.summary.generation_mode == "llm"
+        assert result.summary.generation_provider == "ollama"
+        assert result.summary.generation_model == "llama3.1:8b"
+        assert result.summary.citations == [
+            SummaryCitationOut(
+                source_type="case_field",
+                path="case.name",
+                label="Case name",
+            )
+        ]
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model == "llama3.1:8b"
 
     @pytest.mark.asyncio
     async def test_generate_simulation_summary_falls_back_on_unexpected_exception(
@@ -456,7 +755,70 @@ class TestGenerateSimulationSummary:
 
         result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
 
-        assert result.fallback_reason == "RuntimeError"
+        assert result.fallback_reason == "RuntimeError: boom"
         assert result.summary.generation_mode == "deterministic"
+        assert result.summary.fallback_used is True
         assert result.attempted_provider == "livai"
         assert result.attempted_model == "livai-model"
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_preserves_model_api_error_details(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model="gemma4:e4b")
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            raise ModelAPIError("gemma4:e4b", "unsupported value for tools")
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == ("ModelAPIError: unsupported value for tools")
+        assert result.summary.generation_mode == "deterministic"
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model == "gemma4:e4b"
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_preserves_model_http_error_details(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_ollama_settings(monkeypatch, model="gemma4:e4b")
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            raise ModelHTTPError(
+                400,
+                "gemma4:e4b",
+                {"error": {"message": "unknown field `tools`"}},
+            )
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == (
+            'ModelHTTPError: status_code=400; body={"error": {"message": "unknown field `tools`"}}'
+        )
+        assert result.summary.generation_mode == "deterministic"
+        assert result.attempted_provider == "ollama"
+        assert result.attempted_model == "gemma4:e4b"

--- a/backend/tests/features/assistant/test_orchestrator.py
+++ b/backend/tests/features/assistant/test_orchestrator.py
@@ -1,0 +1,462 @@
+from typing import cast
+
+import pytest
+from pydantic import SecretStr
+
+from app.core.config import settings
+from app.features.assistant import orchestrator
+from app.features.assistant.schemas import SimulationSummaryContent, SummaryCitationOut
+from app.features.assistant.service import LLM_FALLBACK_CAVEAT
+from app.features.assistant.snapshot import (
+    SimulationSnapshot,
+    SnapshotArtifact,
+    SnapshotBudgetExceededError,
+    SnapshotCaseFields,
+    SnapshotLink,
+    SnapshotSimulationFields,
+)
+from app.features.simulation.models import Simulation
+
+DEFAULT_LIVAI_API_KEY = SecretStr("livai-key")
+
+
+def _make_snapshot() -> SimulationSnapshot:
+    return SimulationSnapshot(
+        simulation=SnapshotSimulationFields(
+            id="simulation-1",
+            execution_id="assistant-livai-exec",
+            description="LivAI-backed simulation summary test.",
+            compset="AQUAPLANET",
+            compset_alias="QPC4",
+            grid_name="f19_f19",
+            grid_resolution="1.9x2.5",
+            simulation_type="experimental",
+            status="completed",
+            campaign="historical",
+            experiment_type="historical",
+            initialization_type="startup",
+            simulation_start_date="2023-01-01T00:00:00Z",
+            simulation_end_date="2023-12-31T00:00:00Z",
+            git_tag="v1.0.0",
+        ),
+        case=SnapshotCaseFields(
+            name="assistant_livai_case",
+            reference_simulation_id="simulation-1",
+        ),
+        snapshot_caveats=[],
+    )
+
+
+def _make_llm_content(**overrides) -> SimulationSummaryContent:
+    payload = {
+        "answer": "Simulation assistant-livai-exec belongs to case assistant_livai_case.",
+        "citations": [
+            SummaryCitationOut(
+                source_type="simulation_field",
+                path="simulation.execution_id",
+                label="Execution ID",
+            ),
+            SummaryCitationOut(
+                source_type="case_field",
+                path="case.name",
+                label="Case Name",
+            ),
+        ],
+        "assumptions": [],
+        "caveats": [],
+        "limitations": ["Custom LLM caveat."],
+        "suggested_followups": ["Review recorded artifacts."],
+    }
+    payload.update(overrides)
+    return SimulationSummaryContent(**payload)
+
+
+def _set_livai_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enabled: bool = True,
+    api_key: SecretStr | None = DEFAULT_LIVAI_API_KEY,
+    model: str | None = "livai-model",
+    base_url: str = "https://api.livai.llnl.gov/v1",
+) -> None:
+    monkeypatch.setattr(settings, "assistant_llm_enabled", enabled)
+    monkeypatch.setattr(settings, "assistant_llm_provider", "livai")
+    monkeypatch.setattr(settings, "assistant_livai_api_key", api_key)
+    monkeypatch.setattr(settings, "assistant_livai_model", model)
+    monkeypatch.setattr(settings, "assistant_livai_base_url", base_url)
+    monkeypatch.setattr(settings, "assistant_llm_timeout_seconds", 30.0)
+    monkeypatch.setattr(settings, "assistant_llm_temperature", 0.2)
+    monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
+
+
+class TestResolveLLMConfig:
+    def test_resolve_llm_config_for_openai_returns_expected_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "assistant_llm_provider", "openai")
+        monkeypatch.setattr(
+            settings, "assistant_openai_api_key", SecretStr("openai-key")
+        )
+        monkeypatch.setattr(settings, "assistant_openai_model", "gpt-test")
+        monkeypatch.setattr(settings, "assistant_llm_timeout_seconds", 20.0)
+        monkeypatch.setattr(settings, "assistant_llm_temperature", 0.2)
+        monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
+
+        config = orchestrator._resolve_llm_config()
+
+        assert config.provider == "openai"
+        assert config.model_name == "gpt-test"
+        assert config.api_key.get_secret_value() == "openai-key"
+        assert config.temperature == 0.2
+        assert config.max_tokens == 2048
+
+    def test_resolve_llm_config_for_livai_uses_wrapper_key_and_base_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_livai_settings(monkeypatch)
+
+        config = orchestrator._resolve_llm_config()
+
+        assert config.provider == "livai"
+        assert config.model_name == "livai-model"
+        assert config.api_key.get_secret_value() == "livai-key"
+        assert config.base_url == "https://api.livai.llnl.gov/v1"
+
+    def test_resolve_llm_config_for_anthropic_returns_expected_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "assistant_llm_provider", "anthropic")
+        monkeypatch.setattr(
+            settings, "assistant_anthropic_api_key", SecretStr("anthropic-key")
+        )
+        monkeypatch.setattr(settings, "assistant_anthropic_model", "claude-test")
+        monkeypatch.setattr(settings, "assistant_llm_timeout_seconds", 15.0)
+        monkeypatch.setattr(settings, "assistant_llm_temperature", 0.2)
+        monkeypatch.setattr(settings, "assistant_llm_max_tokens", 2048)
+
+        config = orchestrator._resolve_llm_config()
+
+        assert config.provider == "anthropic"
+        assert config.model_name == "claude-test"
+        assert config.api_key.get_secret_value() == "anthropic-key"
+        assert config.temperature == 0.2
+        assert config.max_tokens == 2048
+
+    def test_resolve_llm_config_rejects_openai_misconfiguration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "assistant_llm_provider", "openai")
+        monkeypatch.setattr(settings, "assistant_openai_api_key", None)
+        monkeypatch.setattr(settings, "assistant_openai_model", "gpt-test")
+
+        with pytest.raises(ValueError, match="openai_misconfigured"):
+            orchestrator._resolve_llm_config()
+
+    def test_resolve_llm_config_rejects_anthropic_misconfiguration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "assistant_llm_provider", "anthropic")
+        monkeypatch.setattr(settings, "assistant_anthropic_api_key", None)
+        monkeypatch.setattr(settings, "assistant_anthropic_model", "claude-test")
+
+        with pytest.raises(ValueError, match="anthropic_misconfigured"):
+            orchestrator._resolve_llm_config()
+
+    def test_resolve_llm_config_rejects_unsupported_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "assistant_llm_provider", "unsupported")
+
+        with pytest.raises(ValueError, match="unsupported_provider"):
+            orchestrator._resolve_llm_config()
+
+    @pytest.mark.parametrize(
+        ("provider", "expected"),
+        [
+            ("openai", "gpt-test"),
+            ("anthropic", "claude-test"),
+            ("livai", "livai-model"),
+        ],
+    )
+    def test_configured_model_name_uses_provider_setting(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        provider: str,
+        expected: str,
+    ) -> None:
+        from app.features.assistant.schemas import SummaryGenerationProvider
+
+        monkeypatch.setattr(settings, "assistant_openai_model", "gpt-test")
+        monkeypatch.setattr(settings, "assistant_anthropic_model", "claude-test")
+        monkeypatch.setattr(settings, "assistant_livai_model", "livai-model")
+
+        assert (
+            orchestrator._configured_model_name(
+                cast(SummaryGenerationProvider, provider)
+            )
+            == expected
+        )
+
+
+class TestValidationHelpers:
+    def test_standardize_citations_rejects_invalid_path(self) -> None:
+        with pytest.raises(ValueError, match="invalid_citation_path:invalid.path"):
+            orchestrator._standardize_citations(
+                [
+                    SummaryCitationOut(
+                        source_type="simulation_field",
+                        path="invalid.path",
+                        label="Invalid",
+                    )
+                ],
+                _make_snapshot(),
+            )
+
+    def test_standardize_citations_rejects_missing_snapshot_path(self) -> None:
+        with pytest.raises(ValueError, match="missing_citation_path:machine.name"):
+            orchestrator._standardize_citations(
+                [
+                    SummaryCitationOut(
+                        source_type="machine_field",
+                        path="machine.name",
+                        label="Machine",
+                    )
+                ],
+                _make_snapshot(),
+            )
+
+    @pytest.mark.parametrize(
+        ("overrides", "expected_error"),
+        [
+            ({"answer": "   "}, "empty_answer"),
+            ({"citations": []}, "missing_citations"),
+            ({"limitations": []}, "missing_limitations"),
+            ({"suggested_followups": []}, "missing_followups"),
+        ],
+    )
+    def test_validate_llm_content_requires_all_required_fields(
+        self,
+        overrides: dict[str, object],
+        expected_error: str,
+    ) -> None:
+        with pytest.raises(ValueError, match=expected_error):
+            orchestrator._validate_llm_content(
+                _make_llm_content(**overrides),
+                _make_snapshot(),
+            )
+
+    def test_snapshot_has_citation_path_supports_related_record_selectors(self) -> None:
+        snapshot = _make_snapshot().model_copy(
+            update={
+                "artifacts": [SnapshotArtifact(kind="output", uri="s3://bucket/out")],
+                "links": [
+                    SnapshotLink(kind="diagnostic", url="https://diag.example.com")
+                ],
+            }
+        )
+
+        assert orchestrator.snapshot_has_citation_path(
+            snapshot, "artifacts[kind=output]"
+        )
+        assert orchestrator.snapshot_has_citation_path(
+            snapshot, "links[kind=diagnostic]"
+        )
+        assert not orchestrator.snapshot_has_citation_path(snapshot, "links[kind=docs]")
+        assert not orchestrator.snapshot_has_citation_path(snapshot, "invalid.path")
+
+
+class TestGenerateSimulationSummary:
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_returns_deterministic_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        monkeypatch.setattr(settings, "assistant_llm_enabled", False)
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == "llm_disabled"
+        assert result.summary.generation_mode == "deterministic"
+        assert result.attempted_provider is None
+        assert result.attempted_model is None
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_returns_livai_provider_on_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_livai_settings(monkeypatch)
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            return SimulationSummaryContent(
+                answer="Simulation assistant-livai-exec belongs to case assistant_livai_case.",
+                citations=[
+                    SummaryCitationOut(
+                        source_type="simulation_field",
+                        path="simulation.execution_id",
+                        label="Execution ID",
+                    ),
+                    SummaryCitationOut(
+                        source_type="case_field",
+                        path="case.name",
+                        label="Case Name",
+                    ),
+                ],
+                assumptions=[],
+                caveats=[],
+                limitations=["Custom LLM caveat."],
+                suggested_followups=["Review recorded artifacts."],
+            )
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason is None
+        assert result.summary.generation_mode == "llm"
+        assert result.summary.generation_provider == "livai"
+        assert result.summary.generation_model == "livai-model"
+        assert result.attempted_provider == "livai"
+        assert result.attempted_model == "livai-model"
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_falls_back_for_livai_misconfiguration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_livai_settings(monkeypatch, api_key=None)
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == "livai_misconfigured"
+        assert result.summary.generation_mode == "deterministic"
+        assert result.summary.generation_provider is None
+        assert result.summary.generation_model is None
+        assert result.attempted_provider == "livai"
+        assert result.attempted_model == "livai-model"
+        assert LLM_FALLBACK_CAVEAT in result.summary.caveats
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_falls_back_when_snapshot_budget_exceeded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_livai_settings(monkeypatch)
+
+        def fail_snapshot_build(simulation: Simulation) -> SimulationSnapshot:
+            raise SnapshotBudgetExceededError(snapshot, 10)
+
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            fail_snapshot_build,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason is not None
+        assert result.fallback_reason.startswith("Snapshot size ")
+        assert result.summary.generation_mode == "deterministic"
+        assert result.attempted_provider == "livai"
+        assert result.attempted_model == "livai-model"
+        assert LLM_FALLBACK_CAVEAT in result.summary.caveats
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_keeps_deterministic_mode_when_llm_disabled_and_snapshot_budget_exceeded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_livai_settings(monkeypatch, enabled=False)
+
+        def fail_snapshot_build(simulation: Simulation) -> SimulationSnapshot:
+            raise SnapshotBudgetExceededError(snapshot, 10)
+
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            fail_snapshot_build,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == "llm_disabled"
+        assert result.summary.generation_mode == "deterministic"
+        assert result.attempted_provider is None
+        assert result.attempted_model is None
+        assert LLM_FALLBACK_CAVEAT not in result.summary.caveats
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_falls_back_on_invalid_llm_content(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_livai_settings(monkeypatch)
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            return _make_llm_content(limitations=[])
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == "missing_limitations"
+        assert result.summary.generation_mode == "deterministic"
+        assert result.attempted_provider == "livai"
+        assert result.attempted_model == "livai-model"
+        assert LLM_FALLBACK_CAVEAT in result.summary.caveats
+
+    @pytest.mark.asyncio
+    async def test_generate_simulation_summary_falls_back_on_unexpected_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+        _set_livai_settings(monkeypatch)
+        monkeypatch.setattr(
+            orchestrator,
+            "build_simulation_snapshot",
+            lambda simulation: snapshot,
+        )
+
+        async def fake_generate(self, snapshot_arg):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            orchestrator.SummaryLLMGenerator,
+            "generate",
+            fake_generate,
+        )
+
+        result = await orchestrator.generate_simulation_summary(cast(Simulation, None))
+
+        assert result.fallback_reason == "RuntimeError"
+        assert result.summary.generation_mode == "deterministic"
+        assert result.attempted_provider == "livai"
+        assert result.attempted_model == "livai-model"

--- a/backend/tests/features/assistant/test_service.py
+++ b/backend/tests/features/assistant/test_service.py
@@ -1,0 +1,295 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.features.assistant.service import build_simulation_summary
+from app.features.assistant.snapshot import (
+    SimulationSnapshot,
+    SnapshotCaseFields,
+    SnapshotSimulationFields,
+)
+from app.features.ingestion.enums import IngestionSourceType, IngestionStatus
+from app.features.ingestion.models import Ingestion
+from app.features.machine.models import Machine
+from app.features.simulation.enums import ArtifactKind, ExternalLinkKind
+from app.features.simulation.models import Artifact, Case, ExternalLink, Simulation
+
+
+def _create_case(db: Session, name: str = "assistant_case") -> Case:
+    case = Case(name=name)
+    db.add(case)
+    db.flush()
+    return case
+
+
+def _create_simulation(
+    db: Session,
+    normal_user_sync: dict[str, UUID | str],
+    admin_user_sync: dict[str, UUID | str],
+    *,
+    case_name: str = "assistant_case",
+    execution_id: str = "assistant-exec-1",
+    is_reference: bool = True,
+    with_diagnostics: bool = True,
+    with_optional_metadata: bool = True,
+) -> Simulation:
+    machine = db.query(Machine).first()
+    assert machine is not None
+
+    case = _create_case(db, case_name)
+
+    ingestion = Ingestion(
+        source_type=IngestionSourceType.BROWSER_UPLOAD,
+        source_reference=execution_id,
+        machine_id=machine.id,
+        triggered_by=normal_user_sync["id"],
+        status=IngestionStatus.SUCCESS,
+        created_count=1,
+        duplicate_count=0,
+        error_count=0,
+    )
+    db.add(ingestion)
+    db.flush()
+
+    simulation = Simulation(
+        case_id=case.id,
+        execution_id=execution_id,
+        description="Control simulation for deterministic summary."
+        if with_optional_metadata
+        else None,
+        compset="AQUAPLANET",
+        compset_alias="QPC4",
+        grid_name="f19_f19",
+        grid_resolution="1.9x2.5",
+        simulation_type="experimental",
+        status="completed",
+        campaign="historical" if with_optional_metadata else None,
+        experiment_type="historical" if with_optional_metadata else None,
+        initialization_type="startup",
+        machine_id=machine.id,
+        simulation_start_date="2023-01-01T00:00:00Z",
+        simulation_end_date="2023-12-31T00:00:00Z" if with_optional_metadata else None,
+        compiler="gcc",
+        key_features="High-resolution control setup."
+        if with_optional_metadata
+        else None,
+        known_issues="Sea-ice diagnostics pending QA."
+        if with_optional_metadata
+        else None,
+        notes_markdown="Reviewed by domain team." if with_optional_metadata else None,
+        git_branch="main" if with_optional_metadata else None,
+        git_tag="v1.2.3" if with_optional_metadata else None,
+        git_commit_hash="abc123def456" if with_optional_metadata else None,
+        created_by=normal_user_sync["id"],
+        last_updated_by=admin_user_sync["id"],
+        ingestion_id=ingestion.id,
+        run_config_deltas=(
+            None
+            if is_reference
+            else {"compiler": {"reference": "gcc-11", "current": "gcc-12"}}
+        ),
+    )
+    db.add(simulation)
+    db.flush()
+
+    if is_reference:
+        case.reference_simulation_id = simulation.id
+    else:
+        reference = Simulation(
+            case_id=case.id,
+            execution_id=f"{execution_id}-ref",
+            compset="AQUAPLANET",
+            compset_alias="QPC4",
+            grid_name="f19_f19",
+            grid_resolution="1.9x2.5",
+            simulation_type="experimental",
+            status="completed",
+            initialization_type="startup",
+            machine_id=machine.id,
+            simulation_start_date="2023-01-01T00:00:00Z",
+            created_by=normal_user_sync["id"],
+            last_updated_by=admin_user_sync["id"],
+            ingestion_id=ingestion.id,
+        )
+        db.add(reference)
+        db.flush()
+        case.reference_simulation_id = reference.id
+
+    if with_diagnostics:
+        db.add(
+            ExternalLink(
+                simulation_id=simulation.id,
+                kind=ExternalLinkKind.DIAGNOSTIC,
+                url="https://example.com/diag",
+                label="Diagnostics Dashboard",
+            )
+        )
+
+    db.add(
+        Artifact(
+            simulation_id=simulation.id,
+            kind=ArtifactKind.OUTPUT,
+            uri="/archive/output.nc",
+            label="Primary output",
+        )
+    )
+
+    db.commit()
+    db.refresh(simulation)
+    return simulation
+
+
+class TestBuildSimulationSummary:
+    def test_complete_metadata_produces_stable_summary_and_citations(
+        self, db: Session, normal_user_sync, admin_user_sync
+    ) -> None:
+        simulation = _create_simulation(
+            db,
+            normal_user_sync,
+            admin_user_sync,
+            execution_id="assistant-complete",
+        )
+
+        summary = build_simulation_summary(simulation)
+
+        assert (
+            "Simulation assistant-complete belongs to case assistant_case."
+            in summary.answer
+        )
+        assert (
+            "Recorded version metadata includes tag v1.2.3, branch main, commit abc123def456."
+            in summary.answer
+        )
+        assert "SimBoard records 1 diagnostic link(s) for this run" in summary.answer
+        assert {citation.path for citation in summary.citations} >= {
+            "simulation.execution_id",
+            "case.name",
+            "simulation.git_tag",
+            "links[kind=diagnostic]",
+        }
+
+    def test_missing_optional_metadata_yields_caveats_not_fabrication(
+        self, db: Session, normal_user_sync, admin_user_sync
+    ) -> None:
+        simulation = _create_simulation(
+            db,
+            normal_user_sync,
+            admin_user_sync,
+            execution_id="assistant-missing",
+            with_diagnostics=False,
+            with_optional_metadata=False,
+        )
+
+        summary = build_simulation_summary(simulation)
+
+        assert "Recorded description:" not in summary.answer
+        assert (
+            "Version metadata is not recorded for this simulation." in summary.caveats
+        )
+        assert (
+            "Campaign metadata is not recorded for this simulation." in summary.caveats
+        )
+        assert (
+            "No diagnostic links are recorded for this simulation in SimBoard."
+            in summary.caveats
+        )
+
+    def test_non_reference_simulation_mentions_change_count(
+        self, db: Session, normal_user_sync, admin_user_sync
+    ) -> None:
+        simulation = _create_simulation(
+            db,
+            normal_user_sync,
+            admin_user_sync,
+            execution_id="assistant-nonref",
+            is_reference=False,
+        )
+
+        summary = build_simulation_summary(simulation)
+
+        assert (
+            "non-reference run with 1 recorded configuration change(s)"
+            in summary.answer
+        )
+        assert "simulation.run_config_deltas" in {
+            citation.path for citation in summary.citations
+        }
+
+    def test_absent_diagnostics_adds_limitation_not_interpretation(
+        self, db: Session, normal_user_sync, admin_user_sync
+    ) -> None:
+        simulation = _create_simulation(
+            db,
+            normal_user_sync,
+            admin_user_sync,
+            execution_id="assistant-nodiag",
+            with_diagnostics=False,
+        )
+
+        summary = build_simulation_summary(simulation)
+
+        assert "interpret diagnostic outputs" not in summary.answer
+        assert (
+            "No diagnostic links are recorded for this simulation in SimBoard."
+            in summary.caveats
+        )
+        assert summary.limitations == [
+            "This summary uses only metadata already stored in SimBoard. It does not use retrieval, diagnostics interpretation, or LLM reasoning."
+        ]
+
+    def test_non_reference_without_deltas_adds_explicit_caveat(self) -> None:
+        summary = build_simulation_summary(
+            SimulationSnapshot(
+                simulation=SnapshotSimulationFields(
+                    id="simulation-1",
+                    execution_id="assistant-nonref-no-deltas",
+                    compset="AQUAPLANET",
+                    compset_alias="QPC4",
+                    grid_name="f19_f19",
+                    grid_resolution="1.9x2.5",
+                    simulation_type="experimental",
+                    status="completed",
+                    initialization_type="startup",
+                    simulation_start_date="2023-01-01T00:00:00Z",
+                ),
+                case=SnapshotCaseFields(
+                    name="assistant_case",
+                    reference_simulation_id="reference-1",
+                ),
+            )
+        )
+
+        assert (
+            "It is a non-reference run, but SimBoard does not currently record any configuration deltas for it."
+            in summary.answer
+        )
+        assert (
+            "This non-reference simulation has no recorded configuration deltas in SimBoard metadata."
+            in summary.caveats
+        )
+
+    def test_missing_start_date_adds_caveat_and_default_followup(self) -> None:
+        summary = build_simulation_summary(
+            SimulationSnapshot(
+                simulation=SnapshotSimulationFields(
+                    id="simulation-1",
+                    execution_id="assistant-no-start-date",
+                    compset="AQUAPLANET",
+                    compset_alias="QPC4",
+                    grid_name="f19_f19",
+                    grid_resolution="1.9x2.5",
+                    simulation_type="experimental",
+                    status="completed",
+                    initialization_type="startup",
+                ),
+                case=SnapshotCaseFields(name="assistant_case"),
+            )
+        )
+
+        assert (
+            "Simulation start date is not recorded in SimBoard metadata."
+            in summary.caveats
+        )
+        assert summary.suggested_followups == [
+            "Review the simulation detail page metadata for additional provenance and run context."
+        ]

--- a/backend/tests/features/assistant/test_snapshot.py
+++ b/backend/tests/features/assistant/test_snapshot.py
@@ -1,0 +1,200 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from app.features.assistant import snapshot as snapshot_module
+from app.features.assistant.snapshot import (
+    SNAPSHOT_TRUNCATED_CAVEAT,
+    SimulationSnapshot,
+    SnapshotArtifact,
+    SnapshotBudgetExceededError,
+    SnapshotCaseFields,
+    SnapshotLink,
+    SnapshotMachineFields,
+    SnapshotSimulationFields,
+    _SnapshotSizeBudget,
+)
+from app.features.simulation.enums import SimulationStatus
+
+
+def _make_snapshot() -> SimulationSnapshot:
+    return SimulationSnapshot(
+        simulation=SnapshotSimulationFields(
+            id="simulation-1",
+            execution_id="assistant-snapshot-exec",
+            description="Description " * 5,
+            compset="AQUAPLANET",
+            compset_alias="QPC4",
+            grid_name="f19_f19",
+            grid_resolution="1.9x2.5",
+            simulation_type="experimental",
+            status="completed",
+            initialization_type="startup",
+            notes_markdown="Notes " * 5,
+            key_features="Features " * 5,
+            known_issues="Issues " * 5,
+            extra={"foo": "bar"},
+            run_config_deltas={
+                "compiler": {"reference": "gcc-11", "current": "gcc-12"}
+            },
+        ),
+        case=SnapshotCaseFields(name="assistant_case"),
+        machine=SnapshotMachineFields(name="perlmutter"),
+        artifacts=[
+            SnapshotArtifact(kind="output", uri="/output.nc", label="Output"),
+            SnapshotArtifact(kind="archive", uri="/archive.tar", label="Archive"),
+        ],
+        links=[
+            SnapshotLink(
+                kind="diagnostic", url="https://example.com/diag", label="Diag"
+            ),
+            SnapshotLink(kind="docs", url="https://example.com/docs", label="Docs"),
+            SnapshotLink(kind="other", url="https://example.com/other", label="Other"),
+        ],
+        snapshot_caveats=[],
+    )
+
+
+class TestSnapshotHelpers:
+    def test_enum_value_and_isoformat_handle_none_enum_and_plain_values(self) -> None:
+        timestamp = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+
+        assert snapshot_module._enum_value(None) is None
+        assert snapshot_module._enum_value(SimulationStatus.COMPLETED) == "completed"
+        assert snapshot_module._enum_value("plain-value") == "plain-value"
+        assert snapshot_module._isoformat(None) is None
+        assert snapshot_module._isoformat(timestamp) == "2024-01-02T03:04:05+00:00"
+
+    def test_add_truncation_caveat_is_idempotent(self) -> None:
+        snapshot = _make_snapshot()
+
+        updated = snapshot_module._add_truncation_caveat(snapshot)
+        again = snapshot_module._add_truncation_caveat(updated)
+
+        assert updated.snapshot_caveats == [SNAPSHOT_TRUNCATED_CAVEAT]
+        assert again is updated
+
+    def test_apply_size_budget_trims_strings_and_related_records(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot()
+
+        def fake_snapshot_size(current_snapshot: SimulationSnapshot) -> int:
+            # After all trimming and caveat, return size within budget
+            if (
+                current_snapshot.simulation.notes_markdown is None
+                and not current_snapshot.artifacts
+                and not current_snapshot.links
+                and SNAPSHOT_TRUNCATED_CAVEAT in current_snapshot.snapshot_caveats
+            ):
+                return 5
+            if current_snapshot.simulation.notes_markdown is None:
+                return 200
+            if (
+                len(current_snapshot.artifacts),
+                len(current_snapshot.links),
+            ) in {(2, 3), (2, 2)}:
+                return 200
+            if (len(current_snapshot.artifacts), len(current_snapshot.links)) == (1, 2):
+                return 50
+            return 200
+
+        monkeypatch.setattr(snapshot_module, "_snapshot_size", fake_snapshot_size)
+
+        trimmed = snapshot_module._apply_size_budget(
+            snapshot,
+            _SnapshotSizeBudget(max_chars=10),
+        )
+
+        assert trimmed.artifacts == []
+        assert trimmed.links == []
+        assert trimmed.simulation.notes_markdown is None
+        assert trimmed.simulation.description is None
+        assert trimmed.simulation.key_features is None
+        assert trimmed.simulation.known_issues is None
+        assert trimmed.simulation.extra == {}
+        assert trimmed.simulation.run_config_deltas is None
+        assert SNAPSHOT_TRUNCATED_CAVEAT in trimmed.snapshot_caveats
+
+    def test_apply_size_budget_drops_remaining_artifacts_after_trim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot().model_copy(
+            update={
+                "artifacts": [SnapshotArtifact(kind="output", uri="/output.nc")],
+                "links": [],
+            }
+        )
+        sizes = iter([200, 0, 200, 200, 0, 0, 0])
+
+        monkeypatch.setattr(
+            snapshot_module,
+            "_snapshot_size",
+            lambda current_snapshot: next(sizes),
+        )
+
+        trimmed = snapshot_module._apply_size_budget(
+            snapshot,
+            _SnapshotSizeBudget(max_chars=10),
+        )
+
+        assert trimmed.artifacts == []
+
+    def test_apply_size_budget_drops_remaining_links_after_trim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot().model_copy(
+            update={
+                "artifacts": [],
+                "links": [SnapshotLink(kind="docs", url="https://example.com/docs")],
+            }
+        )
+        sizes = iter([200, 0, 200, 0, 200, 0, 0])
+
+        monkeypatch.setattr(
+            snapshot_module,
+            "_snapshot_size",
+            lambda current_snapshot: next(sizes),
+        )
+
+        trimmed = snapshot_module._apply_size_budget(
+            snapshot,
+            _SnapshotSizeBudget(max_chars=10),
+        )
+
+        assert trimmed.links == []
+
+    def test_apply_size_budget_raises_when_required_fields_too_large(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        snapshot = _make_snapshot().model_copy(
+            update={
+                "artifacts": [],
+                "links": [],
+            }
+        )
+
+        monkeypatch.setattr(
+            snapshot_module,
+            "_snapshot_size",
+            lambda current_snapshot: 200,
+        )
+
+        with pytest.raises(
+            SnapshotBudgetExceededError,
+            match=r"Snapshot size 200 exceeds budget 10.*Required fields are too large",
+        ) as exc_info:
+            snapshot_module._apply_size_budget(
+                snapshot,
+                _SnapshotSizeBudget(max_chars=10),
+            )
+
+        assert exc_info.value.snapshot.artifacts == []
+        assert exc_info.value.snapshot.links == []
+        assert exc_info.value.snapshot.simulation.notes_markdown is None
+        assert exc_info.value.snapshot.simulation.description is None
+        assert exc_info.value.snapshot.simulation.key_features is None
+        assert exc_info.value.snapshot.simulation.known_issues is None
+        assert exc_info.value.snapshot.simulation.extra == {}
+        assert exc_info.value.snapshot.simulation.run_config_deltas is None
+        assert SNAPSHOT_TRUNCATED_CAVEAT in exc_info.value.snapshot.snapshot_caveats

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -39,25 +39,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.102.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/47/cb2a71f70431fb09af4db83e3ea89eb2dd8e0e348d27af53ed32e6c599dd/anthropic-0.102.0.tar.gz", hash = "sha256:96f747cad11886c4ae12d4080131b94eebd68b202bd2190fe27959031bb1fa9c", size = 763697, upload-time = "2026-05-13T18:12:41.624Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/75/0f6c603594876413bc858a00e7cc0d80a0cc14edf5c7b959a3ea6ec45e44/anthropic-0.102.0-py3-none-any.whl", hash = "sha256:ab96540bbd4b0f36564252d955a86f8abbe4f00944a24bc9931acc9b139bab6f", size = 763070, upload-time = "2026-05-13T18:12:43.474Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -534,15 +515,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -1632,9 +1604,6 @@ wheels = [
 ]
 
 [package.optional-dependencies]
-anthropic = [
-    { name = "anthropic" },
-]
 openai = [
     { name = "openai" },
     { name = "tiktoken" },
@@ -2196,7 +2165,7 @@ dependencies = [
     { name = "fastapi-users", extra = ["oauth", "sqlalchemy"] },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
-    { name = "pydantic-ai-slim", extra = ["anthropic", "openai"] },
+    { name = "pydantic-ai-slim", extra = ["openai"] },
     { name = "pydantic-settings" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
@@ -2226,7 +2195,7 @@ requires-dist = [
     { name = "fastapi-users", extras = ["sqlalchemy", "oauth"], specifier = ">=14.0.0,<15.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.1,<3.3.0" },
     { name = "pydantic", specifier = ">=2.12.3,<2.13.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], specifier = ">=1.0.0,<2.0.0" },
+    { name = "pydantic-ai-slim", extras = ["openai"], specifier = ">=1.0.0,<2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -39,6 +39,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.102.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/47/cb2a71f70431fb09af4db83e3ea89eb2dd8e0e348d27af53ed32e6c599dd/anthropic-0.102.0.tar.gz", hash = "sha256:96f747cad11886c4ae12d4080131b94eebd68b202bd2190fe27959031bb1fa9c", size = 763697, upload-time = "2026-05-13T18:12:41.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/75/0f6c603594876413bc858a00e7cc0d80a0cc14edf5c7b959a3ea6ec45e44/anthropic-0.102.0-py3-none-any.whl", hash = "sha256:ab96540bbd4b0f36564252d955a86f8abbe4f00944a24bc9931acc9b139bab6f", size = 763070, upload-time = "2026-05-13T18:12:43.474Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -255,6 +274,63 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -443,12 +519,30 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -686,6 +780,19 @@ wheels = [
 ]
 
 [[package]]
+name = "genai-prices"
+version = "0.0.59"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c8/b61a028b8d8ee286ffab3f9b9f1c9229087184e7d543cea4e349e11375b0/genai_prices-0.0.59.tar.gz", hash = "sha256:3e1c7dcd9b38163589c8cf4a9bcfd286c52ea57a3becdc062a2cbaa8295b08c4", size = 67406, upload-time = "2026-05-07T12:08:40.475Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/f9/4693c127f9fab0a8d39c47c198e378ecafcb043463e6dd73df205eacbc13/genai_prices-0.0.59-py3-none-any.whl", hash = "sha256:88fd8818e6807374e5a5c03f293b574ade5f18a3060622080cdd94a03cf43115", size = 70509, upload-time = "2026-05-07T12:08:39.075Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -718,6 +825,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
     { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
     { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -817,6 +933,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -908,6 +1036,69 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/1f/198ae537fccb7080a0ed655eb56abf64a92f79489dfbf79f40fa34225bcd/jiter-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7e791e247b8044512e070bd1f3633dc08350d32776d2d6e7473309d0edf256a2", size = 316896, upload-time = "2026-04-10T14:26:01.986Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/34/da67cff3fce964a36d03c3e365fb0f8726ade2a6cfd4d3c70107e216ead6/jiter-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71527ce13fd5a0c4e40ad37331f8c547177dbb2dd0a93e5278b6a5eecf748804", size = 321085, upload-time = "2026-04-10T14:26:03.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/36/4c72e67180d4e71a4f5dcf7886d0840e83c49ab11788172177a77570326e/jiter-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c4a7ab56f746014874f2c525584c0daca1dec37f66fd707ecef3b7e5c2228c", size = 347393, upload-time = "2026-04-10T14:26:05.314Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/db/9b39e09ceafa9878235c0fc29e3e3f9b12a4c6a98ea3085b998cadf3accc/jiter-0.14.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:376e9dafff914253bb9d46cdc5f7965607fbe7feb0a491c34e35f92b2770702e", size = 372937, upload-time = "2026-04-10T14:26:06.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/96/0dcba1d7a82c1b720774b48ef239376addbaf30df24c34742ac4a57b67b2/jiter-0.14.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:23ad2a7a9da1935575c820428dd8d2490ce4d23189691ce33da1fc0a58e14e1c", size = 463646, upload-time = "2026-04-10T14:26:08.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e3/f61b71543e746e6b8b805e7755814fc242715c16f1dba58e1cbccb8032c2/jiter-0.14.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b3ddf5786bc7732d293bba3411ac637ecfa200a39983166d1df86a59a43c9f", size = 380225, upload-time = "2026-04-10T14:26:10.161Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5e/0ddeb7096aca099114abe36c4921016e8d251e6f35f5890240b31f1f60ae/jiter-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c001d5a646c2a50dc055dd526dad5d5245969e8234d2b1131d0451e81f3a373", size = 358682, upload-time = "2026-04-10T14:26:11.574Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d1/fe0c46cd7fda9cad8f1ff9ad217dc61f1e4280b21052ec6dfe88c1446ef2/jiter-0.14.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:834bb5bdabca2e91592a03d373838a8d0a1b8bbde7077ae6913fd2fc51812d00", size = 359973, upload-time = "2026-04-10T14:26:13.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/21/f5317f91729b501019184771c80d60abd89907009e7bfa6c7e348c5bdd44/jiter-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4e9178be60e229b1b2b0710f61b9e24d1f4f8556985a83ff4c4f95920eea7314", size = 397568, upload-time = "2026-04-10T14:26:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/79d8f33fb2bf168db0df5c9cd16fe440a8ada57e929d3677b22712c2568f/jiter-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a7e4ccff04ec03614e62c613e976a3a5860dc9714ce8266f44328bdc8b1cab2c", size = 522535, upload-time = "2026-04-10T14:26:16.956Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/d1e3ff3d2a465e67f08507d74bafb2dcd29eba91dc939820e39e8dea38b8/jiter-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:69539d936fb5d55caf6ecd33e2e884de083ff0ea28579780d56c4403094bb8d9", size = 556709, upload-time = "2026-04-10T14:26:18.5Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/bbb2189f62ace8d95e869aa4c84c9946616f301e2d02895a6f20dcc3bba3/jiter-0.14.0-cp311-cp311-win32.whl", hash = "sha256:4927d09b3e572787cc5e0a5318601448e1ab9391bcef95677f5840c2d00eaa6d", size = 208660, upload-time = "2026-04-10T14:26:20.511Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/86/c500b53dcbf08575f5963e536ebd757a1f7c568272ba5d180b212c9a87fb/jiter-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:42d6ed359ac49eb922fdd565f209c57340aa06d589c84c8413e42a0f9ae1b842", size = 204659, upload-time = "2026-04-10T14:26:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/a676249049d42cb29bef82233e4fe0524d414cbe3606c7a4b311193c2f77/jiter-0.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:6dd689f5f4a5a33747b28686e051095beb214fe28cfda5e9fe58a295a788f593", size = 194772, upload-time = "2026-04-10T14:26:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a1/ef34ca2cab2962598591636a1804b93645821201cc0095d4a93a9a329c9d/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a25ffa2dbbdf8721855612f6dca15c108224b12d0c4024d0ac3d7902132b4211", size = 311366, upload-time = "2026-04-10T14:28:27.943Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/520576a532a6b8a6f42747afed289c8448c879a34d7802fe2c832d4fd38f/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ac9cbaa86c10996b92bd12c91659b60f939f8e28fcfa6bc11a0e90a774ce95b", size = 309873, upload-time = "2026-04-10T14:28:29.688Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7c/c16db114ea1f2f532f198aa8dc39585026af45af362c69a0492f31bc4821/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:844e73b6c56b505e9e169234ea3bdea2ea43f769f847f47ac559ba1d2361ebea", size = 344816, upload-time = "2026-04-10T14:28:31.348Z" },
+    { url = "https://files.pythonhosted.org/packages/99/8f/15e7741ff19e9bcd4d753f7ff22f988fd54592f134ca13701c13ea8c20e0/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e52c076f187405fc21523c746c04399c9af8ece566077ed147b2126f2bcba577", size = 351445, upload-time = "2026-04-10T14:28:33.093Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
+]
+
+[[package]]
 name = "jupyter-client"
 version = "8.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -981,6 +1172,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
     { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
     { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
+]
+
+[[package]]
+name = "logfire-api"
+version = "4.33.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/1a/c44eb3a02407aa739669822d19734e76e8751284b86cd99c73baca36998a/logfire_api-4.33.0.tar.gz", hash = "sha256:0a604f710e803db08a2ddc41e6152bf8d8a56b549f8856cbf82baa36bc7de2c9", size = 81483, upload-time = "2026-05-13T15:14:17.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/58/dc21672e0d5294668f4d35aaba4d839d031f096b4cf6802399c4b411b5fc/logfire_api-4.33.0-py3-none-any.whl", hash = "sha256:b992727bab71412b5a00f54453eec18e559232c83d7120cf5c6a9edd33fb0c4e", size = 128896, upload-time = "2026-05-13T15:14:14.322Z" },
 ]
 
 [[package]]
@@ -1147,6 +1347,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
 ]
 
 [[package]]
@@ -1382,6 +1614,33 @@ email = [
 ]
 
 [[package]]
+name = "pydantic-ai-slim"
+version = "1.96.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "genai-prices" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pydantic-graph" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/b0/26299238be57ddbc1ce5b4fc019338dc4856a549d5b636276bf3743a1008/pydantic_ai_slim-1.96.0.tar.gz", hash = "sha256:44ff8bb5cf81023076e82174de1d6a089515277ce508906263d17880e3fcb2f4", size = 699284, upload-time = "2026-05-14T01:09:07.519Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/a0/4ceb29871244a398fed43009b8d6577ee60b8562437e47027e371ef2d22c/pydantic_ai_slim-1.96.0-py3-none-any.whl", hash = "sha256:58044dee3e5429499938a5ef1a44ef44d5e179f3f68e80600bbddea1f6081967", size = 870756, upload-time = "2026-05-14T01:08:58.945Z" },
+]
+
+[package.optional-dependencies]
+anthropic = [
+    { name = "anthropic" },
+]
+openai = [
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+
+[[package]]
 name = "pydantic-core"
 version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1448,6 +1707,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pydantic-graph"
+version = "1.96.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "logfire-api" },
+    { name = "pydantic" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/b3/7e279ee3e8d1db7ff29fb4c6cf21c2b30a002e0900eae94bcc829a66f0e2/pydantic_graph-1.96.0.tar.gz", hash = "sha256:299a2b1e47e232a78b8038779c1ff5b387d6f02d79aebae217806c5d53607f9e", size = 59294, upload-time = "2026-05-14T01:09:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/918e641e1d94b95315a174bf318a78c0c127191333ffe021a92d417f6159/pydantic_graph-1.96.0-py3-none-any.whl", hash = "sha256:5904661751c4f19cba726e4e16a878f2f83722432236c231c88dba2bd887b43d", size = 73047, upload-time = "2026-05-14T01:09:02.476Z" },
 ]
 
 [[package]]
@@ -1673,6 +1947,93 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1835,6 +2196,7 @@ dependencies = [
     { name = "fastapi-users", extra = ["oauth", "sqlalchemy"] },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "openai"] },
     { name = "pydantic-settings" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
@@ -1864,6 +2226,7 @@ requires-dist = [
     { name = "fastapi-users", extras = ["sqlalchemy", "oauth"], specifier = ">=14.0.0,<15.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.1,<3.3.0" },
     { name = "pydantic", specifier = ">=2.12.3,<2.13.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], specifier = ">=1.0.0,<2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -1892,6 +2255,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -1967,6 +2339,46 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/46/21ea696b21f1d6d1efec8639c204bdf20fde8bafb351e1355c72c5d7de52/tiktoken-0.12.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6e227c7f96925003487c33b1b32265fad2fbcec2b7cf4817afb76d416f40f6bb", size = 1051565, upload-time = "2025-10-06T20:21:44.566Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d9/35c5d2d9e22bb2a5f74ba48266fb56c63d76ae6f66e02feb628671c0283e/tiktoken-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c06cf0fcc24c2cb2adb5e185c7082a82cba29c17575e828518c2f11a01f445aa", size = 995284, upload-time = "2025-10-06T20:21:45.622Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/961106c37b8e49b9fdcf33fe007bb3a8fdcc380c528b20cc7fbba80578b8/tiktoken-0.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f18f249b041851954217e9fd8e5c00b024ab2315ffda5ed77665a05fa91f42dc", size = 1129201, upload-time = "2025-10-06T20:21:47.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d0/3d9275198e067f8b65076a68894bb52fd253875f3644f0a321a720277b8a/tiktoken-0.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:47a5bc270b8c3db00bb46ece01ef34ad050e364b51d406b6f9730b64ac28eded", size = 1152444, upload-time = "2025-10-06T20:21:48.139Z" },
+    { url = "https://files.pythonhosted.org/packages/78/db/a58e09687c1698a7c592e1038e01c206569b86a0377828d51635561f8ebf/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:508fa71810c0efdcd1b898fda574889ee62852989f7c1667414736bcb2b9a4bd", size = 1195080, upload-time = "2025-10-06T20:21:49.246Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/a9e4d2bf91d515c0f74afc526fd773a812232dd6cda33ebea7f531202325/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1af81a6c44f008cba48494089dd98cccb8b313f55e961a52f5b222d1e507967", size = 1255240, upload-time = "2025-10-06T20:21:50.274Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/15/963819345f1b1fb0809070a79e9dd96938d4ca41297367d471733e79c76c/tiktoken-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:3e68e3e593637b53e56f7237be560f7a394451cb8c11079755e80ae64b9e6def", size = 879422, upload-time = "2025-10-06T20:21:51.734Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
+    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2019,6 +2431,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/1a/d7592328d037d36f2d2462f4bc1fbb383eec9278bc786c1b111cbbd44cfa/tornado-6.5.4-cp39-abi3-win32.whl", hash = "sha256:1768110f2411d5cd281bac0a090f707223ce77fd110424361092859e089b38d1", size = 446481, upload-time = "2025-12-15T19:21:00.008Z" },
     { url = "https://files.pythonhosted.org/packages/d6/6d/c69be695a0a64fd37a97db12355a035a6d90f79067a3cf936ec2b1dc38cd/tornado-6.5.4-cp39-abi3-win_amd64.whl", hash = "sha256:fa07d31e0cd85c60713f2b995da613588aa03e1303d75705dca6af8babc18ddc", size = 446886, upload-time = "2025-12-15T19:21:01.287Z" },
     { url = "https://files.pythonhosted.org/packages/50/49/8dc3fd90902f70084bd2cd059d576ddb4f8bb44c2c7c0e33a11422acb17e/tornado-6.5.4-cp39-abi3-win_arm64.whl", hash = "sha256:053e6e16701eb6cbe641f308f4c1a9541f91b6261991160391bfc342e8a551a1", size = 445910, upload-time = "2025-12-15T19:21:02.571Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]
@@ -2270,4 +2694,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]

--- a/docs/ai-196-local-llm/README.md
+++ b/docs/ai-196-local-llm/README.md
@@ -1,0 +1,163 @@
+# AI-196 Local LLM Plan
+
+Issue: [#196](https://github.com/E3SM-Project/simboard/issues/196)
+
+## Task
+
+Add local LLM support for SimBoard AI-assisted simulation summaries and related assistance using Ollama as local inference runtime and Gemma 4 as preferred open-weight model family.
+
+## Scope
+
+### In scope
+
+- Extend existing assistant summary backend to support local Ollama-backed generation.
+- Keep backend model-configurable so runtime is not hardcoded to one Gemma 4 tag.
+- Prefer Gemma 4 family for local prototype guidance and quality testing.
+- Preserve source-grounded summary behavior, structured output contracts, and deterministic fallback behavior.
+- Keep retrieval small, curated, and prototype-oriented when used.
+- Update env templates and developer docs for local Ollama setup.
+- Add backend and contract tests for config, adapter behavior, validation, fallback, and API-path coverage.
+
+### Out of scope
+
+- New frontend model or provider controls.
+- Shipping Ollama container manifests or Docker Compose assets in this repo.
+- Broad RAG architecture, vector databases, or large ingestion/indexing work for this phase.
+- Non-Ollama local runtimes for this prototype.
+
+## Recommended model path
+
+- `gemma4:e4b`
+  - Use for fast local development, adapter testing, UI iteration, and prompt-contract validation.
+- `gemma4:26b`
+  - Use as preferred quality target for SimBoard summaries, comparisons, and source-grounded assistance.
+- `gemma4:31b`
+  - Treat as optional if hardware allows and `gemma4:26b` quality is insufficient.
+
+Plan should document Gemma 4 as recommended Ollama family, but implementation must remain model-configurable so another Ollama-served model can be swapped through config without code changes.
+
+## Configuration
+
+Use existing SimBoard assistant env naming rather than introducing a second env namespace.
+
+Required repo-facing settings:
+
+```env
+ASSISTANT_LLM_ENABLED=true
+ASSISTANT_LLM_PROVIDER=ollama
+ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
+ASSISTANT_OLLAMA_MODEL=gemma4:26b
+ASSISTANT_OLLAMA_API_KEY=
+ASSISTANT_LLM_TIMEOUT_SECONDS=30
+ASSISTANT_LLM_TEMPERATURE=0.2
+ASSISTANT_LLM_MAX_TOKENS=2048
+```
+
+Local runtime example equivalent:
+
+```env
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=gemma4:26b
+```
+
+Doc guidance should explain:
+
+- switch to `gemma4:e4b` for fast local iteration
+- switch back to `gemma4:26b` for quality checks
+- use `gemma4:31b` only when local hardware supports it
+- Ollama remains runtime; model tag remains config
+
+## Implementation approach
+
+1. Extend provider enums and config types in [backend/app/features/assistant/schemas.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/schemas.py) and [backend/app/core/config.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/core/config.py) to include `ollama`.
+2. Add Ollama config fields in [backend/app/core/config.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/core/config.py):
+   - `ASSISTANT_OLLAMA_BASE_URL`
+   - `ASSISTANT_OLLAMA_MODEL`
+   - `ASSISTANT_OLLAMA_API_KEY` if endpoint protection is required by local or proxied deployment
+3. Refactor provider resolution in [backend/app/features/assistant/orchestrator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/orchestrator.py) so provider selection and model selection stay config-driven.
+4. Keep integration model-agnostic through adapter boundary in [backend/app/features/assistant/llm_generator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/app/features/assistant/llm_generator.py):
+   - prompt construction isolated from transport details
+   - model invocation isolated behind provider/model adapter
+   - response validation isolated from provider client
+   - persistence and API response assembly isolated from generation path
+5. Prefer existing OpenAI-compatible path if Ollama works cleanly through current `pydantic_ai` structured output flow; otherwise add smallest Ollama-specific adapter branch needed without hardcoding Gemma 4 tags into invocation logic.
+6. Preserve structured output contract for summaries:
+   - response shape defined in Pydantic schema
+   - JSON/schema validation applied before persistence or API success response
+   - invalid or incomplete model output triggers deterministic fallback
+7. Keep summaries source-grounded:
+   - use only SimBoard metadata and small curated context supplied by backend
+   - when retrieved or injected context is used, include explicit citation/source fields tied to allowed source paths
+   - reject unsupported free-form claims through validation and fallback path
+8. Keep API shape stable except for extending `generation_provider` to allow `ollama`, and update [frontend/src/types/simulation.ts](/Users/vo13/Repositories/tomvothecoder/simboard/frontend/src/types/simulation.ts) to match.
+9. Update docs and examples in:
+   - [.envs/example/backend.env.example](/Users/vo13/Repositories/tomvothecoder/simboard/.envs/example/backend.env.example)
+   - [.envs/example/backend.production.env.example](/Users/vo13/Repositories/tomvothecoder/simboard/.envs/example/backend.production.env.example)
+   - [backend/README.md](/Users/vo13/Repositories/tomvothecoder/simboard/backend/README.md)
+   - [docs/developer/README.md](/Users/vo13/Repositories/tomvothecoder/simboard/docs/developer/README.md)
+   - document one supported local Ollama bootstrap path using upstream Ollama install/container guidance plus `gemma4:e4b` and `gemma4:26b` pull/run steps
+   - [docs/deploy/spin.md](/Users/vo13/Repositories/tomvothecoder/simboard/docs/deploy/spin.md) only if deployment env guidance should mention assistant vars
+
+## Retrieval constraints for this phase
+
+- No broad RAG rollout.
+- No vector DB requirement.
+- No automatic large-context corpus assembly.
+- If retrieval is used, keep it small, explicit, curated, and easy to inspect in tests and logs.
+
+## Tests
+
+### Tests to add or update
+
+- [backend/tests/core/test_config.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/core/test_config.py)
+  - Ollama env vars load and normalize correctly.
+  - `ASSISTANT_OLLAMA_MODEL` remains arbitrary string config, not hardcoded allowlist.
+  - Missing base URL or model yields stable misconfiguration behavior.
+- [backend/tests/features/assistant/test_orchestrator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/features/assistant/test_orchestrator.py)
+  - Ollama config resolves from env-backed settings.
+  - `gemma4:e4b` and `gemma4:26b` both resolve without code changes.
+  - Ollama misconfig falls back with stable reason.
+  - Ollama success reports `generation_provider == "ollama"` and configured model name.
+- [backend/tests/features/assistant/test_llm_generator.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/features/assistant/test_llm_generator.py)
+  - Client/model builder uses Ollama base URL correctly.
+  - Invocation path is model-agnostic and uses configured model name.
+  - Model settings remain compatible with Gemma 4 local behavior.
+  - Invalid model output fails validation safely.
+- [backend/tests/features/assistant/test_api.py](/Users/vo13/Repositories/tomvothecoder/simboard/backend/tests/features/assistant/test_api.py)
+  - Summary route returns deterministic fallback when Ollama path fails.
+  - Summary route returns `generation_provider == "ollama"` and configured model on success.
+  - Response shape stays grounded and does not emit unsupported free-form fields.
+
+### Commands to run
+
+- `make backend-test`
+- `make frontend-lint`
+- Optional focused loop:
+  - `uv run pytest backend/tests/core/test_config.py backend/tests/features/assistant/test_llm_generator.py backend/tests/features/assistant/test_orchestrator.py backend/tests/features/assistant/test_api.py`
+
+## Acceptance criteria
+
+- `ollama` is supported as assistant provider and is selectable entirely through config.
+- Gemma 4 is documented as recommended Ollama model family for this prototype.
+- Plan clearly distinguishes:
+  - `gemma4:e4b` for fast development and prompt-contract iteration
+  - `gemma4:26b` for preferred summary quality testing
+  - `gemma4:31b` as optional higher-cost fallback
+- Backend can call Ollama successfully using configured base URL and model name.
+- Backend remains model-agnostic at adapter boundary and is not hardcoded to one Gemma 4 tag.
+- Invalid JSON, schema-invalid output, or unsupported grounded fields trigger deterministic fallback rather than unsafe persistence or partial success.
+- Generated summaries remain source-grounded and use explicit citation/source fields when retrieved context is included.
+- `generation_provider` contract includes `ollama` and frontend type mirror stays in sync.
+- `gemma4:e4b` and `gemma4:26b` can both be exercised in tests or local verification without code changes.
+
+## Risk
+
+- Ollama structured output behavior may differ from current hosted-provider path.
+- Smaller Gemma 4 variants may pass format checks but underperform on grounded summary quality.
+- `gemma4:26b` may be too heavy for some developer hardware, so docs must make `gemma4:e4b` first-run path explicit.
+- If validation is too weak, local models may generate plausible but unsupported claims.
+- If validation is too strict, fallback churn may hide useful outputs during prototype iteration.
+
+## Open questions
+
+None.

--- a/docs/deploy/spin.md
+++ b/docs/deploy/spin.md
@@ -48,6 +48,19 @@ Environment variable keys:
 | `COOKIE_SAMESITE`            | Yes      | `lax`, `strict`, `none`                | `backend`, `migrate` |
 | `COOKIE_MAX_AGE`             | Yes      | seconds as integer                     | `backend`, `migrate` |
 
+Optional assistant summary keys for `simboard-backend-env` when enabling AI summaries:
+
+| Key                             | Required        | Example/Allowed Value     | Used By              |
+| ------------------------------- | --------------- | ------------------------- | -------------------- |
+| `ASSISTANT_LLM_ENABLED`         | No              | `true` or `false`         | `backend`, `migrate` |
+| `ASSISTANT_LLM_PROVIDER`        | No              | `ollama`                  | `backend`, `migrate` |
+| `ASSISTANT_OLLAMA_BASE_URL`     | If using Ollama | `http://localhost:11434`  | `backend`, `migrate` |
+| `ASSISTANT_OLLAMA_MODEL`        | If using Ollama | `gemma4:26b`              | `backend`, `migrate` |
+| `ASSISTANT_OLLAMA_API_KEY`      | No              | proxy auth token or blank | `backend`, `migrate` |
+| `ASSISTANT_LLM_TIMEOUT_SECONDS` | No              | `30`                      | `backend`, `migrate` |
+| `ASSISTANT_LLM_TEMPERATURE`     | No              | `0.2`                     | `backend`, `migrate` |
+| `ASSISTANT_LLM_MAX_TOKENS`      | No              | `2048`                    | `backend`, `migrate` |
+
 `simboard-db`:
 
 | Key                 | Required | Example/Allowed Value             | Used By |
@@ -80,14 +93,14 @@ Workloads -> Deployments -> Create (top-right)
 
 Create a PersistentVolumeClaim volume for Postgres data.
 
-| Rancher field                | Value                                                  |
-| ---------------------------- | ------------------------------------------------------ |
-| Volume type                  | `PersistentVolumeClaim`                                |
-| Volume name                  | `db-data` (or your naming standard)                    |
-| Persistent Volume Claim Name | `pvc-simboard-db` (or existing claim)                  |
-| Access mode                  | `Single-Node Read/Write`                               |
-| Capacity                     | `1Gi` minimum (or larger per policy)                   |
-| Storage class                | Namespace/default class (example: `nfs-client-vast`)   |
+| Rancher field                | Value                                                |
+| ---------------------------- | ---------------------------------------------------- |
+| Volume type                  | `PersistentVolumeClaim`                              |
+| Volume name                  | `db-data` (or your naming standard)                  |
+| Persistent Volume Claim Name | `pvc-simboard-db` (or existing claim)                |
+| Access mode                  | `Single-Node Read/Write`                             |
+| Capacity                     | `1Gi` minimum (or larger per policy)                 |
+| Storage class                | Namespace/default class (example: `nfs-client-vast`) |
 
 #### 3. Container tab (`db`)
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -61,61 +61,110 @@ For token-based ingestion and service-account details, see [docs/hpc_api_token_a
 
 ## Assistant LLM Env Setup
 
-If you want the simulation details page to use LLM-backed summaries instead of deterministic fallback, configure the assistant env values in `.envs/local/backend.env`.
+Configure `.envs/local/backend.env` to enable LLM-backed summaries on the simulation details page. If LLM support is disabled or misconfigured, the backend falls back to the deterministic metadata summary.
 
-Canonical assistant env names:
+### Required settings
 
-- `ASSISTANT_LLM_ENABLED`
-- `ASSISTANT_LLM_PROVIDER` with `openai`, `anthropic`, or `livai`
-- `ASSISTANT_OPENAI_API_KEY` / `ASSISTANT_OPENAI_MODEL`
-- `ASSISTANT_ANTHROPIC_API_KEY` / `ASSISTANT_ANTHROPIC_MODEL`
-- `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
-- `ASSISTANT_LLM_TEMPERATURE` default `0.2`
-- `ASSISTANT_LLM_MAX_TOKENS` default `2048`
+```env
+ASSISTANT_LLM_ENABLED=true
+ASSISTANT_LLM_PROVIDER=ollama  # ollama or livai
+```
 
-Recommended setup flow:
+Use exactly one provider and configure only that provider's env vars.
 
-1. Open `.envs/local/backend.env`.
-2. Set `ASSISTANT_LLM_ENABLED=true`.
-3. Choose exactly one provider in `ASSISTANT_LLM_PROVIDER`.
-4. Fill only that provider's required env vars.
-5. Restart the backend with `make backend-run`.
-6. Generate an AI Summary from the simulation details page and confirm it does not fall back to deterministic mode.
+### Local Ollama setup
 
-Recommended local default for this repo:
+Recommended local default:
+
+```env
+ASSISTANT_LLM_ENABLED=true
+ASSISTANT_LLM_PROVIDER=ollama
+ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434
+ASSISTANT_OLLAMA_MODEL=llama3.1:8b
+ASSISTANT_OLLAMA_API_KEY=
+ASSISTANT_LLM_TEMPERATURE=0.2
+ASSISTANT_LLM_MAX_TOKENS=256
+```
+
+`ASSISTANT_LLM_MAX_TOKENS=256` keeps local summaries concise on developer hardware. If unset, the backend runtime default is `2048`.
+
+Install and run Ollama:
+
+1. On macOS, install Ollama natively: https://docs.ollama.com/quickstart
+2. Pull a model:
+
+   ```bash
+   make ollama-pull-fast     # llama3.1:8b, faster local default
+   make ollama-pull-dev      # gemma4:e4b, prompt-contract iteration
+   make ollama-pull-quality  # gemma4:26b, quality checks
+   ```
+
+3. Start Ollama in a separate terminal:
+
+   ```bash
+   make ollama-serve
+   ```
+
+   This runs `ollama serve` with `OLLAMA_KEEP_ALIVE=-1`, so models stay loaded while the server is running.
+
+4. Restart the backend:
+
+   ```bash
+   make backend-run
+   ```
+
+Supported local model choices:
+
+- `llama3.1:8b`: faster local summaries on typical developer hardware
+- `gemma4:e4b`: fast prompt-contract iteration
+- `gemma4:26b`: preferred quality checks
+- `gemma4:31b`: only for hardware that can support it
+
+`ASSISTANT_OLLAMA_BASE_URL=http://localhost:11434` is accepted and normalized internally to Ollama's OpenAI-compatible `/v1` endpoint. Values that already include `/v1` also work.
+
+On macOS, native Ollama is recommended. Docker Desktop on macOS does not support Ollama GPU acceleration, so Docker-based Ollama is useful only for CPU-only portability testing.
+
+### LivAI setup
 
 ```env
 ASSISTANT_LLM_ENABLED=true
 ASSISTANT_LLM_PROVIDER=livai
 ASSISTANT_LIVAI_API_KEY=
-ASSISTANT_LIVAI_MODEL=
+ASSISTANT_LIVAI_MODEL=gpt-5.4
 ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
 ASSISTANT_LLM_TEMPERATURE=0.2
-ASSISTANT_LLM_MAX_TOKENS=2048
+ASSISTANT_LLM_MAX_TOKENS=8192
+ASSISTANT_SNAPSHOT_MAX_CHARS=12000
 ```
 
-Direct OpenAI setup:
+For LivAI, `ASSISTANT_LIVAI_API_KEY`, `ASSISTANT_LIVAI_MODEL`, and `ASSISTANT_LIVAI_BASE_URL` are required.
 
-```env
-ASSISTANT_LLM_ENABLED=true
-ASSISTANT_LLM_PROVIDER=openai
-ASSISTANT_OPENAI_API_KEY=
-ASSISTANT_OPENAI_MODEL=
-ASSISTANT_LLM_TEMPERATURE=0.2
-ASSISTANT_LLM_MAX_TOKENS=2048
+**Model selection:**
+
+- **Recommended:** `gpt-5.4` (full model) — reliable structured output completion, handles 8K+ token responses
+- **Avoid:** `gpt-5.4-mini` — may truncate structured responses before completing all required fields (`limitations`, `citations`, `suggested_followups`)
+
+**Token budget guidance:**
+
+- `ASSISTANT_LLM_MAX_TOKENS`: 4096-8192 for `gpt-5.4`; 2048 for mini models (if used despite limitations)
+- `ASSISTANT_SNAPSHOT_MAX_CHARS`: 12000-16000 balances detail vs token budget; reduce to 8000-10000 for mini models
+
+For current LivAI OpenAI-compatible chat endpoints, SimBoard omits `ASSISTANT_LLM_TEMPERATURE` for `gpt-5*` models because the endpoint rejects that parameter. `ASSISTANT_LLM_MAX_TOKENS` still applies.
+
+### Fallback troubleshooting
+
+After changing `.envs/local/backend.env`, restart the backend before testing again:
+
+```bash
+make backend-run
 ```
 
-If `ASSISTANT_LLM_ENABLED=false`, or the selected provider is misconfigured, the backend automatically returns the deterministic metadata summary instead of an LLM-generated one.
+Common fallback reasons:
 
-For LivAI, `ASSISTANT_LIVAI_API_KEY` and `ASSISTANT_LIVAI_BASE_URL` are the canonical names.
-For the current LivAI OpenAI-compatible chat endpoint, SimBoard omits `ASSISTANT_LLM_TEMPERATURE` for `gpt-5*` models because the endpoint rejects that parameter; `ASSISTANT_LLM_MAX_TOKENS` still applies.
+- `fallback_reason=ollama_misconfigured`: missing `ASSISTANT_OLLAMA_MODEL` or `ASSISTANT_OLLAMA_BASE_URL`
+- `fallback_reason=livai_misconfigured`: missing `ASSISTANT_LIVAI_API_KEY`, `ASSISTANT_LIVAI_MODEL`, or `ASSISTANT_LIVAI_BASE_URL`
 
-If summary generation still falls back:
-
-- `fallback_reason=openai_misconfigured` means the backend is still configured for `openai`, but `ASSISTANT_OPENAI_API_KEY` or `ASSISTANT_OPENAI_MODEL` is missing.
-- `fallback_reason=anthropic_misconfigured` means `ASSISTANT_ANTHROPIC_API_KEY` or `ASSISTANT_ANTHROPIC_MODEL` is missing.
-- `fallback_reason=livai_misconfigured` means `ASSISTANT_LIVAI_API_KEY`, `ASSISTANT_LIVAI_MODEL`, or `ASSISTANT_LIVAI_BASE_URL` is missing.
-- If you edit `.envs/local/backend.env`, restart `make backend-run` before testing again.
+For Ollama, `ASSISTANT_OLLAMA_API_KEY` is optional for local runs and can stay blank unless an auth proxy requires it.
 
 ## Architecture
 
@@ -197,10 +246,10 @@ After ingestion completes, the backend stores normalized cases, simulations, mac
 >
 > Referenced case directories under source archive locations are periodically cleaned up by scheduled site-side jobs outside of SimBoard to limit storage growth.
 
-| Site                 | Ingestion mode            | Source archive location                                                |
-| -------------------- | ------------------------- | ---------------------------------------------------------------------- |
-| NERSC / Perlmutter   | Path reference            | `/global/cfs/projectdirs/e3sm/performance_archive`                     |
-| LCRC / Chrysalis     | Archive upload            | `/lcrc/group/e3sm/PERF_Chrysalis/performance_archive`                  |
+| Site                 | Ingestion mode            | Source archive location                                                 |
+| -------------------- | ------------------------- | ----------------------------------------------------------------------- |
+| NERSC / Perlmutter   | Path reference            | `/global/cfs/projectdirs/e3sm/performance_archive`                      |
+| LCRC / Chrysalis     | Archive upload            | `/lcrc/group/e3sm/PERF_Chrysalis/performance_archive`                   |
 | Additional HPC sites | Archive upload by default | Site-specific `performance_archive` path, packaged by the ingestion job |
 
 ## Daily Workflow

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -59,6 +59,64 @@ make backend-create-admin
 
 For token-based ingestion and service-account details, see [docs/hpc_api_token_authentication.md](../hpc_api_token_authentication.md).
 
+## Assistant LLM Env Setup
+
+If you want the simulation details page to use LLM-backed summaries instead of deterministic fallback, configure the assistant env values in `.envs/local/backend.env`.
+
+Canonical assistant env names:
+
+- `ASSISTANT_LLM_ENABLED`
+- `ASSISTANT_LLM_PROVIDER` with `openai`, `anthropic`, or `livai`
+- `ASSISTANT_OPENAI_API_KEY` / `ASSISTANT_OPENAI_MODEL`
+- `ASSISTANT_ANTHROPIC_API_KEY` / `ASSISTANT_ANTHROPIC_MODEL`
+- `ASSISTANT_LIVAI_API_KEY` / `ASSISTANT_LIVAI_MODEL` / `ASSISTANT_LIVAI_BASE_URL`
+- `ASSISTANT_LLM_TEMPERATURE` default `0.2`
+- `ASSISTANT_LLM_MAX_TOKENS` default `2048`
+
+Recommended setup flow:
+
+1. Open `.envs/local/backend.env`.
+2. Set `ASSISTANT_LLM_ENABLED=true`.
+3. Choose exactly one provider in `ASSISTANT_LLM_PROVIDER`.
+4. Fill only that provider's required env vars.
+5. Restart the backend with `make backend-run`.
+6. Generate an AI Summary from the simulation details page and confirm it does not fall back to deterministic mode.
+
+Recommended local default for this repo:
+
+```env
+ASSISTANT_LLM_ENABLED=true
+ASSISTANT_LLM_PROVIDER=livai
+ASSISTANT_LIVAI_API_KEY=
+ASSISTANT_LIVAI_MODEL=
+ASSISTANT_LIVAI_BASE_URL=https://livai-api.llnl.gov/
+ASSISTANT_LLM_TEMPERATURE=0.2
+ASSISTANT_LLM_MAX_TOKENS=2048
+```
+
+Direct OpenAI setup:
+
+```env
+ASSISTANT_LLM_ENABLED=true
+ASSISTANT_LLM_PROVIDER=openai
+ASSISTANT_OPENAI_API_KEY=
+ASSISTANT_OPENAI_MODEL=
+ASSISTANT_LLM_TEMPERATURE=0.2
+ASSISTANT_LLM_MAX_TOKENS=2048
+```
+
+If `ASSISTANT_LLM_ENABLED=false`, or the selected provider is misconfigured, the backend automatically returns the deterministic metadata summary instead of an LLM-generated one.
+
+For LivAI, `ASSISTANT_LIVAI_API_KEY` and `ASSISTANT_LIVAI_BASE_URL` are the canonical names.
+For the current LivAI OpenAI-compatible chat endpoint, SimBoard omits `ASSISTANT_LLM_TEMPERATURE` for `gpt-5*` models because the endpoint rejects that parameter; `ASSISTANT_LLM_MAX_TOKENS` still applies.
+
+If summary generation still falls back:
+
+- `fallback_reason=openai_misconfigured` means the backend is still configured for `openai`, but `ASSISTANT_OPENAI_API_KEY` or `ASSISTANT_OPENAI_MODEL` is missing.
+- `fallback_reason=anthropic_misconfigured` means `ASSISTANT_ANTHROPIC_API_KEY` or `ASSISTANT_ANTHROPIC_MODEL` is missing.
+- `fallback_reason=livai_misconfigured` means `ASSISTANT_LIVAI_API_KEY`, `ASSISTANT_LIVAI_MODEL`, or `ASSISTANT_LIVAI_BASE_URL` is missing.
+- If you edit `.envs/local/backend.env`, restart `make backend-run` before testing again.
+
 ## Architecture
 
 SimBoard is a web application for cataloging and comparing E3SM simulation metadata. The full application (frontend, backend, and database) is hosted on NERSC Spin. Automated ingestion jobs running on HPC sites collect metadata from an E3SM performance archive and push it to SimBoard, where the backend normalizes it and the frontend lets researchers browse, compare, and analyze results.

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1467,8 +1467,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.8.16:
-    resolution: {integrity: sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==}
+  baseline-browser-mapping@2.10.31:
+    resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   binary-extensions@2.3.0:
@@ -1510,8 +1511,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001750:
-    resolution: {integrity: sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==}
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -4247,7 +4248,7 @@ snapshots:
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.26.3
-      caniuse-lite: 1.0.30001750
+      caniuse-lite: 1.0.30001793
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -4268,7 +4269,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.8.16: {}
+  baseline-browser-mapping@2.10.31: {}
 
   binary-extensions@2.3.0: {}
 
@@ -4287,8 +4288,8 @@ snapshots:
 
   browserslist@4.26.3:
     dependencies:
-      baseline-browser-mapping: 2.8.16
-      caniuse-lite: 1.0.30001750
+      baseline-browser-mapping: 2.10.31
+      caniuse-lite: 1.0.30001793
       electron-to-chromium: 1.5.237
       node-releases: 2.0.23
       update-browserslist-db: 1.1.3(browserslist@4.26.3)
@@ -4314,7 +4315,7 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001750: {}
+  caniuse-lite@1.0.30001793: {}
 
   chalk@4.1.2:
     dependencies:

--- a/frontend/src/features/simulations/SimulationDetailsPage.tsx
+++ b/frontend/src/features/simulations/SimulationDetailsPage.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 
+import { useAuth } from '@/auth/hooks/useAuth';
 import { resolvePaceExecution } from '@/features/simulations/api/api';
 import { SimulationDetailsView } from '@/features/simulations/components/SimulationDetailsView';
 import { useSimulation } from '@/features/simulations/hooks/useSimulation';
+import { useSimulationSummary } from '@/features/simulations/hooks/useSimulationSummary';
 
 export const SimulationDetailsPage = () => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const { data: simulation, loading, error } = useSimulation(id ?? '');
+  const { isAuthenticated, loading: authLoading, loginWithGithub } = useAuth();
+  const summary = useSimulationSummary(id ?? '');
   const [paceExperimentId, setPaceExperimentId] = useState<string | null>(null);
   const [isResolvingPace, setIsResolvingPace] = useState(false);
   const [paceResolutionAttempted, setPaceResolutionAttempted] = useState(false);
@@ -114,6 +118,14 @@ export const SimulationDetailsPage = () => {
       paceLink={paceLink}
       isResolvingPace={isResolvingPace}
       showPaceFallbackInfo={paceResolutionAttempted && !paceExperimentId}
+      summary={summary.data}
+      summaryLoading={summary.loading}
+      summaryError={summary.error}
+      summaryRequested={summary.requested}
+      onGenerateSummary={summary.generate}
+      canGenerateSummary={isAuthenticated}
+      isCheckingAuth={authLoading}
+      onLoginForSummary={loginWithGithub}
     />
   );
 };

--- a/frontend/src/features/simulations/SimulationDetailsPage.tsx
+++ b/frontend/src/features/simulations/SimulationDetailsPage.tsx
@@ -122,6 +122,8 @@ export const SimulationDetailsPage = () => {
       summaryLoading={summary.loading}
       summaryError={summary.error}
       summaryRequested={summary.requested}
+      summaryElapsedMs={summary.elapsedMs}
+      summaryLastDurationMs={summary.lastDurationMs}
       onGenerateSummary={summary.generate}
       canGenerateSummary={isAuthenticated}
       isCheckingAuth={authLoading}

--- a/frontend/src/features/simulations/api/api.ts
+++ b/frontend/src/features/simulations/api/api.ts
@@ -1,5 +1,10 @@
 import { api } from '@/api/api';
-import type { CaseOut, SimulationCreate, SimulationOut } from '@/types';
+import type {
+  CaseOut,
+  SimulationCreate,
+  SimulationOut,
+  SimulationSummaryResponseOut,
+} from '@/types';
 
 export const SIMULATIONS_URL = '/simulations';
 export const CASES_URL = '/cases';
@@ -28,6 +33,14 @@ export const getSimulationById = async (id: string): Promise<SimulationOut> => {
   const res = await api.get<SimulationOut>(`${SIMULATIONS_URL}/${id}`, {
     headers: { 'Cache-Control': 'no-cache' },
   });
+
+  return res.data;
+};
+
+export const generateSimulationSummary = async (
+  id: string,
+): Promise<SimulationSummaryResponseOut> => {
+  const res = await api.post<SimulationSummaryResponseOut>(`${SIMULATIONS_URL}/${id}/summary`);
 
   return res.data;
 };

--- a/frontend/src/features/simulations/api/api.ts
+++ b/frontend/src/features/simulations/api/api.ts
@@ -9,6 +9,7 @@ import type {
 export const SIMULATIONS_URL = '/simulations';
 export const CASES_URL = '/cases';
 export const PACE_URL = '/pace';
+const SUMMARY_REQUEST_TIMEOUT_MS = 120_000;
 
 export interface PaceResolutionOut {
   executionId: string;
@@ -40,7 +41,11 @@ export const getSimulationById = async (id: string): Promise<SimulationOut> => {
 export const generateSimulationSummary = async (
   id: string,
 ): Promise<SimulationSummaryResponseOut> => {
-  const res = await api.post<SimulationSummaryResponseOut>(`${SIMULATIONS_URL}/${id}/summary`);
+  const res = await api.post<SimulationSummaryResponseOut>(
+    `${SIMULATIONS_URL}/${id}/summary`,
+    undefined,
+    { timeout: SUMMARY_REQUEST_TIMEOUT_MS },
+  );
 
   return res.data;
 };

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -41,6 +41,8 @@ interface SimulationDetailsViewProps {
   summaryLoading?: boolean;
   summaryError?: string | null;
   summaryRequested?: boolean;
+  summaryElapsedMs?: number;
+  summaryLastDurationMs?: number | null;
   onGenerateSummary?: () => void | Promise<void>;
   canGenerateSummary?: boolean;
   isCheckingAuth?: boolean;
@@ -115,6 +117,8 @@ export const SimulationDetailsView = ({
   summaryLoading = false,
   summaryError = null,
   summaryRequested = false,
+  summaryElapsedMs = 0,
+  summaryLastDurationMs = null,
   onGenerateSummary,
   canGenerateSummary = false,
   isCheckingAuth = false,
@@ -235,6 +239,8 @@ export const SimulationDetailsView = ({
               summaryLoading={summaryLoading}
               summaryError={summaryError}
               summaryRequested={summaryRequested}
+              summaryElapsedMs={summaryElapsedMs}
+              summaryLastDurationMs={summaryLastDurationMs}
               onGenerateSummary={onGenerateSummary}
               canGenerateSummary={canGenerateSummary}
               isCheckingAuth={isCheckingAuth}
@@ -882,6 +888,8 @@ export const SimulationDetailsView = ({
                   summaryLoading={summaryLoading}
                   summaryError={summaryError}
                   summaryRequested={summaryRequested}
+                  summaryElapsedMs={summaryElapsedMs}
+                  summaryLastDurationMs={summaryLastDurationMs}
                   onGenerateSummary={onGenerateSummary}
                   canGenerateSummary={canGenerateSummary}
                   isCheckingAuth={isCheckingAuth}

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -15,9 +15,13 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { SimulationPathCard } from '@/features/simulations/components/SimulationPathCard';
+import {
+  SimulationSummaryLauncher,
+  SimulationSummaryRail,
+} from '@/features/simulations/components/SimulationSummaryPanel';
 import { SimulationTypeBadge } from '@/features/simulations/components/SimulationTypeBadge';
 import { cn } from '@/lib/utils';
-import type { SimulationOut } from '@/types';
+import type { SimulationOut, SimulationSummaryResponseOut } from '@/types';
 import { getArtifactsByKind } from '@/types/artifact';
 import { formatDate, getSimulationDuration } from '@/utils/utils';
 
@@ -33,6 +37,14 @@ interface SimulationDetailsViewProps {
   } | null;
   isResolvingPace?: boolean;
   showPaceFallbackInfo?: boolean;
+  summary?: SimulationSummaryResponseOut | null;
+  summaryLoading?: boolean;
+  summaryError?: string | null;
+  summaryRequested?: boolean;
+  onGenerateSummary?: () => void | Promise<void>;
+  canGenerateSummary?: boolean;
+  isCheckingAuth?: boolean;
+  onLoginForSummary?: () => void;
 }
 
 // -------------------- Small UI helpers --------------------
@@ -99,6 +111,14 @@ export const SimulationDetailsView = ({
   paceLink = null,
   isResolvingPace = false,
   showPaceFallbackInfo = false,
+  summary = null,
+  summaryLoading = false,
+  summaryError = null,
+  summaryRequested = false,
+  onGenerateSummary,
+  canGenerateSummary = false,
+  isCheckingAuth = false,
+  onLoginForSummary,
 }: SimulationDetailsViewProps) => {
   const [activeTab, setActiveTab] = useState('summary');
   const [isAdvancedMetadataOpen, setIsAdvancedMetadataOpen] = useState(false);
@@ -165,7 +185,7 @@ export const SimulationDetailsView = ({
   };
 
   return (
-    <div className="mx-auto w-full max-w-[1200px] px-6 py-8 space-y-6">
+    <div className="mx-auto w-full max-w-[1400px] space-y-6 px-6 py-8">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
@@ -209,615 +229,664 @@ export const SimulationDetailsView = ({
 
         {/* SUMMARY TAB */}
         <TabsContent value="summary" className="space-y-6">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">Configuration</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <FieldRow label="Case Name">
-                  <ReadonlyInput value={simulation.caseName} />
-                </FieldRow>
-                {simulation.caseGroup && (
-                  <FieldRow label="Case Group">
-                    <ReadonlyInput value={simulation.caseGroup} />
-                  </FieldRow>
-                )}
-                <FieldRow label="Reference">
-                  <span className="text-sm">{simulation.isReference ? 'Yes' : 'No'}</span>
-                </FieldRow>
-                {!simulation.isReference && (
-                  <FieldRow label="Changes vs reference">
-                    <span className="text-sm">{simulation.changeCount}</span>
-                  </FieldRow>
-                )}
-                <FieldRow label="Model Version">
-                  <ReadonlyInput value={simulation.gitTag ?? undefined} />
-                </FieldRow>
-                <FieldRow label="Compset">
-                  <ReadonlyInput value={simulation.compset ?? undefined} />
-                </FieldRow>
-                <FieldRow label="Compset Alias">
-                  <ReadonlyInput value={simulation.compsetAlias ?? undefined} />
-                </FieldRow>
-                <FieldRow label="Grid Name">
-                  <ReadonlyInput value={simulation.gridName ?? undefined} />
-                </FieldRow>
-                <FieldRow label="Grid Resolution">
-                  <ReadonlyInput value={simulation.gridResolution ?? undefined} />
-                </FieldRow>
-                <FieldRow label="Initialization Type">
-                  <ReadonlyInput value={simulation.initializationType ?? undefined} />
-                </FieldRow>
-                <FieldRow label="Compiler">
-                  <ReadonlyInput value={simulation.compiler ?? undefined} />
-                </FieldRow>
-                {simulation.description && (
-                  <div className="pt-2">
-                    <Label className="text-xs text-muted-foreground mb-1 block">Description</Label>
-                    <ReadonlyTextBlock value={simulation.description} />
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">Model Setup</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <FieldRow label="Simulation Type">
-                  <ReadonlyInput value={simulation.simulationType} />
-                </FieldRow>
-                <FieldRow label="Status">
-                  <ReadonlyInput value={simulation.status} />
-                </FieldRow>
-                <FieldRow label="Campaign ID">
-                  <ReadonlyInput value={simulation.campaign} />
-                </FieldRow>
-                <FieldRow label="Experiment Type ID">
-                  <ReadonlyInput value={simulation.experimentType} />
-                </FieldRow>
-                <FieldRow label="Machine">
-                  <ReadonlyInput value={simulation.machine.name} />
-                </FieldRow>
-              </CardContent>
-            </Card>
+          <div className="xl:hidden">
+            <SimulationSummaryLauncher
+              summary={summary}
+              summaryLoading={summaryLoading}
+              summaryError={summaryError}
+              summaryRequested={summaryRequested}
+              onGenerateSummary={onGenerateSummary}
+              canGenerateSummary={canGenerateSummary}
+              isCheckingAuth={isCheckingAuth}
+              onLoginForSummary={onLoginForSummary}
+            />
           </div>
 
-          {/* Config diff section for non-reference simulations */}
-          {!simulation.isReference && (
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">Configuration Differences</CardTitle>
-              </CardHeader>
-              <CardContent>
-                {simulation.runConfigDeltas &&
-                Object.keys(simulation.runConfigDeltas).length > 0 ? (
-                  <div className="overflow-hidden rounded-md border">
-                    <table className="w-full table-fixed text-sm">
-                      <thead>
-                        <tr className="border-b bg-muted/50">
-                          <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                            Field
-                          </th>
-                          <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                            Reference
-                          </th>
-                          <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                            Current
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {Object.entries(simulation.runConfigDeltas).map(([field, diff]) => {
-                          const reference = (diff as Record<string, unknown>).reference;
-                          const current = (diff as Record<string, unknown>).current;
-                          return (
-                            <tr key={field} className="border-b last:border-0">
-                              <td className="p-2 align-top">
-                                <DiffCell
-                                  value={field}
-                                  className="max-w-[180px] font-mono text-xs text-muted-foreground"
-                                />
-                              </td>
-                              <td className="p-2 align-top">
-                                <DiffCell value={reference} className="max-w-[240px]" />
-                              </td>
-                              <td className="p-2 align-top">
-                                <DiffCell value={current} className="max-w-[240px]" />
-                              </td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
-                ) : (
-                  <p className="text-sm text-muted-foreground">No configuration differences.</p>
-                )}
-              </CardContent>
-            </Card>
-          )}
-
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">Timeline</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                <FieldRow label="Simulation Start Date">
-                  <span className="text-sm">
-                    {simulation.simulationStartDate
-                      ? formatDate(simulation.simulationStartDate)
-                      : '—'}
-                  </span>
-                </FieldRow>
-                <FieldRow label="Simulation End Date">
-                  <span className="text-sm">
-                    {simulation.simulationEndDate ? formatDate(simulation.simulationEndDate) : '—'}
-                  </span>
-                </FieldRow>
-                <FieldRow label="Total Duration">
-                  <span className="text-sm">
-                    {simulation.simulationStartDate && simulation.simulationEndDate
-                      ? (() => {
-                          return getSimulationDuration(
-                            simulation.simulationStartDate,
-                            simulation.simulationEndDate,
-                          );
-                        })()
-                      : '—'}
-                  </span>
-                </FieldRow>
-                {simulation.runStartDate && (
-                  <FieldRow label="Run Start Date">
-                    <span className="text-sm">{formatDate(simulation.runStartDate)}</span>
-                  </FieldRow>
-                )}
-                {simulation.runEndDate && (
-                  <FieldRow label="Run End Date">
-                    <span className="text-sm">{formatDate(simulation.runEndDate)}</span>
-                  </FieldRow>
-                )}
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">Provenance</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">Created:</Label>
-                  <span className="text-sm">
-                    {simulation.createdAt ? formatDate(simulation.createdAt) : '—'}
-                  </span>
-                  <UserDisplay user={simulation.createdByUser} fallbackId={simulation.createdBy} />
-                </div>
-                {/* Last edited row */}
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">
-                    Last edited:
-                  </Label>
-                  <span className="text-sm">
-                    {simulation.updatedAt ? formatDate(simulation.updatedAt) : '—'}
-                  </span>
-                  <UserDisplay
-                    user={simulation.lastUpdatedByUser}
-                    fallbackId={simulation.lastUpdatedBy}
-                  />
-                </div>
-                {/* Simulation UUID row */}
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">
-                    Simulation UUID:
-                  </Label>
-                  <ReadonlyInput
-                    value={
-                      simulation.id
-                        ? `${simulation.id.slice(0, 8)}…${simulation.id.slice(-6)}`
-                        : undefined
-                    }
-                  />
-                  {simulation.id && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      type="button"
-                      onClick={() => navigator.clipboard.writeText(simulation.id)}
-                      title="Copy full Simulation ID"
-                    >
-                      Copy
-                    </Button>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">Case ID:</Label>
-                  <ReadonlyInput
-                    value={
-                      simulation.caseId
-                        ? `${simulation.caseId.slice(0, 8)}…${simulation.caseId.slice(-6)}`
-                        : undefined
-                    }
-                  />
-                  {simulation.caseId && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      type="button"
-                      onClick={() => navigator.clipboard.writeText(simulation.caseId)}
-                      title="Copy full Case ID"
-                    >
-                      Copy
-                    </Button>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">Machine ID:</Label>
-                  <ReadonlyInput
-                    value={
-                      simulation.machineId
-                        ? `${simulation.machineId.slice(0, 8)}…${simulation.machineId.slice(-6)}`
-                        : undefined
-                    }
-                  />
-                  {simulation.machineId && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      type="button"
-                      onClick={() => navigator.clipboard.writeText(simulation.machineId)}
-                      title="Copy full Machine ID"
-                    >
-                      Copy
-                    </Button>
-                  )}
-                </div>
-
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">
-                    Git Repository:
-                  </Label>
-                  {simulation.gitRepositoryUrl ? (
-                    <a
-                      href={simulation.gitRepositoryUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm text-blue-600 hover:underline"
-                    >
-                      {simulation.gitRepositoryUrl}
-                    </a>
-                  ) : (
-                    <p className="text-sm">—</p>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">Git Branch:</Label>
-                  <p className="text-sm">{simulation.gitBranch ?? '—'}</p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">Git Tag:</Label>
-                  <p className="text-sm">{simulation.gitTag ?? '—'}</p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">
-                    Git Commit Hash:
-                  </Label>
-                  <p className="text-sm">{simulation.gitCommitHash ?? '—'}</p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[100px]">
-                    HPC Username:
-                  </Label>
-                  <p className="text-sm">{simulation.hpcUsername ?? '—'}</p>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Scientific Metadata */}
-          {(simulation.keyFeatures || simulation.knownIssues) && (
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">Scientific Metadata</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {simulation.keyFeatures && (
-                  <div>
-                    <Label className="text-xs text-muted-foreground mb-1 block">Key Features</Label>
-                    <ReadonlyTextBlock value={simulation.keyFeatures} />
-                  </div>
-                )}
-                {simulation.knownIssues && (
-                  <div>
-                    <Label className="text-xs text-muted-foreground mb-1 block">Known Issues</Label>
-                    <ReadonlyTextBlock value={simulation.knownIssues} />
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Advanced Metadata (Collapsible) */}
-          {simulation.extra && Object.keys(simulation.extra).length > 0 && (
-            <Collapsible open={isAdvancedMetadataOpen} onOpenChange={setIsAdvancedMetadataOpen}>
-              <Card>
-                <CardHeader className="pb-2">
-                  <CollapsibleTrigger className="flex w-full items-center justify-between [&[data-state=open]>svg]:rotate-180">
-                    <CardTitle className="text-base">Advanced Metadata</CardTitle>
-                    <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform duration-200" />
-                  </CollapsibleTrigger>
-                </CardHeader>
-                <CollapsibleContent>
-                  <CardContent>
-                    {isAdvancedMetadataOpen && (
-                      <pre className="max-h-[400px] overflow-auto rounded-md bg-muted p-4 text-xs">
-                        {JSON.stringify(simulation.extra, null, 2)}
-                      </pre>
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px] xl:items-start">
+            <div className="space-y-6">
+              <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">Configuration</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <FieldRow label="Case Name">
+                      <ReadonlyInput value={simulation.caseName} />
+                    </FieldRow>
+                    {simulation.caseGroup && (
+                      <FieldRow label="Case Group">
+                        <ReadonlyInput value={simulation.caseGroup} />
+                      </FieldRow>
+                    )}
+                    <FieldRow label="Reference">
+                      <span className="text-sm">{simulation.isReference ? 'Yes' : 'No'}</span>
+                    </FieldRow>
+                    {!simulation.isReference && (
+                      <FieldRow label="Changes vs reference">
+                        <span className="text-sm">{simulation.changeCount}</span>
+                      </FieldRow>
+                    )}
+                    <FieldRow label="Model Version">
+                      <ReadonlyInput value={simulation.gitTag ?? undefined} />
+                    </FieldRow>
+                    <FieldRow label="Compset">
+                      <ReadonlyInput value={simulation.compset ?? undefined} />
+                    </FieldRow>
+                    <FieldRow label="Compset Alias">
+                      <ReadonlyInput value={simulation.compsetAlias ?? undefined} />
+                    </FieldRow>
+                    <FieldRow label="Grid Name">
+                      <ReadonlyInput value={simulation.gridName ?? undefined} />
+                    </FieldRow>
+                    <FieldRow label="Grid Resolution">
+                      <ReadonlyInput value={simulation.gridResolution ?? undefined} />
+                    </FieldRow>
+                    <FieldRow label="Initialization Type">
+                      <ReadonlyInput value={simulation.initializationType ?? undefined} />
+                    </FieldRow>
+                    <FieldRow label="Compiler">
+                      <ReadonlyInput value={simulation.compiler ?? undefined} />
+                    </FieldRow>
+                    {simulation.description && (
+                      <div className="pt-2">
+                        <Label className="mb-1 block text-xs text-muted-foreground">
+                          Description
+                        </Label>
+                        <ReadonlyTextBlock value={simulation.description} />
+                      </div>
                     )}
                   </CardContent>
-                </CollapsibleContent>
-              </Card>
-            </Collapsible>
-          )}
+                </Card>
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">Model Setup</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <FieldRow label="Simulation Type">
+                      <ReadonlyInput value={simulation.simulationType} />
+                    </FieldRow>
+                    <FieldRow label="Status">
+                      <ReadonlyInput value={simulation.status} />
+                    </FieldRow>
+                    <FieldRow label="Campaign ID">
+                      <ReadonlyInput value={simulation.campaign} />
+                    </FieldRow>
+                    <FieldRow label="Experiment Type ID">
+                      <ReadonlyInput value={simulation.experimentType} />
+                    </FieldRow>
+                    <FieldRow label="Machine">
+                      <ReadonlyInput value={simulation.machine.name} />
+                    </FieldRow>
+                  </CardContent>
+                </Card>
+              </div>
 
-          <Card className="lg:col-span-2">
-            <CardHeader className="pb-2">
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-base">External Resources</CardTitle>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <Label className="mb-1 block text-sm">Diagnostics</Label>
-                  {simulation.groupedLinks.diagnostic?.length ? (
-                    <ul className="list-disc pl-5 text-sm">
-                      {simulation.groupedLinks.diagnostic.map((d) => (
-                        <li key={d.url} className="flex items-center gap-2">
-                          <a
-                            className="text-blue-600 hover:underline flex items-center gap-1"
-                            href={d.url}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              width="16"
-                              height="16"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              className="inline-block"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
-                              />
-                            </svg>
-                            {d.label}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <div className="mb-2 text-sm text-muted-foreground">
-                      Links to diagnostics will appear here once available.
+              {!simulation.isReference && (
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">Configuration Differences</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    {simulation.runConfigDeltas &&
+                    Object.keys(simulation.runConfigDeltas).length > 0 ? (
+                      <div className="overflow-hidden rounded-md border">
+                        <table className="w-full table-fixed text-sm">
+                          <thead>
+                            <tr className="border-b bg-muted/50">
+                              <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Field
+                              </th>
+                              <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Reference
+                              </th>
+                              <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Current
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {Object.entries(simulation.runConfigDeltas).map(([field, diff]) => {
+                              const reference = (diff as Record<string, unknown>).reference;
+                              const current = (diff as Record<string, unknown>).current;
+                              return (
+                                <tr key={field} className="border-b last:border-0">
+                                  <td className="p-2 align-top">
+                                    <DiffCell
+                                      value={field}
+                                      className="max-w-[180px] font-mono text-xs text-muted-foreground"
+                                    />
+                                  </td>
+                                  <td className="p-2 align-top">
+                                    <DiffCell value={reference} className="max-w-[240px]" />
+                                  </td>
+                                  <td className="p-2 align-top">
+                                    <DiffCell value={current} className="max-w-[240px]" />
+                                  </td>
+                                </tr>
+                              );
+                            })}
+                          </tbody>
+                        </table>
+                      </div>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">No configuration differences.</p>
+                    )}
+                  </CardContent>
+                </Card>
+              )}
+
+              <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">Timeline</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-2">
+                    <FieldRow label="Simulation Start Date">
+                      <span className="text-sm">
+                        {simulation.simulationStartDate
+                          ? formatDate(simulation.simulationStartDate)
+                          : '—'}
+                      </span>
+                    </FieldRow>
+                    <FieldRow label="Simulation End Date">
+                      <span className="text-sm">
+                        {simulation.simulationEndDate
+                          ? formatDate(simulation.simulationEndDate)
+                          : '—'}
+                      </span>
+                    </FieldRow>
+                    <FieldRow label="Total Duration">
+                      <span className="text-sm">
+                        {simulation.simulationStartDate && simulation.simulationEndDate
+                          ? getSimulationDuration(
+                              simulation.simulationStartDate,
+                              simulation.simulationEndDate,
+                            )
+                          : '—'}
+                      </span>
+                    </FieldRow>
+                    {simulation.runStartDate && (
+                      <FieldRow label="Run Start Date">
+                        <span className="text-sm">{formatDate(simulation.runStartDate)}</span>
+                      </FieldRow>
+                    )}
+                    {simulation.runEndDate && (
+                      <FieldRow label="Run End Date">
+                        <span className="text-sm">{formatDate(simulation.runEndDate)}</span>
+                      </FieldRow>
+                    )}
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">Provenance</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Label className="min-w-[100px] text-xs text-muted-foreground">
+                        Created:
+                      </Label>
+                      <span className="text-sm">
+                        {simulation.createdAt ? formatDate(simulation.createdAt) : '—'}
+                      </span>
+                      <UserDisplay
+                        user={simulation.createdByUser}
+                        fallbackId={simulation.createdBy}
+                      />
                     </div>
-                  )}
-                </div>
-                <div>
-                  <Label className="mb-1 block text-sm">Performance</Label>
-                  {performanceLinks.length || paceLink ? (
-                    <ul className="list-disc pl-5 text-sm">
-                      {performanceLinks.map((p) => (
-                        <li key={p.url} className="flex items-center gap-2">
-                          <a
-                            className="text-blue-600 hover:underline flex items-center gap-1"
-                            href={p.url}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              width="16"
-                              height="16"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              className="inline-block"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
-                              />
-                            </svg>
-                            {p.label}
-                          </a>
-                        </li>
-                      ))}
-                      {paceLink && (
-                        <li className="flex items-center gap-2">
-                          <a
-                            className="text-blue-600 hover:underline flex items-center gap-1"
-                            href={paceLink.href}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              width="16"
-                              height="16"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              className="inline-block"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
-                              />
-                            </svg>
-                            {paceLink.label}
-                          </a>
-                          {isResolvingPace && (
-                            <>
-                              <Spinner className="size-3 text-muted-foreground" />
-                              <TooltipProvider delayDuration={150}>
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <button
-                                      type="button"
-                                      aria-label="PACE link resolution status"
-                                      className="text-muted-foreground hover:text-foreground"
-                                    >
-                                      <CircleHelp className="size-3" />
-                                    </button>
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    Checking for a direct PACE experiment link
-                                  </TooltipContent>
-                                </Tooltip>
-                              </TooltipProvider>
-                            </>
-                          )}
-                          {!isResolvingPace && showPaceFallbackInfo && (
-                            <TooltipProvider delayDuration={150}>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <button
-                                    type="button"
-                                    aria-label="PACE link fallback information"
-                                    className="text-muted-foreground hover:text-foreground"
-                                  >
-                                    <CircleHelp className="size-3" />
-                                  </button>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  Direct PACE experiment link not found. Search results may still
-                                  contain this run.
-                                </TooltipContent>
-                              </Tooltip>
-                            </TooltipProvider>
-                          )}
-                        </li>
+                    <div className="flex items-center gap-2">
+                      <Label className="min-w-[100px] text-xs text-muted-foreground">
+                        Last edited:
+                      </Label>
+                      <span className="text-sm">
+                        {simulation.updatedAt ? formatDate(simulation.updatedAt) : '—'}
+                      </span>
+                      <UserDisplay
+                        user={simulation.lastUpdatedByUser}
+                        fallbackId={simulation.lastUpdatedBy}
+                      />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Label className="min-w-[100px] text-xs text-muted-foreground">
+                        Simulation UUID:
+                      </Label>
+                      <ReadonlyInput
+                        value={
+                          simulation.id
+                            ? `${simulation.id.slice(0, 8)}…${simulation.id.slice(-6)}`
+                            : undefined
+                        }
+                      />
+                      {simulation.id && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          type="button"
+                          onClick={() => navigator.clipboard.writeText(simulation.id)}
+                          title="Copy full Simulation ID"
+                        >
+                          Copy
+                        </Button>
                       )}
-                    </ul>
-                  ) : (
-                    <div className="mb-2 text-sm text-muted-foreground">
-                      Links to performance metrics will appear here once available.
                     </div>
-                  )}
-                </div>
+                    <div className="flex items-center gap-2">
+                      <Label className="min-w-[100px] text-xs text-muted-foreground">
+                        Case ID:
+                      </Label>
+                      <ReadonlyInput
+                        value={
+                          simulation.caseId
+                            ? `${simulation.caseId.slice(0, 8)}…${simulation.caseId.slice(-6)}`
+                            : undefined
+                        }
+                      />
+                      {simulation.caseId && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          type="button"
+                          onClick={() => navigator.clipboard.writeText(simulation.caseId)}
+                          title="Copy full Case ID"
+                        >
+                          Copy
+                        </Button>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Label className="min-w-[100px] text-xs text-muted-foreground">
+                        Machine ID:
+                      </Label>
+                      <ReadonlyInput
+                        value={
+                          simulation.machineId
+                            ? `${simulation.machineId.slice(0, 8)}…${simulation.machineId.slice(-6)}`
+                            : undefined
+                        }
+                      />
+                      {simulation.machineId && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          type="button"
+                          onClick={() => navigator.clipboard.writeText(simulation.machineId)}
+                          title="Copy full Machine ID"
+                        >
+                          Copy
+                        </Button>
+                      )}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <Label className="min-w-[100px] text-xs text-muted-foreground">
+                        Git Repository:
+                      </Label>
+                      {simulation.gitRepositoryUrl ? (
+                        <a
+                          href={simulation.gitRepositoryUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sm text-blue-600 hover:underline"
+                        >
+                          {simulation.gitRepositoryUrl}
+                        </a>
+                      ) : (
+                        <p className="text-sm">—</p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Label className="min-w-[100px] text-xs text-muted-foreground">
+                        Git Branch:
+                      </Label>
+                      <p className="text-sm">{simulation.gitBranch ?? '—'}</p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Label className="min-w-[100px] text-xs text-muted-foreground">
+                        Git Tag:
+                      </Label>
+                      <p className="text-sm">{simulation.gitTag ?? '—'}</p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Label className="min-w-[100px] text-xs text-muted-foreground">
+                        Git Commit Hash:
+                      </Label>
+                      <p className="text-sm">{simulation.gitCommitHash ?? '—'}</p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Label className="min-w-[100px] text-xs text-muted-foreground">
+                        HPC Username:
+                      </Label>
+                      <p className="text-sm">{simulation.hpcUsername ?? '—'}</p>
+                    </div>
+                  </CardContent>
+                </Card>
               </div>
-              <div>
-                {Object.entries(simulation.groupedLinks)
-                  .filter(([key]) => key !== 'diagnostic' && key !== 'performance')
-                  .map(([key, linkList]) => (
-                    <div key={key} className="mb-4">
-                      <h4 className="text-sm font-medium capitalize">{key}</h4>
-                      <ul className="list-disc pl-5 text-sm">
-                        {linkList.map((link) => (
-                          <li key={link.url} className="flex items-center gap-2">
-                            <a
-                              className="text-blue-600 hover:underline flex items-center gap-1"
-                              href={link.url}
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                width="16"
-                                height="16"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                className="inline-block"
+
+              {(simulation.keyFeatures || simulation.knownIssues) && (
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">Scientific Metadata</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    {simulation.keyFeatures && (
+                      <div>
+                        <Label className="mb-1 block text-xs text-muted-foreground">
+                          Key Features
+                        </Label>
+                        <ReadonlyTextBlock value={simulation.keyFeatures} />
+                      </div>
+                    )}
+                    {simulation.knownIssues && (
+                      <div>
+                        <Label className="mb-1 block text-xs text-muted-foreground">
+                          Known Issues
+                        </Label>
+                        <ReadonlyTextBlock value={simulation.knownIssues} />
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              )}
+
+              {simulation.extra && Object.keys(simulation.extra).length > 0 && (
+                <Collapsible open={isAdvancedMetadataOpen} onOpenChange={setIsAdvancedMetadataOpen}>
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CollapsibleTrigger className="flex w-full items-center justify-between [&[data-state=open]>svg]:rotate-180">
+                        <CardTitle className="text-base">Advanced Metadata</CardTitle>
+                        <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform duration-200" />
+                      </CollapsibleTrigger>
+                    </CardHeader>
+                    <CollapsibleContent>
+                      <CardContent>
+                        {isAdvancedMetadataOpen && (
+                          <pre className="max-h-[400px] overflow-auto rounded-md bg-muted p-4 text-xs">
+                            {JSON.stringify(simulation.extra, null, 2)}
+                          </pre>
+                        )}
+                      </CardContent>
+                    </CollapsibleContent>
+                  </Card>
+                </Collapsible>
+              )}
+
+              <Card>
+                <CardHeader className="pb-2">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-base">External Resources</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                    <div>
+                      <Label className="mb-1 block text-sm">Diagnostics</Label>
+                      {simulation.groupedLinks.diagnostic?.length ? (
+                        <ul className="list-disc pl-5 text-sm">
+                          {simulation.groupedLinks.diagnostic.map((d) => (
+                            <li key={d.url} className="flex items-center gap-2">
+                              <a
+                                className="flex items-center gap-1 text-blue-600 hover:underline"
+                                href={d.url}
+                                target="_blank"
+                                rel="noreferrer"
                               >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth={2}
-                                  d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
-                                />
-                              </svg>
-                              {link.label}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  width="16"
+                                  height="16"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  className="inline-block"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
+                                  />
+                                </svg>
+                                {d.label}
+                              </a>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <div className="mb-2 text-sm text-muted-foreground">
+                          Links to diagnostics will appear here once available.
+                        </div>
+                      )}
+                    </div>
+                    <div>
+                      <Label className="mb-1 block text-sm">Performance</Label>
+                      {performanceLinks.length || paceLink ? (
+                        <ul className="list-disc pl-5 text-sm">
+                          {performanceLinks.map((p) => (
+                            <li key={p.url} className="flex items-center gap-2">
+                              <a
+                                className="flex items-center gap-1 text-blue-600 hover:underline"
+                                href={p.url}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  width="16"
+                                  height="16"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  className="inline-block"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
+                                  />
+                                </svg>
+                                {p.label}
+                              </a>
+                            </li>
+                          ))}
+                          {paceLink && (
+                            <li className="flex items-center gap-2">
+                              <a
+                                className="flex items-center gap-1 text-blue-600 hover:underline"
+                                href={paceLink.href}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  width="16"
+                                  height="16"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  className="inline-block"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
+                                  />
+                                </svg>
+                                {paceLink.label}
+                              </a>
+                              {isResolvingPace && (
+                                <>
+                                  <Spinner className="size-3 text-muted-foreground" />
+                                  <TooltipProvider delayDuration={150}>
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <button
+                                          type="button"
+                                          aria-label="PACE link resolution status"
+                                          className="text-muted-foreground hover:text-foreground"
+                                        >
+                                          <CircleHelp className="size-3" />
+                                        </button>
+                                      </TooltipTrigger>
+                                      <TooltipContent>
+                                        Checking for a direct PACE experiment link
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  </TooltipProvider>
+                                </>
+                              )}
+                              {!isResolvingPace && showPaceFallbackInfo && (
+                                <TooltipProvider delayDuration={150}>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <button
+                                        type="button"
+                                        aria-label="PACE link fallback information"
+                                        className="text-muted-foreground hover:text-foreground"
+                                      >
+                                        <CircleHelp className="size-3" />
+                                      </button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      Direct PACE experiment link not found. Search results may
+                                      still contain this run.
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              )}
+                            </li>
+                          )}
+                        </ul>
+                      ) : (
+                        <div className="mb-2 text-sm text-muted-foreground">
+                          Links to performance metrics will appear here once available.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  <div>
+                    {Object.entries(simulation.groupedLinks)
+                      .filter(([key]) => key !== 'diagnostic' && key !== 'performance')
+                      .map(([key, linkList]) => (
+                        <div key={key} className="mb-4">
+                          <h4 className="text-sm font-medium capitalize">{key}</h4>
+                          <ul className="list-disc pl-5 text-sm">
+                            {linkList.map((link) => (
+                              <li key={link.url} className="flex items-center gap-2">
+                                <a
+                                  className="flex items-center gap-1 text-blue-600 hover:underline"
+                                  href={link.url}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                >
+                                  <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    width="16"
+                                    height="16"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                    className="inline-block"
+                                  >
+                                    <path
+                                      strokeLinecap="round"
+                                      strokeLinejoin="round"
+                                      strokeWidth={2}
+                                      d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
+                                    />
+                                  </svg>
+                                  {link.label}
+                                </a>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      ))}
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">Notes</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <Textarea
+                    placeholder="Add notes..."
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                    className="min-h-[120px]"
+                    readOnly={!canEdit}
+                  />
+                  {!canEdit && (
+                    <p className="text-xs text-muted-foreground">
+                      A user account with write privilege is required to update this simulation
+                      page.
+                    </p>
+                  )}
+                  <div>
+                    <Button disabled={!canEdit}>Save</Button>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <div>
+                <h3 className="mb-2 text-sm font-semibold tracking-tight">Comments</h3>
+                <div className="space-y-4">
+                  {comments.map((c) => (
+                    <div
+                      key={c.id}
+                      className="flex gap-3 rounded px-2 py-4 transition-all"
+                      style={{ marginBottom: '16px', marginTop: '16px' }}
+                    >
+                      <Avatar className="mt-1 h-8 w-8">
+                        <AvatarFallback>
+                          {c.author
+                            .split(' ')
+                            .map((n) => n[0])
+                            .join('')
+                            .slice(0, 2)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="flex-1">
+                        <div className="mb-1 flex items-center gap-2 text-xs text-muted-foreground">
+                          <span className="font-medium text-foreground">{c.author}</span>
+                          <span>•</span>
+                          <span>{formatDate(c.date)}</span>
+                        </div>
+                        <p className="text-sm leading-relaxed">{c.text}</p>
+                      </div>
                     </div>
                   ))}
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-base">Notes</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <Textarea
-                placeholder="Add notes..."
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                className="min-h-[120px]"
-                readOnly={!canEdit}
-              />
-              {!canEdit && (
-                <p className="text-xs text-muted-foreground">
-                  A user account with write privilege is required to update this simulation page.
-                </p>
-              )}
-              <div>
-                <Button disabled={!canEdit}>Save</Button>
-              </div>
-            </CardContent>
-          </Card>
-          <div>
-            <h3 className="mb-2 text-sm font-semibold tracking-tight">Comments</h3>
-            <div className="space-y-4">
-              {comments.map((c) => (
-                <div
-                  key={c.id}
-                  className="flex gap-3 py-4 px-2 rounded transition-all"
-                  style={{ marginBottom: '16px', marginTop: '16px' }}
-                >
-                  <Avatar className="h-8 w-8 mt-1">
-                    <AvatarFallback>
-                      {c.author
-                        .split(' ')
-                        .map((n) => n[0])
-                        .join('')
-                        .slice(0, 2)}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
-                      <span className="font-medium text-foreground">{c.author}</span>
-                      <span>•</span>
-                      <span>{formatDate(c.date)}</span>
-                    </div>
-                    <p className="text-sm leading-relaxed">{c.text}</p>
+                  <Separator />
+                  <div className="flex items-start gap-2">
+                    <Textarea
+                      placeholder="Add a comment ..."
+                      className="min-h-[80px]"
+                      value={newComment}
+                      onChange={(e) => setNewComment(e.target.value)}
+                      readOnly={!canEdit}
+                    />
+                    <Button onClick={addComment} className="shrink-0" disabled={!canEdit}>
+                      Post
+                    </Button>
                   </div>
                 </div>
-              ))}
-              <Separator />
-              <div className="flex items-start gap-2">
-                <Textarea
-                  placeholder="Add a comment ..."
-                  className="min-h-[80px]"
-                  value={newComment}
-                  onChange={(e) => setNewComment(e.target.value)}
-                  readOnly={!canEdit}
+              </div>
+            </div>
+
+            <div className="hidden xl:block">
+              <div className="sticky top-6">
+                <SimulationSummaryRail
+                  summary={summary}
+                  summaryLoading={summaryLoading}
+                  summaryError={summaryError}
+                  summaryRequested={summaryRequested}
+                  onGenerateSummary={onGenerateSummary}
+                  canGenerateSummary={canGenerateSummary}
+                  isCheckingAuth={isCheckingAuth}
+                  onLoginForSummary={onLoginForSummary}
                 />
-                <Button onClick={addComment} className="shrink-0" disabled={!canEdit}>
-                  Post
-                </Button>
               </div>
             </div>
           </div>

--- a/frontend/src/features/simulations/components/SimulationSummaryPanel.tsx
+++ b/frontend/src/features/simulations/components/SimulationSummaryPanel.tsx
@@ -27,11 +27,25 @@ interface SimulationSummaryPanelProps {
   summaryLoading?: boolean;
   summaryError?: string | null;
   summaryRequested?: boolean;
+  summaryElapsedMs?: number;
+  summaryLastDurationMs?: number | null;
   onGenerateSummary?: () => void | Promise<void>;
   canGenerateSummary?: boolean;
   isCheckingAuth?: boolean;
   onLoginForSummary?: () => void;
 }
+
+const formatSummaryRuntime = (durationMs: number) => {
+  const totalSeconds = Math.max(1, Math.round(durationMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes === 0) {
+    return `${totalSeconds}s`;
+  }
+
+  return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+};
 
 const getSummaryActionLabel = ({
   summary,
@@ -223,6 +237,8 @@ const SummaryPanelBody = ({
   summaryLoading = false,
   summaryError = null,
   summaryRequested = false,
+  summaryElapsedMs = 0,
+  summaryLastDurationMs = null,
   canGenerateSummary = false,
   isCheckingAuth = false,
   scrollable = false,
@@ -233,6 +249,8 @@ const SummaryPanelBody = ({
   | 'summaryLoading'
   | 'summaryError'
   | 'summaryRequested'
+  | 'summaryElapsedMs'
+  | 'summaryLastDurationMs'
   | 'canGenerateSummary'
   | 'isCheckingAuth'
 > & {
@@ -240,6 +258,7 @@ const SummaryPanelBody = ({
   className?: string;
 }) => {
   const summaryGenerationMode = summary?.generationMode ?? 'deterministic';
+  const summaryFallbackUsed = summary?.fallbackUsed ?? false;
   const summaryGenerationProvider =
     summaryGenerationMode === 'llm' ? summary?.generationProvider ?? null : null;
   const summaryGenerationModel =
@@ -263,15 +282,26 @@ const SummaryPanelBody = ({
 
       {summaryError && (
         <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {summaryError}
+          <div>{summaryError}</div>
+          {summaryLastDurationMs !== null && (
+            <div className="mt-1 text-xs text-red-600/80">
+              Latest attempt ran for {formatSummaryRuntime(summaryLastDurationMs)}.
+            </div>
+          )}
         </div>
       )}
 
       {summaryLoading && !summary && (
         <div className="flex min-h-[220px] items-center rounded-md border bg-white/80 px-4 py-5">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Spinner className="size-4" />
-            Generating summary from SimBoard metadata...
+          <div className="space-y-1 text-sm text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <Spinner className="size-4" />
+              Generating summary from SimBoard metadata...
+            </div>
+            <div className="pl-6 text-xs text-slate-500">
+              {formatSummaryRuntime(summaryElapsedMs)} elapsed. This can fall back to a
+              metadata-based summary if AI generation stalls or fails.
+            </div>
           </div>
         </div>
       )}
@@ -295,7 +325,19 @@ const SummaryPanelBody = ({
                 {summaryGenerationModel ? ` · ${summaryGenerationModel}` : ''}
               </span>
             )}
+            {summaryLastDurationMs !== null && (
+              <span className="text-sm text-muted-foreground">
+                Runtime: {formatSummaryRuntime(summaryLastDurationMs)}
+              </span>
+            )}
           </div>
+
+          {summaryFallbackUsed && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              AI generation did not complete for this attempt. Showing metadata-based summary
+              instead.
+            </div>
+          )}
 
           <div>
             <Label className="mb-2 block text-xs text-muted-foreground">Summary</Label>
@@ -329,6 +371,8 @@ export const SimulationSummaryRail = ({
   summaryLoading = false,
   summaryError = null,
   summaryRequested = false,
+  summaryElapsedMs = 0,
+  summaryLastDurationMs = null,
   onGenerateSummary,
   canGenerateSummary = false,
   isCheckingAuth = false,
@@ -361,6 +405,8 @@ export const SimulationSummaryRail = ({
         summaryLoading={summaryLoading}
         summaryError={summaryError}
         summaryRequested={summaryRequested}
+        summaryElapsedMs={summaryElapsedMs}
+        summaryLastDurationMs={summaryLastDurationMs}
         canGenerateSummary={canGenerateSummary}
         isCheckingAuth={isCheckingAuth}
         scrollable
@@ -374,6 +420,8 @@ export const SimulationSummaryLauncher = ({
   summaryLoading = false,
   summaryError = null,
   summaryRequested = false,
+  summaryElapsedMs = 0,
+  summaryLastDurationMs = null,
   onGenerateSummary,
   canGenerateSummary = false,
   isCheckingAuth = false,
@@ -402,11 +450,15 @@ export const SimulationSummaryLauncher = ({
         <CardContent className="flex items-center justify-between gap-3 pt-0">
           <p className="text-sm text-muted-foreground">
             {summary
-              ? 'Summary is ready to review.'
+              ? summaryLastDurationMs !== null
+                ? `Summary ready. Latest attempt took ${formatSummaryRuntime(summaryLastDurationMs)}.`
+                : 'Summary is ready to review.'
               : summaryError
-                ? 'Review the latest summary error.'
+                ? summaryLastDurationMs !== null
+                  ? `Latest summary attempt failed after ${formatSummaryRuntime(summaryLastDurationMs)}.`
+                  : 'Review the latest summary error.'
                 : summaryLoading
-                  ? 'Summary generation is in progress.'
+                  ? `Summary generation is in progress. ${formatSummaryRuntime(summaryElapsedMs)} elapsed.`
                   : canGenerateSummary
                     ? 'Generate a metadata-based summary when you need a quick overview.'
                     : 'Log in to generate a metadata-based summary for this run.'}
@@ -451,6 +503,8 @@ export const SimulationSummaryLauncher = ({
                 summaryLoading={summaryLoading}
                 summaryError={summaryError}
                 summaryRequested={summaryRequested}
+                summaryElapsedMs={summaryElapsedMs}
+                summaryLastDurationMs={summaryLastDurationMs}
                 canGenerateSummary={canGenerateSummary}
                 isCheckingAuth={isCheckingAuth}
               />

--- a/frontend/src/features/simulations/components/SimulationSummaryPanel.tsx
+++ b/frontend/src/features/simulations/components/SimulationSummaryPanel.tsx
@@ -1,0 +1,463 @@
+import { Sparkles } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import { cn } from '@/lib/utils';
+import type { SimulationSummaryResponseOut } from '@/types';
+
+interface SimulationSummaryPanelProps {
+  summary?: SimulationSummaryResponseOut | null;
+  summaryLoading?: boolean;
+  summaryError?: string | null;
+  summaryRequested?: boolean;
+  onGenerateSummary?: () => void | Promise<void>;
+  canGenerateSummary?: boolean;
+  isCheckingAuth?: boolean;
+  onLoginForSummary?: () => void;
+}
+
+const getSummaryActionLabel = ({
+  summary,
+  summaryLoading = false,
+  canGenerateSummary = false,
+  isCheckingAuth = false,
+}: Pick<
+  SimulationSummaryPanelProps,
+  'summary' | 'summaryLoading' | 'canGenerateSummary' | 'isCheckingAuth'
+>) => {
+  if (isCheckingAuth) return 'Checking login...';
+  if (summaryLoading) return 'Generating...';
+  if (!canGenerateSummary) return 'Log In To Generate AI Summary';
+  if (summary) return 'Regenerate AI Summary';
+  return 'Generate AI Summary';
+};
+
+const getSummaryStatusLabel = ({
+  summary,
+  summaryLoading = false,
+  summaryError = null,
+  isCheckingAuth = false,
+}: Pick<
+  SimulationSummaryPanelProps,
+  'summary' | 'summaryLoading' | 'summaryError' | 'isCheckingAuth'
+>) => {
+  if (isCheckingAuth) return 'Checking login';
+  if (summaryLoading) return 'Generating';
+  if (summaryError) return 'Error';
+  if (summary) return 'Ready';
+  return 'Not generated';
+};
+
+const getSummaryStatusClasses = (status: string) => {
+  switch (status) {
+    case 'Ready':
+      return 'bg-emerald-100 text-emerald-900';
+    case 'Generating':
+    case 'Checking login':
+      return 'bg-blue-100 text-blue-900';
+    case 'Error':
+      return 'bg-red-100 text-red-800';
+    default:
+      return 'bg-slate-100 text-slate-700';
+  }
+};
+
+const SummaryTextBlock = ({ value, className }: { value: string; className?: string }) => (
+  <div
+    className={cn(
+      'min-h-[140px] whitespace-pre-wrap rounded-md border bg-white px-4 py-3 text-sm leading-6 break-words',
+      className,
+    )}
+  >
+    {value.trim()}
+  </div>
+);
+
+const SummaryList = ({ items }: { items: string[] }) => (
+  <ul className="space-y-2 rounded-md border bg-white px-4 py-3 text-sm">
+    {items.map((item) => (
+      <li key={item} className="list-none leading-6">
+        {item}
+      </li>
+    ))}
+  </ul>
+);
+
+const SummaryCitations = ({ summary }: { summary: SimulationSummaryResponseOut }) => (
+  <div className="rounded-md border bg-white">
+    <div className="divide-y">
+      {summary.citations.map((citation) => (
+        <div
+          key={`${citation.sourceType}-${citation.path}`}
+          className="flex flex-col gap-1 px-4 py-3 text-sm md:flex-row md:items-start md:justify-between"
+        >
+          <div className="font-medium text-foreground">{citation.label}</div>
+          <code className="text-xs text-muted-foreground">{citation.path}</code>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+const SummarySectionAccordion = ({
+  summary,
+  defaultValue = ['caveats'],
+}: {
+  summary: SimulationSummaryResponseOut;
+  defaultValue?: string[];
+}) => {
+  const sections = [
+    {
+      value: 'caveats',
+      label: `Caveats (${summary.caveats.length})`,
+      visible: summary.caveats.length > 0,
+      content: <SummaryList items={summary.caveats} />,
+    },
+    {
+      value: 'limitations',
+      label: `Limitations (${summary.limitations.length})`,
+      visible: summary.limitations.length > 0,
+      content: <SummaryList items={summary.limitations} />,
+    },
+    {
+      value: 'citations',
+      label: `Citations (${summary.citations.length})`,
+      visible: summary.citations.length > 0,
+      content: <SummaryCitations summary={summary} />,
+    },
+    {
+      value: 'followups',
+      label: `Suggested Follow-up Questions (${summary.suggestedFollowups.length})`,
+      visible: summary.suggestedFollowups.length > 0,
+      content: <SummaryList items={summary.suggestedFollowups} />,
+    },
+  ].filter((section) => section.visible);
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  return (
+    <Accordion type="multiple" defaultValue={defaultValue} className="rounded-md border bg-white px-4">
+      {sections.map((section) => (
+        <AccordionItem
+          key={section.value}
+          value={section.value}
+          className="border-slate-200 last:border-b-0"
+        >
+          <AccordionTrigger className="py-3 text-sm font-medium text-foreground hover:no-underline">
+            {section.label}
+          </AccordionTrigger>
+          <AccordionContent className="pb-3">{section.content}</AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+};
+
+const SummaryActionButton = ({
+  summary,
+  summaryLoading = false,
+  onGenerateSummary,
+  canGenerateSummary = false,
+  isCheckingAuth = false,
+  onLoginForSummary,
+  className,
+}: Pick<
+  SimulationSummaryPanelProps,
+  | 'summary'
+  | 'summaryLoading'
+  | 'onGenerateSummary'
+  | 'canGenerateSummary'
+  | 'isCheckingAuth'
+  | 'onLoginForSummary'
+> & {
+  className?: string;
+}) => (
+  <Button
+    type="button"
+    variant="outline"
+    onClick={() => {
+      if (!canGenerateSummary) {
+        onLoginForSummary?.();
+        return;
+      }
+
+      void onGenerateSummary?.();
+    }}
+    disabled={summaryLoading || isCheckingAuth || (!canGenerateSummary && !onLoginForSummary)}
+    className={cn('border-blue-200 bg-white text-blue-900 hover:bg-blue-50', className)}
+  >
+    {isCheckingAuth ? (
+      'Checking login...'
+    ) : summaryLoading ? (
+      <>
+        <Spinner className="mr-2 size-4" />
+        Generating...
+      </>
+    ) : (
+      getSummaryActionLabel({ summary, summaryLoading, canGenerateSummary, isCheckingAuth })
+    )}
+  </Button>
+);
+
+const SummaryPanelBody = ({
+  summary,
+  summaryLoading = false,
+  summaryError = null,
+  summaryRequested = false,
+  canGenerateSummary = false,
+  isCheckingAuth = false,
+  scrollable = false,
+  className,
+}: Pick<
+  SimulationSummaryPanelProps,
+  | 'summary'
+  | 'summaryLoading'
+  | 'summaryError'
+  | 'summaryRequested'
+  | 'canGenerateSummary'
+  | 'isCheckingAuth'
+> & {
+  scrollable?: boolean;
+  className?: string;
+}) => {
+  const summaryGenerationMode = summary?.generationMode ?? 'deterministic';
+  const summaryGenerationProvider =
+    summaryGenerationMode === 'llm' ? summary?.generationProvider ?? null : null;
+  const summaryGenerationModel =
+    summaryGenerationMode === 'llm' ? summary?.generationModel ?? null : null;
+
+  return (
+    <div
+      className={cn(
+        'space-y-4',
+        scrollable && 'max-h-[calc(100vh-15rem)] overflow-y-auto pr-1',
+        className,
+      )}
+    >
+      {!summaryRequested && !summary && !summaryError && (
+        <div className="flex min-h-[220px] items-center rounded-md border border-dashed border-blue-200 bg-white/80 px-4 py-5 text-sm text-muted-foreground">
+          {canGenerateSummary
+            ? 'Generate a read-only summary grounded only in metadata already stored in SimBoard. It will not change this simulation record.'
+            : 'Log in with GitHub to generate a read-only, metadata-based AI summary for this simulation.'}
+        </div>
+      )}
+
+      {summaryError && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {summaryError}
+        </div>
+      )}
+
+      {summaryLoading && !summary && (
+        <div className="flex min-h-[220px] items-center rounded-md border bg-white/80 px-4 py-5">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Spinner className="size-4" />
+            Generating summary from SimBoard metadata...
+          </div>
+        </div>
+      )}
+
+      {summary && (
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center gap-2 rounded-md border bg-white px-4 py-3">
+            <Badge
+              variant="secondary"
+              className={
+                summaryGenerationMode === 'llm'
+                  ? 'bg-emerald-100 text-emerald-800'
+                  : 'bg-slate-100 text-slate-700'
+              }
+            >
+              {summaryGenerationMode === 'llm' ? 'LLM Summary' : 'Deterministic Summary'}
+            </Badge>
+            {summaryGenerationProvider && (
+              <span className="text-sm text-muted-foreground">
+                Provider: {summaryGenerationProvider}
+                {summaryGenerationModel ? ` · ${summaryGenerationModel}` : ''}
+              </span>
+            )}
+          </div>
+
+          <div>
+            <Label className="mb-2 block text-xs text-muted-foreground">Summary</Label>
+            <SummaryTextBlock value={summary.answer} />
+          </div>
+
+          <SummarySectionAccordion
+            summary={summary}
+            defaultValue={summary.caveats.length > 0 ? ['caveats'] : []}
+          />
+        </div>
+      )}
+
+      {!summary && !summaryLoading && !summaryError && summaryRequested && (
+        <div className="flex min-h-[220px] items-center rounded-md border bg-white/80 px-4 py-5 text-sm text-muted-foreground">
+          No summary is available yet.
+        </div>
+      )}
+
+      {isCheckingAuth && !summaryLoading && !summary && !summaryError && !summaryRequested && (
+        <div className="text-xs text-muted-foreground">
+          Verifying whether summary generation is available for this session.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const SimulationSummaryRail = ({
+  summary,
+  summaryLoading = false,
+  summaryError = null,
+  summaryRequested = false,
+  onGenerateSummary,
+  canGenerateSummary = false,
+  isCheckingAuth = false,
+  onLoginForSummary,
+}: SimulationSummaryPanelProps) => (
+  <Card className="overflow-hidden border-blue-200/80 bg-gradient-to-br from-blue-50/70 via-white to-slate-50 shadow-sm">
+    <CardHeader className="space-y-3 border-b border-blue-100/80 pb-4">
+      <div className="space-y-1">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Sparkles className="h-4 w-4 text-blue-600" />
+          AI Summary
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Read-only summary generated from metadata already recorded in SimBoard.
+        </p>
+      </div>
+      <SummaryActionButton
+        summary={summary}
+        summaryLoading={summaryLoading}
+        onGenerateSummary={onGenerateSummary}
+        canGenerateSummary={canGenerateSummary}
+        isCheckingAuth={isCheckingAuth}
+        onLoginForSummary={onLoginForSummary}
+        className="w-full"
+      />
+    </CardHeader>
+    <CardContent className="min-h-[440px] p-4">
+      <SummaryPanelBody
+        summary={summary}
+        summaryLoading={summaryLoading}
+        summaryError={summaryError}
+        summaryRequested={summaryRequested}
+        canGenerateSummary={canGenerateSummary}
+        isCheckingAuth={isCheckingAuth}
+        scrollable
+      />
+    </CardContent>
+  </Card>
+);
+
+export const SimulationSummaryLauncher = ({
+  summary,
+  summaryLoading = false,
+  summaryError = null,
+  summaryRequested = false,
+  onGenerateSummary,
+  canGenerateSummary = false,
+  isCheckingAuth = false,
+  onLoginForSummary,
+}: SimulationSummaryPanelProps) => {
+  const [open, setOpen] = useState(false);
+  const status = getSummaryStatusLabel({ summary, summaryLoading, summaryError, isCheckingAuth });
+
+  return (
+    <>
+      <Card className="border-blue-200/80 bg-gradient-to-br from-blue-50/70 via-white to-slate-50 shadow-sm">
+        <CardHeader className="space-y-3 pb-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Sparkles className="h-4 w-4 text-blue-600" />
+                AI Summary
+              </CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Open the AI summary drawer without moving the simulation metadata.
+              </p>
+            </div>
+            <Badge className={cn('shrink-0', getSummaryStatusClasses(status))}>{status}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="flex items-center justify-between gap-3 pt-0">
+          <p className="text-sm text-muted-foreground">
+            {summary
+              ? 'Summary is ready to review.'
+              : summaryError
+                ? 'Review the latest summary error.'
+                : summaryLoading
+                  ? 'Summary generation is in progress.'
+                  : canGenerateSummary
+                    ? 'Generate a metadata-based summary when you need a quick overview.'
+                    : 'Log in to generate a metadata-based summary for this run.'}
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            className="shrink-0 border-blue-200 bg-white text-blue-900 hover:bg-blue-50"
+            onClick={() => setOpen(true)}
+          >
+            Open AI Summary
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="left-auto right-0 top-0 h-[100dvh] w-full max-w-[min(92vw,42rem)] translate-x-0 translate-y-0 gap-0 overflow-hidden rounded-none border-l border-slate-200 p-0 data-[state=closed]:slide-out-to-right data-[state=closed]:slide-out-to-top-0 data-[state=closed]:zoom-out-100 data-[state=open]:slide-in-from-right data-[state=open]:slide-in-from-top-0 data-[state=open]:zoom-in-100 sm:max-w-[28rem] sm:rounded-none">
+          <div className="flex h-full min-h-0 flex-col">
+            <DialogHeader className="gap-3 border-b border-blue-100/80 px-6 py-5 text-left">
+              <div className="pr-10">
+                <DialogTitle className="flex items-center gap-2 text-base">
+                  <Sparkles className="h-4 w-4 text-blue-600" />
+                  AI Summary
+                </DialogTitle>
+                <DialogDescription className="mt-1">
+                  Read-only summary generated from metadata already recorded in SimBoard.
+                </DialogDescription>
+              </div>
+              <SummaryActionButton
+                summary={summary}
+                summaryLoading={summaryLoading}
+                onGenerateSummary={onGenerateSummary}
+                canGenerateSummary={canGenerateSummary}
+                isCheckingAuth={isCheckingAuth}
+                onLoginForSummary={onLoginForSummary}
+                className="w-full justify-center"
+              />
+            </DialogHeader>
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+              <SummaryPanelBody
+                summary={summary}
+                summaryLoading={summaryLoading}
+                summaryError={summaryError}
+                summaryRequested={summaryRequested}
+                canGenerateSummary={canGenerateSummary}
+                isCheckingAuth={isCheckingAuth}
+              />
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/frontend/src/features/simulations/hooks/useSimulationSummary.ts
+++ b/frontend/src/features/simulations/hooks/useSimulationSummary.ts
@@ -9,6 +9,9 @@ export const useSimulationSummary = (simulationId: string) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [requested, setRequested] = useState(false);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [lastDurationMs, setLastDurationMs] = useState<number | null>(null);
+  const [activeRequestStartedAt, setActiveRequestStartedAt] = useState<number | null>(null);
   const currentSimulationIdRef = useRef(simulationId);
   const requestIdRef = useRef(0);
 
@@ -19,13 +22,35 @@ export const useSimulationSummary = (simulationId: string) => {
     setLoading(false);
     setError(null);
     setRequested(false);
+    setElapsedMs(0);
+    setLastDurationMs(null);
+    setActiveRequestStartedAt(null);
   }, [simulationId]);
+
+  useEffect(() => {
+    if (activeRequestStartedAt === null) {
+      setElapsedMs(0);
+      return;
+    }
+
+    const updateElapsed = () => {
+      setElapsedMs(Date.now() - activeRequestStartedAt);
+    };
+
+    updateElapsed();
+    const intervalId = window.setInterval(updateElapsed, 1000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [activeRequestStartedAt]);
 
   const generate = async () => {
     if (!simulationId) return;
 
     const requestedSimulationId = simulationId;
     const requestId = requestIdRef.current + 1;
+    const startTime = Date.now();
     requestIdRef.current = requestId;
     const isLatestRequest = () =>
       requestId === requestIdRef.current &&
@@ -34,6 +59,9 @@ export const useSimulationSummary = (simulationId: string) => {
     setRequested(true);
     setLoading(true);
     setError(null);
+    setElapsedMs(0);
+    setLastDurationMs(null);
+    setActiveRequestStartedAt(startTime);
 
     try {
       const result = await generateSimulationSummary(requestedSimulationId);
@@ -53,10 +81,12 @@ export const useSimulationSummary = (simulationId: string) => {
       }
     } finally {
       if (isLatestRequest()) {
+        setLastDurationMs(Date.now() - startTime);
+        setActiveRequestStartedAt(null);
         setLoading(false);
       }
     }
   };
 
-  return { data, loading, error, requested, generate };
+  return { data, loading, error, requested, elapsedMs, lastDurationMs, generate };
 };

--- a/frontend/src/features/simulations/hooks/useSimulationSummary.ts
+++ b/frontend/src/features/simulations/hooks/useSimulationSummary.ts
@@ -1,0 +1,62 @@
+import axios from 'axios';
+import { useEffect, useRef, useState } from 'react';
+
+import { generateSimulationSummary } from '@/features/simulations/api/api';
+import type { SimulationSummaryResponseOut } from '@/types';
+
+export const useSimulationSummary = (simulationId: string) => {
+  const [data, setData] = useState<SimulationSummaryResponseOut | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [requested, setRequested] = useState(false);
+  const currentSimulationIdRef = useRef(simulationId);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    currentSimulationIdRef.current = simulationId;
+    requestIdRef.current += 1;
+    setData(null);
+    setLoading(false);
+    setError(null);
+    setRequested(false);
+  }, [simulationId]);
+
+  const generate = async () => {
+    if (!simulationId) return;
+
+    const requestedSimulationId = simulationId;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    const isLatestRequest = () =>
+      requestId === requestIdRef.current &&
+      currentSimulationIdRef.current === requestedSimulationId;
+
+    setRequested(true);
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = await generateSimulationSummary(requestedSimulationId);
+      if (!isLatestRequest()) {
+        return;
+      }
+      setData(result);
+    } catch (e) {
+      if (!isLatestRequest()) {
+        return;
+      }
+      setData(null);
+      if (axios.isAxiosError(e) && (e.response?.status === 401 || e.response?.status === 403)) {
+        setError('Log in to generate an AI summary for this simulation.');
+      } else {
+        setError(e instanceof Error ? e.message : 'Failed to generate AI summary.');
+      }
+    } finally {
+      if (isLatestRequest()) {
+        setLoading(false);
+      }
+    }
+  };
+
+  return { data, loading, error, requested, generate };
+};

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -30,7 +30,8 @@ export interface SimulationSummaryResponseOut {
   limitations: string[];
   suggestedFollowups: string[];
   generationMode?: 'llm' | 'deterministic';
-  generationProvider?: 'openai' | 'anthropic' | 'livai' | null;
+  fallbackUsed?: boolean;
+  generationProvider?: 'livai' | 'ollama' | null;
   generationModel?: string | null;
   traceId: string;
 }

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -9,6 +9,32 @@ export interface SimulationUserPreview {
   full_name?: string | null;
 }
 
+export type SummaryCitationSourceType =
+  | 'simulation_field'
+  | 'case_field'
+  | 'machine_field'
+  | 'artifact'
+  | 'external_link';
+
+export interface SimulationSummaryCitationOut {
+  sourceType: SummaryCitationSourceType;
+  path: string;
+  label: string;
+}
+
+export interface SimulationSummaryResponseOut {
+  answer: string;
+  citations: SimulationSummaryCitationOut[];
+  assumptions: string[];
+  caveats: string[];
+  limitations: string[];
+  suggestedFollowups: string[];
+  generationMode?: 'llm' | 'deterministic';
+  generationProvider?: 'openai' | 'anthropic' | 'livai' | null;
+  generationModel?: string | null;
+  traceId: string;
+}
+
 /**
  * API response model for a Case with nested simulation summaries.
  */
@@ -129,6 +155,8 @@ export interface SimulationOut extends SimulationCreate {
 
   // Relationships
   // ~~~~~~~~~~~~~~
+  artifacts: ArtifactOut[];
+  links: ExternalLinkOut[];
   machine: Machine;
 
   // Computed fields


### PR DESCRIPTION
## Description
Promote AI summary work from `dev-ai` into `main`.

This PR rolls up already-reviewed changes from:
- #187, which added LLM-backed simulation summaries with deterministic fallback, structured citations/caveats/limitations/follow-ups, snapshot extraction and validation, backend orchestration, and summary metadata in the simulation details UI.
- #197, which added locally hosted LLM provider support on top of that foundation, starting with Ollama, narrowed supported providers to `ollama` and `livai`, hardened fallback handling for local-model output drift, and improved runtime plus fallback messaging in the UI.

Result: `main` gains the current end-to-end AI summary vertical slice across backend, frontend, configuration, documentation, and tests.

- Includes #187
- Includes #197
- Follow-up to #52

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [x] Tests added or updated (if needed)
- [x] All tests pass (locally and CI/CD)
- [x] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)

- No database migration expected.
- To enable LLM-backed summaries, set `ASSISTANT_LLM_ENABLED=true` and configure supported assistant provider env vars for `ollama` or `livai`.