### PR TITLE
Fix frontend Docker pnpm config

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,13 +7,13 @@ FROM node:24-alpine AS build-stage
 
 ENV CI=true
 
-# Install pnpm globally
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Activate repo-pinned pnpm version
+RUN corepack enable && corepack prepare pnpm@10.24.0 --activate
 
 WORKDIR /app
 
 # Copy dependency manifests for caching
-COPY pnpm-lock.yaml package.json ./
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
 
 # Install dependencies (with caching)
 RUN --mount=type=cache,target=/root/.pnpm-store \

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "simboard",
   "private": true,
   "version": "0.0.0",
+  "packageManager": "pnpm@10.24.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 onlyBuiltDependencies:
   - esbuild
+  - unrs-resolver


### PR DESCRIPTION
## Description
This fixes the frontend Docker image build failure in GitHub Actions.

The root cause was twofold:
- the Docker dependency-install layer copied only `package.json` and `pnpm-lock.yaml`, so pnpm could not see the frontend build-script allowlist from `pnpm-workspace.yaml`
- the allowlist was also missing `unrs-resolver`, which is now required by the current frontend dependency graph

This PR:
- pins frontend pnpm to `10.24.0` via `packageManager` and Docker activation
- copies `pnpm-workspace.yaml` into the Docker install layer
- adds `unrs-resolver` to `onlyBuiltDependencies`

Validation completed:
- `pnpm --dir frontend run build`
- `docker build -f frontend/Dockerfile --build-arg VITE_API_BASE_URL=https://simboard-dev-api.e3sm.org frontend`

Notes:
- `pnpm --dir frontend run lint` was not runnable in the local sandbox after `node_modules` recreation because package installation was network-restricted there
- this is a config-only fix; no application behavior change is intended

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [ ] No new warnings
- [ ] Tests added or updated (if needed)
- [ ] All tests pass (locally and CI/CD)
- [ ] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)
No special deployment or migration steps required.