### PR TITLE
Fix Read the Docs MkDocs install configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,4 @@ python:
   install:
     - method: uv
       command: pip
-      path: backend
-      extras:
-        - docs
+      requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material
+pymdown-extensions


### PR DESCRIPTION
## Description

- Fix Read the Docs setup so the MkDocs toolchain is installed explicitly during docs builds.
- Replace the backend `extras: [docs]` install path in `.readthedocs.yaml` with `docs/requirements.txt`.
- Add `docs/requirements.txt` with the MkDocs packages required by the existing docs site.
- Motivation: Read the Docs was installing packages but then failing with `Failed to spawn: mkdocs`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [ ] Tests added or updated (if needed)
- [ ] All tests pass (locally and CI/CD)
- [x] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)

- No application deployment changes.
- Docs build verification in this sandbox was blocked by lack of outbound PyPI access, so final confirmation should come from the Read the Docs rebuild.