### PR TITLE
Track config deltas by case-hash subgroup

### DIFF
--- a/backend/app/features/assistant/orchestrator.py
+++ b/backend/app/features/assistant/orchestrator.py
@@ -11,6 +11,7 @@ from pydantic_ai.exceptions import (
     ModelHTTPError,
     UnexpectedModelBehavior,
 )
+from sqlalchemy.ext.asyncio import async_object_session
 
 from app.core.config import settings
 from app.features.assistant.llm_generator import AssistantLLMConfig, SummaryLLMGenerator
@@ -30,11 +31,15 @@ from app.features.assistant.snapshot import (
     SnapshotBudgetExceededError,
     build_simulation_snapshot,
 )
+from app.features.simulation.anchor import resolve_anchor_run_state_async
 from app.features.simulation.models import Simulation
 
 _SNAPSHOT_PATH_ACCESSORS = {
     "simulation.id": lambda snapshot: snapshot.simulation.id,
     "simulation.execution_id": lambda snapshot: snapshot.simulation.execution_id,
+    "simulation.case_hash": lambda snapshot: snapshot.simulation.case_hash,
+    "simulation.is_anchor_run": lambda snapshot: snapshot.simulation.is_anchor_run,
+    "simulation.anchor_simulation_id": lambda snapshot: snapshot.simulation.anchor_simulation_id,
     "simulation.description": lambda snapshot: snapshot.simulation.description,
     "simulation.compset": lambda snapshot: snapshot.simulation.compset,
     "simulation.compset_alias": lambda snapshot: snapshot.simulation.compset_alias,
@@ -61,7 +66,6 @@ _SNAPSHOT_PATH_ACCESSORS = {
     "simulation.run_config_deltas": lambda snapshot: snapshot.simulation.run_config_deltas,
     "case.name": lambda snapshot: snapshot.case.name,
     "case.case_group": lambda snapshot: snapshot.case.case_group,
-    "case.reference_simulation_id": lambda snapshot: snapshot.case.reference_simulation_id,
     "machine.name": lambda snapshot: snapshot.machine.name
     if snapshot.machine
     else None,
@@ -124,7 +128,19 @@ async def generate_simulation_summary(
     )
 
     try:
-        snapshot = build_simulation_snapshot(simulation)
+        async_session = (
+            async_object_session(simulation) if simulation is not None else None
+        )
+        anchor_state = (
+            await resolve_anchor_run_state_async(async_session, simulation)
+            if async_session is not None
+            else None
+        )
+        snapshot = (
+            build_simulation_snapshot(simulation, anchor_state=anchor_state)
+            if anchor_state is not None
+            else build_simulation_snapshot(simulation)
+        )
     except SnapshotBudgetExceededError as exc:
         if not allow_llm:
             return _build_deterministic_result(

--- a/backend/app/features/assistant/registry.py
+++ b/backend/app/features/assistant/registry.py
@@ -28,6 +28,18 @@ _CITATION_REGISTRY = {
         source_type="simulation_field",
         label="Execution ID",
     ),
+    "simulation.case_hash": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Case hash",
+    ),
+    "simulation.is_anchor_run": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Anchor run status",
+    ),
+    "simulation.anchor_simulation_id": CitationRegistryEntry(
+        source_type="simulation_field",
+        label="Comparison anchor",
+    ),
     "simulation.description": CitationRegistryEntry(
         source_type="simulation_field",
         label="Description",
@@ -131,10 +143,6 @@ _CITATION_REGISTRY = {
     "case.case_group": CitationRegistryEntry(
         source_type="case_field",
         label="Case group",
-    ),
-    "case.reference_simulation_id": CitationRegistryEntry(
-        source_type="case_field",
-        label="Reference simulation",
     ),
     "machine.name": CitationRegistryEntry(
         source_type="machine_field",

--- a/backend/app/features/assistant/service.py
+++ b/backend/app/features/assistant/service.py
@@ -56,29 +56,34 @@ def _add_identity_and_status(
     )
 
     type_bits = [snapshot.simulation.simulation_type]
-    if snapshot.case.reference_simulation_id:
-        draft.add_citation("case.reference_simulation_id")
-
-    if (
-        snapshot.case.reference_simulation_id
-        and snapshot.case.reference_simulation_id == snapshot.simulation.id
-    ):
-        type_bits.append("reference")
+    if snapshot.simulation.case_hash is None:
+        type_bits.append("legacy")
+        draft.sentences.append("It is a legacy run without a comparison anchor.")
+        draft.add_citation("simulation.case_hash")
+    elif snapshot.simulation.is_anchor_run:
+        type_bits.append("anchor")
+        draft.sentences.append("It is the anchor run for its case-hash subgroup.")
+        draft.add_citation("simulation.is_anchor_run")
+        draft.add_citation("simulation.anchor_simulation_id")
+        draft.add_citation("simulation.case_hash")
     else:
-        type_bits.append("non-reference")
+        type_bits.append("anchored")
         if snapshot.simulation.run_config_deltas:
             draft.sentences.append(
-                f"It is a non-reference run with {change_count} recorded "
-                "configuration change(s)."
+                "It is a run with "
+                f"{change_count} recorded configuration change(s) from its "
+                "comparison anchor."
             )
             draft.add_citation("simulation.run_config_deltas")
         else:
             draft.sentences.append(
-                "It is a non-reference run with no recorded configuration differences."
+                "It has no recorded configuration differences from its comparison anchor."
             )
             draft.caveats.append(
-                "This non-reference simulation has no recorded configuration differences in SimBoard metadata."
+                "This simulation has no recorded configuration differences from its comparison anchor in SimBoard metadata."
             )
+        draft.add_citation("simulation.anchor_simulation_id")
+        draft.add_citation("simulation.case_hash")
 
     if snapshot.machine and snapshot.machine.name:
         draft.sentences.append(
@@ -221,7 +226,7 @@ def _add_diagnostics_and_followups(
 
     if snapshot.simulation.known_issues:
         draft.followups.append(
-            "Review the recorded known issues before using this simulation as a baseline."
+            "Review the recorded known issues before using this simulation for comparison context."
         )
 
     output_artifacts = [

--- a/backend/app/features/assistant/service.py
+++ b/backend/app/features/assistant/service.py
@@ -69,16 +69,15 @@ def _add_identity_and_status(
         if snapshot.simulation.run_config_deltas:
             draft.sentences.append(
                 f"It is a non-reference run with {change_count} recorded "
-                "configuration change(s) versus the case reference simulation."
+                "configuration change(s)."
             )
             draft.add_citation("simulation.run_config_deltas")
         else:
             draft.sentences.append(
-                "It is a non-reference run, but SimBoard does not currently record "
-                "any configuration deltas for it."
+                "It is a non-reference run with no recorded configuration differences."
             )
             draft.caveats.append(
-                "This non-reference simulation has no recorded configuration deltas in SimBoard metadata."
+                "This non-reference simulation has no recorded configuration differences in SimBoard metadata."
             )
 
     if snapshot.machine and snapshot.machine.name:
@@ -217,7 +216,7 @@ def _add_diagnostics_and_followups(
 
     if snapshot.simulation.run_config_deltas:
         draft.followups.append(
-            "Compare this run against the case reference simulation to review the recorded configuration deltas."
+            "Use Compare to review the recorded configuration differences for this run."
         )
 
     if snapshot.simulation.known_issues:

--- a/backend/app/features/assistant/snapshot.py
+++ b/backend/app/features/assistant/snapshot.py
@@ -7,8 +7,10 @@ from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, Field
+from sqlalchemy.orm import object_session
 
 from app.core.config import settings
+from app.features.simulation.anchor import AnchorRunState, resolve_anchor_run_state
 from app.features.simulation.models import Artifact, ExternalLink, Simulation
 
 SNAPSHOT_TRUNCATED_CAVEAT = (
@@ -46,6 +48,9 @@ class SnapshotLink(BaseModel):
 class SnapshotSimulationFields(BaseModel):
     id: str
     execution_id: str
+    case_hash: str | None = None
+    is_anchor_run: bool = False
+    anchor_simulation_id: str | None = None
     description: str | None = None
     compset: str
     compset_alias: str
@@ -75,7 +80,6 @@ class SnapshotSimulationFields(BaseModel):
 class SnapshotCaseFields(BaseModel):
     name: str
     case_group: str | None = None
-    reference_simulation_id: str | None = None
 
 
 class SnapshotMachineFields(BaseModel):
@@ -201,12 +205,29 @@ def _apply_size_budget(
 def build_simulation_snapshot(
     simulation: Simulation,
     *,
+    anchor_state: AnchorRunState | None = None,
     max_chars: int | None = None,
 ) -> SimulationSnapshot:
+    resolved_anchor_state = anchor_state
+    if resolved_anchor_state is None:
+        session = object_session(simulation)
+        resolved_anchor_state = (
+            resolve_anchor_run_state(session, simulation)
+            if session is not None
+            else AnchorRunState(is_anchor_run=False, anchor_simulation_id=None)
+        )
+
     snapshot = SimulationSnapshot(
         simulation=SnapshotSimulationFields(
             id=str(simulation.id),
             execution_id=simulation.execution_id,
+            case_hash=simulation.case_hash,
+            is_anchor_run=resolved_anchor_state.is_anchor_run,
+            anchor_simulation_id=(
+                str(resolved_anchor_state.anchor_simulation_id)
+                if resolved_anchor_state.anchor_simulation_id
+                else None
+            ),
             description=simulation.description,
             compset=simulation.compset,
             compset_alias=simulation.compset_alias,
@@ -235,11 +256,6 @@ def build_simulation_snapshot(
         case=SnapshotCaseFields(
             name=simulation.case.name,
             case_group=simulation.case.case_group,
-            reference_simulation_id=(
-                str(simulation.case.reference_simulation_id)
-                if simulation.case.reference_simulation_id
-                else None
-            ),
         ),
         machine=(
             SnapshotMachineFields(name=simulation.machine.name)

--- a/backend/app/features/ingestion/api.py
+++ b/backend/app/features/ingestion/api.py
@@ -676,26 +676,6 @@ def _resolve_ingestion_status(created_count: int, error_count: int) -> str:
     return IngestionStatus.FAILED.value
 
 
-def _set_reference_simulations(db: Session, created_sims: list[Simulation]) -> None:
-    """Set the reference simulation per case when one is not already set."""
-    case_ids: set[UUID] = {
-        case_id for sim in created_sims if isinstance((case_id := sim.case_id), UUID)
-    }
-    cases = {c.id: c for c in db.query(Case).filter(Case.id.in_(case_ids)).all()}
-
-    for sim in created_sims:
-        if isinstance(sim.case_id, UUID):
-            case = cases.get(sim.case_id)
-
-            if (
-                case
-                and case.reference_simulation_id is None
-                and isinstance(sim.id, UUID)
-            ):
-                case.reference_simulation_id = sim.id
-                db.add(case)
-
-
 def _persist_simulations(
     ingestion_id: UUID,
     simulations: list[SimulationCreate],
@@ -704,10 +684,6 @@ def _persist_simulations(
     hpc_username: str | None = None,
 ) -> list[Simulation]:
     """Persist simulation records with artifacts and links to the database.
-
-    After all simulations are flushed, sets the reference simulation on
-    each Case that does not yet have one.  The first simulation per Case
-    (in insertion order) becomes the reference.
 
     Parameters
     ----------
@@ -773,9 +749,12 @@ def _persist_simulations(
 
     db.flush()
 
-    _set_reference_simulations(db, created_sims)
-
     return created_sims
+
+
+def _set_reference_simulations(db: Session, created_sims: list[Simulation]) -> None:
+    """Legacy compatibility hook retained for tests; no case-level anchor exists."""
+    return None
 
 
 def _build_ingestion_simulation_summaries(

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -4,19 +4,25 @@ Module for ingesting simulation archives and mapping to DB schemas.
 Reference simulation semantics for performance_archive ingestion:
   - A run is "successful" only if all required metadata files are present.
   - case_name (from timing files) is the identity for Case grouping.
-  - The first successful run per case is the reference simulation.
+  - The first successful hashless run per case is the case-wide reference.
   - CASE_HASH is stored as execution metadata for grouping related runs.
+  - Hashed runs compare configuration deltas within their
+    ``(case_id, case_hash)`` subgroup.
   - Each run creates a Simulation linked to a Case via case_id.
-  - Reference simulations have run_config_deltas = None.
-  - Non-reference runs store config differences vs the reference.
+  - Baseline simulations have ``run_config_deltas = None``.
+  - Non-baseline runs store config differences versus the stored baseline.
   - Incomplete runs are skipped at the parser level.
   - Re-processing is idempotent due to execution_id uniqueness.
 
-Caching for reference lookup:
-  - reference_cache: reference metadata for new cases in this ingest batch,
-    keyed by case_name.
-  - persisted_reference_cache: reference metadata for cases already in DB,
-    keyed by case.id, to avoid repeated DB queries.
+Caching for baseline lookup:
+  - reference_cache: case-wide baseline metadata for new hashless cases in this
+    ingest batch, keyed by case_name.
+  - persisted_reference_cache: case-wide baseline metadata for cases already in
+    DB, keyed by case.id, to avoid repeated DB queries.
+  - subgroup_reference_cache: subgroup baseline metadata for new hashed runs in
+    this ingest batch, keyed by ``(case.id, case_hash)``.
+  - persisted_subgroup_reference_cache: subgroup baseline metadata for hashed
+    runs already in DB, keyed by ``(case.id, case_hash)``.
 """
 
 import shlex
@@ -43,6 +49,7 @@ logger = _setup_custom_logger(__name__)
 _STRING_ADAPTER = TypeAdapter(str)
 _DATETIME_ADAPTER = TypeAdapter(datetime)
 _HTTP_URL_ADAPTER = TypeAdapter(HttpUrl)
+SubgroupReferenceKey = tuple[UUID, str]
 
 
 @dataclass
@@ -113,24 +120,15 @@ def ingest_archive(
 ) -> IngestArchiveResult:
     """Ingest a simulation archive and return summary counts.
 
-    Implements reference simulation semantics:
+    Implements baseline selection for reference-style config deltas:
 
     - Case lookup/creation is done by ``case_name`` from timing files.
-    - The first successful run per case becomes the reference simulation
-      (``run_config_deltas = None``).
-    - Non-reference simulations store a single dict of configuration
-      differences versus the reference.
+    - Hashless runs keep case-wide reference behavior.
+    - Hashed runs compare against the stored baseline in the same
+      ``(case_id, case_hash)`` subgroup.
+    - Baseline simulations store ``run_config_deltas = None``.
     - Duplicate detection is based on ``execution_id`` uniqueness.
-    - Uses two caches to avoid redundant work:
-       - ``reference_cache``: Tracks the reference simulation metadata for each
-           new case found in the current ingest batch (keyed by case_name). This
-           ensures that if multiple new runs for the same case appear in a
-           single archive, all are compared against the same in-batch reference.
-       - ``persisted_reference_cache``: Tracks reference simulation metadata
-           for cases already in the database (keyed by case.id). This avoids
-           repeated database queries for the reference simulation of a case
-           when processing multiple runs for the same case in a single ingest
-           operation.
+    - Uses caches to avoid repeated baseline lookups within one ingest.
 
     Parameters
     ----------
@@ -174,6 +172,10 @@ def ingest_archive(
     errors: list[dict[str, str]] = []
     reference_cache: dict[str, SimulationConfigSnapshot] = {}
     persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
+    subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot] = {}
+    persisted_subgroup_reference_cache: dict[
+        SubgroupReferenceKey, SimulationConfigSnapshot | None
+    ] = {}
     case_hash_cache: dict[str, str] = {}
     persisted_case_hash_cache: dict[UUID, str | None] = {}
 
@@ -184,6 +186,8 @@ def ingest_archive(
                 db=db,
                 reference_cache=reference_cache,
                 persisted_reference_cache=persisted_reference_cache,
+                subgroup_reference_cache=subgroup_reference_cache,
+                persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
                 case_hash_cache=case_hash_cache,
                 persisted_case_hash_cache=persisted_case_hash_cache,
             )
@@ -227,6 +231,10 @@ def _process_simulation_for_ingest(
     db: Session,
     reference_cache: dict[str, SimulationConfigSnapshot],
     persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
+    subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
+    persisted_subgroup_reference_cache: dict[
+        SubgroupReferenceKey, SimulationConfigSnapshot | None
+    ],
     case_hash_cache: dict[str, str],
     persisted_case_hash_cache: dict[UUID, str | None],
 ) -> tuple[SimulationCreate | None, bool]:
@@ -253,10 +261,31 @@ def _process_simulation_for_ingest(
     execution_id = parsed_simulation.execution_id
     case_name = _require_case_name(parsed_simulation)
     machine_id = _resolve_machine_id(parsed_simulation, db)
+    existing_simulation = _find_existing_simulation(db, execution_id)
 
-    if _is_duplicate_simulation(execution_id, parsed_simulation.execution_dir, db):
+    if existing_simulation is not None:
+        case = existing_simulation.case
+        _track_case_hash_grouping(
+            parsed_simulation=parsed_simulation,
+            case=case,
+            case_hash_cache=case_hash_cache,
+            persisted_case_hash_cache=persisted_case_hash_cache,
+            db=db,
+        )
+        logger.info(
+            "Simulation with execution_id='%s' already exists. Skipping duplicate "
+            "from %s.",
+            execution_id,
+            parsed_simulation.execution_dir,
+        )
         _seed_reference_cache_from_duplicate(
-            case_name, parsed_simulation, reference_cache
+            parsed_simulation=parsed_simulation,
+            case=case,
+            reference_cache=reference_cache,
+            persisted_reference_cache=persisted_reference_cache,
+            subgroup_reference_cache=subgroup_reference_cache,
+            persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
+            db=db,
         )
         return None, True
 
@@ -276,6 +305,8 @@ def _process_simulation_for_ingest(
         case=case,
         reference_cache=reference_cache,
         persisted_reference_cache=persisted_reference_cache,
+        subgroup_reference_cache=subgroup_reference_cache,
+        persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
         db=db,
     )
 
@@ -370,30 +401,44 @@ def _resolve_case(
     return result
 
 
-def _is_duplicate_simulation(
-    execution_id: str, execution_dir: str, db: Session
-) -> bool:
-    """Return True when a simulation with execution_id already exists."""
-    existing_sim = _find_existing_simulation(db, execution_id)
-
-    if not existing_sim:
-        return False
-
-    logger.info(
-        f"Simulation with execution_id='{execution_id}' "
-        f"already exists. Skipping duplicate from {execution_dir}."
-    )
-    return True
-
-
 def _seed_reference_cache_from_duplicate(
-    case_name: str,
     parsed_simulation: ParsedSimulation,
+    case: Case,
     reference_cache: dict[str, SimulationConfigSnapshot],
+    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
+    subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
+    persisted_subgroup_reference_cache: dict[
+        SubgroupReferenceKey, SimulationConfigSnapshot | None
+    ],
+    db: Session,
 ) -> None:
-    """Seed per-case reference cache using duplicate metadata when needed."""
-    if case_name not in reference_cache:
-        reference_cache[case_name] = _build_config_snapshot(parsed_simulation)
+    """Seed caches from persisted baselines when a duplicate is encountered."""
+    case_hash = parsed_simulation.case_hash
+    if case_hash:
+        reference_snapshot = _get_persisted_subgroup_reference_metadata(
+            case=case,
+            case_hash=case_hash,
+            persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
+            db=db,
+        )
+        if reference_snapshot is None:
+            return
+
+        subgroup_reference_cache.setdefault(
+            _build_subgroup_reference_key(case.id, case_hash),
+            reference_snapshot,
+        )
+        return
+
+    reference_snapshot = _get_persisted_case_reference_metadata(
+        case=case,
+        persisted_reference_cache=persisted_reference_cache,
+        db=db,
+    )
+    if reference_snapshot is None:
+        return
+
+    reference_cache.setdefault(case.name, reference_snapshot)
 
 
 def _build_simulation_create(
@@ -402,6 +447,10 @@ def _build_simulation_create(
     case: Case,
     reference_cache: dict[str, SimulationConfigSnapshot],
     persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
+    subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
+    persisted_subgroup_reference_cache: dict[
+        SubgroupReferenceKey, SimulationConfigSnapshot | None
+    ],
     db: Session,
 ) -> SimulationCreate:
     """Create a SimulationCreate using reference simulation semantics.
@@ -421,17 +470,27 @@ def _build_simulation_create(
     db : Session
         Active database session for lookups and case resolution.
     """
-    case_name = case.name
-    reference_snapshot = _get_reference_metadata_for_case(
+    case_hash = parsed_simulation.case_hash
+    reference_snapshot = _get_reference_metadata_for_simulation(
         case=case,
-        case_name=case_name,
+        case_name=case.name,
+        case_hash=case_hash,
         reference_cache=reference_cache,
         persisted_reference_cache=persisted_reference_cache,
+        subgroup_reference_cache=subgroup_reference_cache,
+        persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
         db=db,
     )
 
     if reference_snapshot is None:
-        reference_cache[case_name] = _build_config_snapshot(parsed_simulation)
+        _cache_reference_snapshot(
+            case=case,
+            case_name=case.name,
+            case_hash=case_hash,
+            reference_snapshot=_build_config_snapshot(parsed_simulation),
+            reference_cache=reference_cache,
+            subgroup_reference_cache=subgroup_reference_cache,
+        )
 
         simulation = _validate_simulation_create(
             replace(prevalidated_draft, case_id=case.id)
@@ -440,7 +499,7 @@ def _build_simulation_create(
         logger.info(
             "Mapped reference simulation from %s: %s",
             parsed_simulation.execution_dir,
-            case_name,
+            case.name,
         )
 
         return simulation
@@ -591,6 +650,63 @@ def _validate_pre_case_draft(draft: SimulationCreateDraft) -> None:
         _HTTP_URL_ADAPTER.validate_python(draft.git_repository_url)
 
 
+def _build_subgroup_reference_key(
+    case_id: UUID, case_hash: str
+) -> SubgroupReferenceKey:
+    return (case_id, case_hash)
+
+
+def _cache_reference_snapshot(
+    *,
+    case: Case,
+    case_name: str,
+    case_hash: str | None,
+    reference_snapshot: SimulationConfigSnapshot,
+    reference_cache: dict[str, SimulationConfigSnapshot],
+    subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
+) -> None:
+    """Store a new baseline snapshot in the appropriate in-batch cache."""
+    if case_hash:
+        subgroup_reference_cache[_build_subgroup_reference_key(case.id, case_hash)] = (
+            reference_snapshot
+        )
+        return
+
+    reference_cache[case_name] = reference_snapshot
+
+
+def _get_reference_metadata_for_simulation(
+    *,
+    case: Case,
+    case_name: str,
+    case_hash: str | None,
+    reference_cache: dict[str, SimulationConfigSnapshot],
+    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
+    subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
+    persisted_subgroup_reference_cache: dict[
+        SubgroupReferenceKey, SimulationConfigSnapshot | None
+    ],
+    db: Session,
+) -> SimulationConfigSnapshot | None:
+    """Resolve baseline metadata for a parsed simulation."""
+    if case_hash:
+        return _get_reference_metadata_for_subgroup(
+            case=case,
+            case_hash=case_hash,
+            subgroup_reference_cache=subgroup_reference_cache,
+            persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
+            db=db,
+        )
+
+    return _get_reference_metadata_for_case(
+        case=case,
+        case_name=case_name,
+        reference_cache=reference_cache,
+        persisted_reference_cache=persisted_reference_cache,
+        db=db,
+    )
+
+
 def _get_reference_metadata_for_case(
     case: Case,
     case_name: str,
@@ -619,26 +735,99 @@ def _get_reference_metadata_for_case(
     SimulationConfigSnapshot | None
         The reference config snapshot for the case, or None if no reference run exists.
     """
-    if case.reference_simulation_id is not None:
-        if case.id in persisted_reference_cache:
-            return persisted_reference_cache[case.id]
-
-        reference_simulation = (
-            db.query(Simulation)
-            .filter(Simulation.id == case.reference_simulation_id)
-            .first()
-        )
-
-        if reference_simulation:
-            reference_snapshot = _build_config_snapshot(reference_simulation)
-            persisted_reference_cache[case.id] = reference_snapshot
-
-            return reference_snapshot
-
-        persisted_reference_cache[case.id] = None
-        return None
+    persisted_reference = _get_persisted_case_reference_metadata(
+        case=case,
+        persisted_reference_cache=persisted_reference_cache,
+        db=db,
+    )
+    if persisted_reference is not None:
+        return persisted_reference
 
     return reference_cache.get(case_name)
+
+
+def _get_persisted_case_reference_metadata(
+    case: Case,
+    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
+    db: Session,
+) -> SimulationConfigSnapshot | None:
+    """Resolve case-wide baseline metadata from the persisted reference simulation."""
+    if case.reference_simulation_id is None:
+        return None
+
+    if case.id in persisted_reference_cache:
+        return persisted_reference_cache[case.id]
+
+    reference_simulation = (
+        db.query(Simulation)
+        .filter(Simulation.id == case.reference_simulation_id)
+        .first()
+    )
+
+    if reference_simulation:
+        reference_snapshot = _build_config_snapshot(reference_simulation)
+        persisted_reference_cache[case.id] = reference_snapshot
+        return reference_snapshot
+
+    persisted_reference_cache[case.id] = None
+    return None
+
+
+def _get_reference_metadata_for_subgroup(
+    *,
+    case: Case,
+    case_hash: str,
+    subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
+    persisted_subgroup_reference_cache: dict[
+        SubgroupReferenceKey, SimulationConfigSnapshot | None
+    ],
+    db: Session,
+) -> SimulationConfigSnapshot | None:
+    """Resolve baseline metadata for a hashed subgroup."""
+    subgroup_key = _build_subgroup_reference_key(case.id, case_hash)
+    persisted_reference = _get_persisted_subgroup_reference_metadata(
+        case=case,
+        case_hash=case_hash,
+        persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
+        db=db,
+    )
+    if persisted_reference is not None:
+        return persisted_reference
+
+    return subgroup_reference_cache.get(subgroup_key)
+
+
+def _get_persisted_subgroup_reference_metadata(
+    *,
+    case: Case,
+    case_hash: str,
+    persisted_subgroup_reference_cache: dict[
+        SubgroupReferenceKey, SimulationConfigSnapshot | None
+    ],
+    db: Session,
+) -> SimulationConfigSnapshot | None:
+    """Resolve subgroup baseline metadata from persisted simulations."""
+    subgroup_key = _build_subgroup_reference_key(case.id, case_hash)
+    if subgroup_key in persisted_subgroup_reference_cache:
+        return persisted_subgroup_reference_cache[subgroup_key]
+
+    reference_simulation = (
+        db.query(Simulation)
+        .filter(
+            Simulation.case_id == case.id,
+            Simulation.case_hash == case_hash,
+        )
+        .order_by(Simulation.created_at, Simulation.id)
+        .first()
+    )
+
+    if reference_simulation:
+        reference_snapshot = _build_config_snapshot(reference_simulation)
+        persisted_subgroup_reference_cache[subgroup_key] = reference_snapshot
+        return reference_snapshot
+
+    persisted_subgroup_reference_cache[subgroup_key] = None
+    return None
 
 
 def _get_or_create_case(db: Session, name: str, case_group: str | None = None) -> Case:

--- a/backend/app/features/ingestion/ingest.py
+++ b/backend/app/features/ingestion/ingest.py
@@ -1,27 +1,23 @@
 """
 Module for ingesting simulation archives and mapping to DB schemas.
 
-Reference simulation semantics for performance_archive ingestion:
+Anchor-run semantics for performance_archive ingestion:
   - A run is "successful" only if all required metadata files are present.
   - case_name (from timing files) is the identity for Case grouping.
-  - The first successful hashless run per case is the case-wide reference.
   - CASE_HASH is stored as execution metadata for grouping related runs.
   - Hashed runs compare configuration deltas within their
     ``(case_id, case_hash)`` subgroup.
+  - Hashless runs are treated as legacy rows without a comparison anchor.
   - Each run creates a Simulation linked to a Case via case_id.
-  - Baseline simulations have ``run_config_deltas = None``.
-  - Non-baseline runs store config differences versus the stored baseline.
+  - Anchor runs and legacy hashless runs have ``run_config_deltas = None``.
+  - Non-anchor hashed runs store config differences versus the subgroup anchor.
   - Incomplete runs are skipped at the parser level.
   - Re-processing is idempotent due to execution_id uniqueness.
 
-Caching for baseline lookup:
-  - reference_cache: case-wide baseline metadata for new hashless cases in this
-    ingest batch, keyed by case_name.
-  - persisted_reference_cache: case-wide baseline metadata for cases already in
-    DB, keyed by case.id, to avoid repeated DB queries.
-  - subgroup_reference_cache: subgroup baseline metadata for new hashed runs in
+Caching for anchor lookup:
+  - subgroup_reference_cache: subgroup anchor metadata for new hashed runs in
     this ingest batch, keyed by ``(case.id, case_hash)``.
-  - persisted_subgroup_reference_cache: subgroup baseline metadata for hashed
+  - persisted_subgroup_reference_cache: subgroup anchor metadata for hashed
     runs already in DB, keyed by ``(case.id, case_hash)``.
 """
 
@@ -120,15 +116,15 @@ def ingest_archive(
 ) -> IngestArchiveResult:
     """Ingest a simulation archive and return summary counts.
 
-    Implements baseline selection for reference-style config deltas:
+    Implements subgroup anchor selection for config deltas:
 
     - Case lookup/creation is done by ``case_name`` from timing files.
-    - Hashless runs keep case-wide reference behavior.
+    - Hashless runs keep legacy fallback behavior with no comparison anchor.
     - Hashed runs compare against the stored baseline in the same
       ``(case_id, case_hash)`` subgroup.
-    - Baseline simulations store ``run_config_deltas = None``.
+    - Anchor simulations store ``run_config_deltas = None``.
     - Duplicate detection is based on ``execution_id`` uniqueness.
-    - Uses caches to avoid repeated baseline lookups within one ingest.
+    - Uses caches to avoid repeated anchor lookups within one ingest.
 
     Parameters
     ----------
@@ -170,8 +166,6 @@ def ingest_archive(
     simulations: list[SimulationCreate] = []
     duplicate_count = 0
     errors: list[dict[str, str]] = []
-    reference_cache: dict[str, SimulationConfigSnapshot] = {}
-    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
     subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot] = {}
     persisted_subgroup_reference_cache: dict[
         SubgroupReferenceKey, SimulationConfigSnapshot | None
@@ -184,8 +178,6 @@ def ingest_archive(
             simulation, is_duplicate = _process_simulation_for_ingest(
                 parsed_simulation=parsed_simulation,
                 db=db,
-                reference_cache=reference_cache,
-                persisted_reference_cache=persisted_reference_cache,
                 subgroup_reference_cache=subgroup_reference_cache,
                 persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
                 case_hash_cache=case_hash_cache,
@@ -229,8 +221,6 @@ def ingest_archive(
 def _process_simulation_for_ingest(
     parsed_simulation: ParsedSimulation,
     db: Session,
-    reference_cache: dict[str, SimulationConfigSnapshot],
-    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
     subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
     persisted_subgroup_reference_cache: dict[
         SubgroupReferenceKey, SimulationConfigSnapshot | None
@@ -246,11 +236,6 @@ def _process_simulation_for_ingest(
         Parsed archive-derived metadata for the simulation.
     db : Session
         Active database session for lookups and case resolution.
-    reference_cache : dict[str, SimulationConfigSnapshot]
-        In-memory cache of reference config values per case_name for the current batch.
-    persisted_reference_cache : dict[UUID, SimulationConfigSnapshot | None]
-        Cache of reference metadata loaded from the database by case_id.
-
     Returns
     -------
     tuple[SimulationCreate | None, bool]
@@ -281,8 +266,6 @@ def _process_simulation_for_ingest(
         _seed_reference_cache_from_duplicate(
             parsed_simulation=parsed_simulation,
             case=case,
-            reference_cache=reference_cache,
-            persisted_reference_cache=persisted_reference_cache,
             subgroup_reference_cache=subgroup_reference_cache,
             persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
             db=db,
@@ -303,8 +286,6 @@ def _process_simulation_for_ingest(
         parsed_simulation=parsed_simulation,
         prevalidated_draft=prevalidated_draft,
         case=case,
-        reference_cache=reference_cache,
-        persisted_reference_cache=persisted_reference_cache,
         subgroup_reference_cache=subgroup_reference_cache,
         persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
         db=db,
@@ -356,23 +337,24 @@ def _get_known_case_hash(
     db: Session,
 ) -> str | None:
     """Return first known CASE_HASH used for within-case execution grouping."""
-    if case.reference_simulation_id is not None:
-        if case.id not in persisted_case_hash_cache:
-            reference_simulation = (
-                db.query(Simulation)
-                .filter(Simulation.id == case.reference_simulation_id)
-                .first()
+    if case.id not in persisted_case_hash_cache:
+        known_hash = (
+            db.query(Simulation.case_hash)
+            .filter(
+                Simulation.case_id == case.id,
+                Simulation.case_hash.is_not(None),
             )
-            known_hash = (
-                reference_simulation.case_hash if reference_simulation else None
-            )
-            persisted_case_hash_cache[case.id] = known_hash
-            if known_hash is not None:
-                case_hash_cache.setdefault(case.name, known_hash)
-
-        known_hash = persisted_case_hash_cache[case.id]
+            .order_by(Simulation.created_at, Simulation.id)
+            .limit(1)
+            .scalar()
+        )
+        persisted_case_hash_cache[case.id] = known_hash
         if known_hash is not None:
-            return known_hash
+            case_hash_cache.setdefault(case.name, known_hash)
+
+    known_hash = persisted_case_hash_cache[case.id]
+    if known_hash is not None:
+        return known_hash
 
     return case_hash_cache.get(case.name)
 
@@ -404,56 +386,43 @@ def _resolve_case(
 def _seed_reference_cache_from_duplicate(
     parsed_simulation: ParsedSimulation,
     case: Case,
-    reference_cache: dict[str, SimulationConfigSnapshot],
-    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
     subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
     persisted_subgroup_reference_cache: dict[
         SubgroupReferenceKey, SimulationConfigSnapshot | None
     ],
     db: Session,
 ) -> None:
-    """Seed caches from persisted baselines when a duplicate is encountered."""
+    """Seed hashed subgroup anchor caches when a duplicate is encountered."""
     case_hash = parsed_simulation.case_hash
-    if case_hash:
-        reference_snapshot = _get_persisted_subgroup_reference_metadata(
-            case=case,
-            case_hash=case_hash,
-            persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
-            db=db,
-        )
-        if reference_snapshot is None:
-            return
-
-        subgroup_reference_cache.setdefault(
-            _build_subgroup_reference_key(case.id, case_hash),
-            reference_snapshot,
-        )
+    if not case_hash:
         return
 
-    reference_snapshot = _get_persisted_case_reference_metadata(
+    reference_snapshot = _get_persisted_subgroup_reference_metadata(
         case=case,
-        persisted_reference_cache=persisted_reference_cache,
+        case_hash=case_hash,
+        persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
         db=db,
     )
     if reference_snapshot is None:
         return
 
-    reference_cache.setdefault(case.name, reference_snapshot)
+    subgroup_reference_cache.setdefault(
+        _build_subgroup_reference_key(case.id, case_hash),
+        reference_snapshot,
+    )
 
 
 def _build_simulation_create(
     parsed_simulation: ParsedSimulation,
     prevalidated_draft: SimulationCreateDraft,
     case: Case,
-    reference_cache: dict[str, SimulationConfigSnapshot],
-    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
     subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
     persisted_subgroup_reference_cache: dict[
         SubgroupReferenceKey, SimulationConfigSnapshot | None
     ],
     db: Session,
 ) -> SimulationCreate:
-    """Create a SimulationCreate using reference simulation semantics.
+    """Create a SimulationCreate using anchor-run semantics.
 
     Parameters
     ----------
@@ -463,20 +432,13 @@ def _build_simulation_create(
         Draft with normalized fields already parsed and prevalidated.
     case : Case
         Resolved Case object for this simulation.
-    reference_cache : dict[str, SimulationConfigSnapshot]
-        In-memory cache of reference metadata per case_name for the current batch.
-    persisted_reference_cache : dict[UUID, SimulationConfigSnapshot | None]
-        Cache of reference metadata loaded from the database by case_id.
     db : Session
         Active database session for lookups and case resolution.
     """
     case_hash = parsed_simulation.case_hash
     reference_snapshot = _get_reference_metadata_for_simulation(
         case=case,
-        case_name=case.name,
         case_hash=case_hash,
-        reference_cache=reference_cache,
-        persisted_reference_cache=persisted_reference_cache,
         subgroup_reference_cache=subgroup_reference_cache,
         persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
         db=db,
@@ -485,10 +447,8 @@ def _build_simulation_create(
     if reference_snapshot is None:
         _cache_reference_snapshot(
             case=case,
-            case_name=case.name,
             case_hash=case_hash,
             reference_snapshot=_build_config_snapshot(parsed_simulation),
-            reference_cache=reference_cache,
             subgroup_reference_cache=subgroup_reference_cache,
         )
 
@@ -496,11 +456,19 @@ def _build_simulation_create(
             replace(prevalidated_draft, case_id=case.id)
         )
         simulation = _attach_path_artifacts(simulation, parsed_simulation)
-        logger.info(
-            "Mapped reference simulation from %s: %s",
-            parsed_simulation.execution_dir,
-            case.name,
-        )
+        if case_hash:
+            logger.info(
+                "Mapped anchor run from %s: %s [%s]",
+                parsed_simulation.execution_dir,
+                case.name,
+                case_hash,
+            )
+        else:
+            logger.info(
+                "Mapped legacy run without comparison anchor from %s: %s",
+                parsed_simulation.execution_dir,
+                case.name,
+            )
 
         return simulation
 
@@ -515,13 +483,13 @@ def _build_simulation_create(
 
     if delta:
         logger.info(
-            "Non-reference run in '%s' has config differences from the reference: %s",
+            "Run in '%s' has config differences from its comparison anchor: %s",
             parsed_simulation.execution_dir,
             list(delta.keys()),
         )
     else:
         logger.info(
-            "Non-reference run in '%s' has identical configuration to the reference.",
+            "Run in '%s' has identical configuration to its comparison anchor.",
             parsed_simulation.execution_dir,
         )
 
@@ -659,50 +627,38 @@ def _build_subgroup_reference_key(
 def _cache_reference_snapshot(
     *,
     case: Case,
-    case_name: str,
     case_hash: str | None,
     reference_snapshot: SimulationConfigSnapshot,
-    reference_cache: dict[str, SimulationConfigSnapshot],
     subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
 ) -> None:
-    """Store a new baseline snapshot in the appropriate in-batch cache."""
-    if case_hash:
-        subgroup_reference_cache[_build_subgroup_reference_key(case.id, case_hash)] = (
-            reference_snapshot
-        )
+    """Store a new hashed subgroup anchor snapshot in the in-batch cache."""
+    if case_hash is None:
         return
 
-    reference_cache[case_name] = reference_snapshot
+    subgroup_reference_cache[_build_subgroup_reference_key(case.id, case_hash)] = (
+        reference_snapshot
+    )
 
 
 def _get_reference_metadata_for_simulation(
     *,
     case: Case,
-    case_name: str,
     case_hash: str | None,
-    reference_cache: dict[str, SimulationConfigSnapshot],
-    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
     subgroup_reference_cache: dict[SubgroupReferenceKey, SimulationConfigSnapshot],
     persisted_subgroup_reference_cache: dict[
         SubgroupReferenceKey, SimulationConfigSnapshot | None
     ],
     db: Session,
 ) -> SimulationConfigSnapshot | None:
-    """Resolve baseline metadata for a parsed simulation."""
-    if case_hash:
-        return _get_reference_metadata_for_subgroup(
-            case=case,
-            case_hash=case_hash,
-            subgroup_reference_cache=subgroup_reference_cache,
-            persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
-            db=db,
-        )
+    """Resolve comparison anchor metadata for a parsed simulation."""
+    if case_hash is None:
+        return None
 
-    return _get_reference_metadata_for_case(
+    return _get_reference_metadata_for_subgroup(
         case=case,
-        case_name=case_name,
-        reference_cache=reference_cache,
-        persisted_reference_cache=persisted_reference_cache,
+        case_hash=case_hash,
+        subgroup_reference_cache=subgroup_reference_cache,
+        persisted_subgroup_reference_cache=persisted_subgroup_reference_cache,
         db=db,
     )
 
@@ -714,62 +670,7 @@ def _get_reference_metadata_for_case(
     persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
     db: Session,
 ) -> SimulationConfigSnapshot | None:
-    """Resolve reference metadata from persisted reference or batch cache.
-
-    This function is useful for ensuring that all simulations of the same case
-    within a batch are compared against a consistent reference simulation.
-
-    Parameters
-    ----------
-    case : Case
-        The Case object for which to retrieve reference metadata.
-    case_name : str
-        The name of the case, used for in-memory cache lookup.
-    reference_cache : dict[str, SimulationConfigSnapshot]
-        In-memory cache of reference metadata per case_name for the current batch.
-    persisted_reference_cache : dict[UUID, SimulationConfigSnapshot | None]
-        Cache of reference metadata loaded from the database by case_id.
-
-    Returns
-    -------
-    SimulationConfigSnapshot | None
-        The reference config snapshot for the case, or None if no reference run exists.
-    """
-    persisted_reference = _get_persisted_case_reference_metadata(
-        case=case,
-        persisted_reference_cache=persisted_reference_cache,
-        db=db,
-    )
-    if persisted_reference is not None:
-        return persisted_reference
-
-    return reference_cache.get(case_name)
-
-
-def _get_persisted_case_reference_metadata(
-    case: Case,
-    persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None],
-    db: Session,
-) -> SimulationConfigSnapshot | None:
-    """Resolve case-wide baseline metadata from the persisted reference simulation."""
-    if case.reference_simulation_id is None:
-        return None
-
-    if case.id in persisted_reference_cache:
-        return persisted_reference_cache[case.id]
-
-    reference_simulation = (
-        db.query(Simulation)
-        .filter(Simulation.id == case.reference_simulation_id)
-        .first()
-    )
-
-    if reference_simulation:
-        reference_snapshot = _build_config_snapshot(reference_simulation)
-        persisted_reference_cache[case.id] = reference_snapshot
-        return reference_snapshot
-
-    persisted_reference_cache[case.id] = None
+    """Legacy compatibility helper: hashless rows no longer resolve a case-level anchor."""
     return None
 
 

--- a/backend/app/features/simulation/anchor.py
+++ b/backend/app/features/simulation/anchor.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import func, select, tuple_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from app.features.simulation.models import Simulation
+
+SubgroupKey = tuple[UUID, str]
+
+
+@dataclass(frozen=True)
+class AnchorRunState:
+    is_anchor_run: bool
+    anchor_simulation_id: UUID | None
+
+
+def resolve_anchor_run_state(
+    db: Session,
+    simulation: Simulation,
+) -> AnchorRunState:
+    states = resolve_anchor_run_states(db, [simulation])
+    if simulation.id is None:
+        return AnchorRunState(is_anchor_run=False, anchor_simulation_id=None)
+
+    return states.get(
+        simulation.id,
+        AnchorRunState(is_anchor_run=False, anchor_simulation_id=None),
+    )
+
+
+async def resolve_anchor_run_state_async(
+    db: AsyncSession,
+    simulation: Simulation,
+) -> AnchorRunState:
+    states = await resolve_anchor_run_states_async(db, [simulation])
+    if simulation.id is None:
+        return AnchorRunState(is_anchor_run=False, anchor_simulation_id=None)
+
+    return states.get(
+        simulation.id,
+        AnchorRunState(is_anchor_run=False, anchor_simulation_id=None),
+    )
+
+
+def resolve_anchor_run_states(
+    db: Session,
+    simulations: Sequence[Simulation],
+) -> dict[UUID, AnchorRunState]:
+    subgroup_keys = {
+        (simulation.case_id, simulation.case_hash)
+        for simulation in simulations
+        if simulation.id is not None and simulation.case_hash is not None
+    }
+    anchor_ids = _load_subgroup_anchor_ids(db, subgroup_keys)
+    states: dict[UUID, AnchorRunState] = {}
+
+    for simulation in simulations:
+        if simulation.id is None:
+            continue
+
+        if simulation.case_hash is None:
+            states[simulation.id] = AnchorRunState(
+                is_anchor_run=False,
+                anchor_simulation_id=None,
+            )
+            continue
+
+        anchor_simulation_id = anchor_ids.get(
+            (simulation.case_id, simulation.case_hash)
+        )
+        states[simulation.id] = AnchorRunState(
+            is_anchor_run=anchor_simulation_id == simulation.id,
+            anchor_simulation_id=anchor_simulation_id,
+        )
+
+    return states
+
+
+async def resolve_anchor_run_states_async(
+    db: AsyncSession,
+    simulations: Sequence[Simulation],
+) -> dict[UUID, AnchorRunState]:
+    subgroup_keys = {
+        (simulation.case_id, simulation.case_hash)
+        for simulation in simulations
+        if simulation.id is not None and simulation.case_hash is not None
+    }
+    anchor_ids = await _load_subgroup_anchor_ids_async(db, subgroup_keys)
+    states: dict[UUID, AnchorRunState] = {}
+
+    for simulation in simulations:
+        if simulation.id is None:
+            continue
+
+        if simulation.case_hash is None:
+            states[simulation.id] = AnchorRunState(
+                is_anchor_run=False,
+                anchor_simulation_id=None,
+            )
+            continue
+
+        anchor_simulation_id = anchor_ids.get(
+            (simulation.case_id, simulation.case_hash)
+        )
+        states[simulation.id] = AnchorRunState(
+            is_anchor_run=anchor_simulation_id == simulation.id,
+            anchor_simulation_id=anchor_simulation_id,
+        )
+
+    return states
+
+
+def _load_subgroup_anchor_ids(
+    db: Session,
+    subgroup_keys: set[SubgroupKey],
+) -> dict[SubgroupKey, UUID]:
+    if not subgroup_keys:
+        return {}
+
+    rows = db.execute(_build_anchor_ids_query(subgroup_keys)).all()
+
+    return _map_anchor_rows(rows)
+
+
+async def _load_subgroup_anchor_ids_async(
+    db: AsyncSession,
+    subgroup_keys: set[SubgroupKey],
+) -> dict[SubgroupKey, UUID]:
+    if not subgroup_keys:
+        return {}
+
+    rows = (await db.execute(_build_anchor_ids_query(subgroup_keys))).all()
+
+    return _map_anchor_rows(rows)
+
+
+def _build_anchor_ids_query(subgroup_keys: set[SubgroupKey]):
+    ranked_subquery = (
+        select(
+            Simulation.case_id.label("case_id"),
+            Simulation.case_hash.label("case_hash"),
+            Simulation.id.label("simulation_id"),
+            func.row_number()
+            .over(
+                partition_by=(Simulation.case_id, Simulation.case_hash),
+                order_by=(Simulation.created_at.asc(), Simulation.id.asc()),
+            )
+            .label("row_number"),
+        )
+        .where(tuple_(Simulation.case_id, Simulation.case_hash).in_(subgroup_keys))
+        .subquery()
+    )
+
+    return select(
+        ranked_subquery.c.case_id,
+        ranked_subquery.c.case_hash,
+        ranked_subquery.c.simulation_id,
+    ).where(ranked_subquery.c.row_number == 1)
+
+
+def _map_anchor_rows(
+    rows: Sequence[tuple[UUID, str | None, UUID]],
+) -> dict[SubgroupKey, UUID]:
+    return {
+        (case_id, case_hash): simulation_id
+        for case_id, case_hash, simulation_id in rows
+        if case_hash is not None
+    }

--- a/backend/app/features/simulation/api.py
+++ b/backend/app/features/simulation/api.py
@@ -9,6 +9,11 @@ from app.core.database import transaction
 from app.features.assistant.orchestrator import is_summary_llm_available
 from app.features.ingestion.enums import IngestionSourceType, IngestionStatus
 from app.features.ingestion.models import Ingestion
+from app.features.simulation.anchor import (
+    AnchorRunState,
+    resolve_anchor_run_state,
+    resolve_anchor_run_states,
+)
 from app.features.simulation.models import Artifact, Case, ExternalLink, Simulation
 from app.features.simulation.schemas import (
     CaseOut,
@@ -54,7 +59,7 @@ def list_cases(db: Session = Depends(get_database_session)) -> list[CaseOut]:
         .all()
     )
 
-    resp = [_case_to_out(c) for c in cases]
+    resp = [_case_to_out(db, c) for c in cases]
 
     return resp
 
@@ -124,12 +129,12 @@ def get_case(case_id: UUID, db: Session = Depends(get_database_session)) -> Case
     if not case:
         raise HTTPException(status_code=404, detail="Case not found")
 
-    resp = _case_to_out(case)
+    resp = _case_to_out(db, case)
 
     return resp
 
 
-def _case_to_out(case: Case) -> CaseOut:
+def _case_to_out(db: Session, case: Case) -> CaseOut:
     """Convert a Case ORM instance to CaseOut with nested SimulationSummaryOut.
 
     Parameters
@@ -157,8 +162,13 @@ def _case_to_out(case: Case) -> CaseOut:
         key=lambda username: username.lower(),
     )
 
+    anchor_states = resolve_anchor_run_states(db, case.simulations)
+
     for sim in case.simulations:
-        is_reference = sim.id == case.reference_simulation_id
+        anchor_state = anchor_states.get(
+            sim.id,
+            AnchorRunState(is_anchor_run=False, anchor_simulation_id=None),
+        )
         change_count = len(sim.run_config_deltas) if sim.run_config_deltas else 0
 
         summaries.append(
@@ -167,7 +177,8 @@ def _case_to_out(case: Case) -> CaseOut:
                 execution_id=sim.execution_id,
                 case_hash=sim.case_hash,
                 status=sim.status,
-                is_reference=is_reference,
+                is_anchor_run=anchor_state.is_anchor_run,
+                anchor_simulation_id=anchor_state.anchor_simulation_id,
                 change_count=change_count,
                 simulation_start_date=sim.simulation_start_date,
                 simulation_end_date=sim.simulation_end_date,
@@ -178,7 +189,6 @@ def _case_to_out(case: Case) -> CaseOut:
         id=case.id,
         name=case.name,
         case_group=case.case_group,
-        reference_simulation_id=case.reference_simulation_id,
         simulations=summaries,
         machine_names=machine_names,
         hpc_usernames=hpc_usernames,
@@ -260,11 +270,6 @@ def create_simulation(
         db.add(sim)
         db.flush()
 
-        if case.reference_simulation_id is None:
-            sim.run_config_deltas = None
-            case.reference_simulation_id = sim.id
-            db.add(case)
-
     # Re-query with relationships loaded
     sim_loaded = (
         db.query(Simulation)
@@ -284,7 +289,7 @@ def create_simulation(
             detail="Failed to load newly created simulation.",
         )
 
-    result = _simulation_to_out(sim_loaded)
+    result = _simulation_to_out(db, sim_loaded)
 
     return result
 
@@ -344,7 +349,8 @@ def list_simulations(
         query = query.filter(Simulation.case.has(case_group=case_group))
 
     sims = query.order_by(Simulation.created_at.desc()).all()
-    return [_simulation_to_out(s) for s in sims]
+    anchor_states = resolve_anchor_run_states(db, sims)
+    return [_simulation_to_out(db, s, anchor_states.get(s.id)) for s in sims]
 
 
 @simulation_router.get(
@@ -393,13 +399,17 @@ def get_simulation(sim_id: UUID, db: Session = Depends(get_database_session)):
     if not sim:
         raise HTTPException(status_code=404, detail="Simulation not found")
 
-    return _simulation_to_out(sim)
+    return _simulation_to_out(db, sim)
 
 
-def _simulation_to_out(sim: Simulation) -> SimulationOut:
+def _simulation_to_out(
+    db: Session,
+    sim: Simulation,
+    anchor_state: AnchorRunState | None = None,
+) -> SimulationOut:
     """Convert a Simulation ORM instance to a SimulationOut schema.
 
-    Derives ``case_name``, ``is_reference``, and ``change_count`` from
+    Derives ``case_name``, anchor metadata, and ``change_count`` from
     the associated Case relationship.
 
     Parameters
@@ -414,7 +424,7 @@ def _simulation_to_out(sim: Simulation) -> SimulationOut:
         fields.
     """
     case = sim.case
-    is_reference = sim.id == case.reference_simulation_id
+    resolved_anchor_state = anchor_state or resolve_anchor_run_state(db, sim)
     change_count = len(sim.run_config_deltas) if sim.run_config_deltas else 0
     llm_available = is_summary_llm_available()
 
@@ -423,7 +433,8 @@ def _simulation_to_out(sim: Simulation) -> SimulationOut:
             **{k: v for k, v in sim.__dict__.items() if not k.startswith("_")},
             "case_name": case.name,
             "case_group": case.case_group,
-            "is_reference": is_reference,
+            "is_anchor_run": resolved_anchor_state.is_anchor_run,
+            "anchor_simulation_id": resolved_anchor_state.anchor_simulation_id,
             "change_count": change_count,
             "summary_capabilities": SimulationSummaryCapabilitiesOut(
                 llm_available=llm_available,

--- a/backend/app/features/simulation/models.py
+++ b/backend/app/features/simulation/models.py
@@ -29,20 +29,13 @@ if TYPE_CHECKING:
 class Case(Base, IDMixin, TimestampMixin):
     """A logical experiment grouped by case name.
 
-    Each Case contains one or more Simulation executions.  Exactly one
-    Simulation may be designated as the reference via
-    :attr:`reference_simulation_id`.
+    Each Case contains one or more Simulation executions grouped by case name.
     """
 
     __tablename__ = "cases"
 
     name: Mapped[str] = mapped_column(Text, unique=True, index=True)
     case_group: Mapped[str | None] = mapped_column(Text, index=True, nullable=True)
-    reference_simulation_id: Mapped[UUID | None] = mapped_column(
-        PG_UUID(as_uuid=True),
-        ForeignKey("simulations.id", use_alter=True, name="fk_cases_reference_sim"),
-        nullable=True,
-    )
 
     # Relationships
     simulations: Mapped[list[Simulation]] = relationship(
@@ -51,9 +44,6 @@ class Case(Base, IDMixin, TimestampMixin):
         foreign_keys="Simulation.case_id",
         cascade="all, delete-orphan",
         passive_deletes=True,
-    )
-    reference_simulation: Mapped[Simulation | None] = relationship(
-        "Simulation", foreign_keys=[reference_simulation_id], post_update=True
     )
 
 

--- a/backend/app/features/simulation/schemas.py
+++ b/backend/app/features/simulation/schemas.py
@@ -262,8 +262,8 @@ class SimulationCreate(CamelInBaseModel):
             None,
             description=(
                 "Configuration differences between this simulation and the "
-                "reference simulation for the same case. None for reference "
-                "simulations or when no differences exist."
+                "stored baseline for its case or case-hash subgroup. None for "
+                "baseline simulations or when no differences exist."
             ),
         ),
     ]
@@ -330,8 +330,8 @@ class SimulationSummaryOut(CamelOutBaseModel):
         Field(
             ...,
             description=(
-                "Number of configuration differences vs the reference simulation. "
-                "0 for reference simulations."
+                "Number of recorded configuration differences for this run. "
+                "0 when no differences are recorded."
             ),
         ),
     ]
@@ -467,8 +467,8 @@ class SimulationOut(CamelOutBaseModel):
         Field(
             ...,
             description=(
-                "Number of configuration differences vs the reference simulation. "
-                "0 for reference simulations."
+                "Number of recorded configuration differences for this run. "
+                "0 when no differences are recorded."
             ),
         ),
     ]
@@ -617,8 +617,8 @@ class SimulationOut(CamelOutBaseModel):
             None,
             description=(
                 "Configuration differences between this simulation and the "
-                "reference simulation for the same case. None for reference "
-                "simulations or when no differences exist."
+                "stored baseline for its case or case-hash subgroup. None for "
+                "baseline simulations or when no differences exist."
             ),
         ),
     ]

--- a/backend/app/features/simulation/schemas.py
+++ b/backend/app/features/simulation/schemas.py
@@ -261,9 +261,9 @@ class SimulationCreate(CamelInBaseModel):
         Field(
             None,
             description=(
-                "Configuration differences between this simulation and the "
-                "stored baseline for its case or case-hash subgroup. None for "
-                "baseline simulations or when no differences exist."
+                "Configuration differences between this simulation and its "
+                "comparison anchor in the same case-hash subgroup when one "
+                "exists. None when no differences are recorded."
             ),
         ),
     ]
@@ -318,11 +318,23 @@ class SimulationSummaryOut(CamelOutBaseModel):
     status: Annotated[
         SimulationStatus, Field(..., description="Current status of the simulation")
     ]
-    is_reference: Annotated[
+    is_anchor_run: Annotated[
         bool,
         Field(
             ...,
-            description="Whether this simulation is the reference for its case",
+            description=(
+                "Whether this simulation is the anchor run for its case-hash subgroup."
+            ),
+        ),
+    ]
+    anchor_simulation_id: Annotated[
+        UUID | None,
+        Field(
+            None,
+            description=(
+                "ID of the comparison anchor run for this simulation's "
+                "case-hash subgroup. Null for legacy runs without CASE_HASH."
+            ),
         ),
     ]
     change_count: Annotated[
@@ -376,10 +388,6 @@ class CaseOut(CamelOutBaseModel):
                 "Groups related cases (e.g. ensemble members) together."
             ),
         ),
-    ]
-    reference_simulation_id: Annotated[
-        UUID | None,
-        Field(None, description="ID of the reference simulation for this case."),
     ]
     simulations: Annotated[
         list[SimulationSummaryOut],
@@ -455,11 +463,23 @@ class SimulationOut(CamelOutBaseModel):
             ),
         ),
     ]
-    is_reference: Annotated[
+    is_anchor_run: Annotated[
         bool,
         Field(
             ...,
-            description="Whether this simulation is the reference for its case",
+            description=(
+                "Whether this simulation is the anchor run for its case-hash subgroup."
+            ),
+        ),
+    ]
+    anchor_simulation_id: Annotated[
+        UUID | None,
+        Field(
+            None,
+            description=(
+                "ID of the comparison anchor run for this simulation's "
+                "case-hash subgroup. Null for legacy runs without CASE_HASH."
+            ),
         ),
     ]
     change_count: Annotated[
@@ -616,9 +636,9 @@ class SimulationOut(CamelOutBaseModel):
         Field(
             None,
             description=(
-                "Configuration differences between this simulation and the "
-                "stored baseline for its case or case-hash subgroup. None for "
-                "baseline simulations or when no differences exist."
+                "Configuration differences between this simulation and its "
+                "comparison anchor in the same case-hash subgroup when one "
+                "exists. None when no differences are recorded."
             ),
         ),
     ]

--- a/backend/app/scripts/db/rollback_seed.py
+++ b/backend/app/scripts/db/rollback_seed.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 import app.models  # noqa: F401 # required to register models with SQLAlchemy
@@ -71,14 +71,6 @@ def rollback_seed(db: Session):
                         Artifact.__table__.c.simulation_id.in_(simulation_ids)
                     )
                 )
-
-                # Clear reference_simulation_id on cases before deleting simulations
-                if case_ids:
-                    db.execute(
-                        update(Case)
-                        .where(Case.__table__.c.id.in_(case_ids))
-                        .values(reference_simulation_id=None)
-                    )
 
                 db.execute(
                     delete(Simulation).where(

--- a/backend/app/scripts/db/seed.py
+++ b/backend/app/scripts/db/seed.py
@@ -167,21 +167,10 @@ def seed_from_json(db: Session, json_path: str):
         db.add(case)
         db.flush()
 
-        first_sim = None
-
         for sim_entry in simulations_data:
-            sim = _seed_simulation(db, sim_entry, case, case_name, first_user_id)
-
-            if first_sim is None:
-                first_sim = sim
+            _seed_simulation(db, sim_entry, case, case_name, first_user_id)
 
             total_sims += 1
-
-        # Set the first simulation as the reference for this case
-        if first_sim is not None:
-            if first_sim.id is not None:
-                case.reference_simulation_id = first_sim.id
-            db.flush()
 
     db.commit()
     print(

--- a/backend/migrations/versions/20260603_120000_remove_case_reference_simulation.py
+++ b/backend/migrations/versions/20260603_120000_remove_case_reference_simulation.py
@@ -1,0 +1,41 @@
+"""Remove case-level reference simulation column.
+
+Revision ID: 20260603_120000
+Revises: 20260601_112110_e1a37fccb0f7
+Create Date: 2026-06-03 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260603_120000"
+down_revision: Union[str, Sequence[str], None] = "e1a37fccb0f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("fk_cases_reference_sim", "cases", type_="foreignkey")
+    op.drop_column("cases", "reference_simulation_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "cases",
+        sa.Column(
+            "reference_simulation_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_cases_reference_sim",
+        "cases",
+        "simulations",
+        ["reference_simulation_id"],
+        ["id"],
+    )

--- a/backend/tests/features/assistant/test_api.py
+++ b/backend/tests/features/assistant/test_api.py
@@ -69,6 +69,7 @@ async def _create_simulation(
     simulation = Simulation(
         case_id=case.id,
         execution_id=execution_id,
+        case_hash="assistant-api-hash-1",
         compset="AQUAPLANET",
         compset_alias="QPC4",
         grid_name="f19_f19",
@@ -85,7 +86,6 @@ async def _create_simulation(
     )
     db.add(simulation)
     await db.flush()
-    case.reference_simulation_id = simulation.id
     await db.commit()
     await db.refresh(simulation)
     return simulation

--- a/backend/tests/features/assistant/test_orchestrator.py
+++ b/backend/tests/features/assistant/test_orchestrator.py
@@ -31,6 +31,9 @@ def _make_snapshot() -> SimulationSnapshot:
         simulation=SnapshotSimulationFields(
             id="simulation-1",
             execution_id="assistant-livai-exec",
+            case_hash="hash-1",
+            is_anchor_run=True,
+            anchor_simulation_id="simulation-1",
             description="LivAI-backed simulation summary test.",
             compset="AQUAPLANET",
             compset_alias="QPC4",
@@ -45,10 +48,7 @@ def _make_snapshot() -> SimulationSnapshot:
             simulation_end_date="2023-12-31T00:00:00Z",
             git_tag="v1.0.0",
         ),
-        case=SnapshotCaseFields(
-            name="assistant_livai_case",
-            reference_simulation_id="simulation-1",
-        ),
+        case=SnapshotCaseFields(name="assistant_livai_case"),
         snapshot_caveats=[],
     )
 

--- a/backend/tests/features/assistant/test_service.py
+++ b/backend/tests/features/assistant/test_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -29,7 +30,7 @@ def _create_simulation(
     *,
     case_name: str = "assistant_case",
     execution_id: str = "assistant-exec-1",
-    is_reference: bool = True,
+    is_anchor_run: bool = True,
     with_diagnostics: bool = True,
     with_optional_metadata: bool = True,
 ) -> Simulation:
@@ -51,9 +52,33 @@ def _create_simulation(
     db.add(ingestion)
     db.flush()
 
+    if not is_anchor_run:
+        anchor = Simulation(
+            case_id=case.id,
+            execution_id=f"{execution_id}-ref",
+            case_hash="assistant-hash-1",
+            compset="AQUAPLANET",
+            compset_alias="QPC4",
+            grid_name="f19_f19",
+            grid_resolution="1.9x2.5",
+            simulation_type="experimental",
+            status="completed",
+            initialization_type="startup",
+            machine_id=machine.id,
+            simulation_start_date="2023-01-01T00:00:00Z",
+            created_by=normal_user_sync["id"],
+            last_updated_by=admin_user_sync["id"],
+            ingestion_id=ingestion.id,
+            created_at=datetime(2023, 1, 1, 0, 0, 0),
+            updated_at=datetime(2023, 1, 1, 0, 0, 0),
+        )
+        db.add(anchor)
+        db.flush()
+
     simulation = Simulation(
         case_id=case.id,
         execution_id=execution_id,
+        case_hash="assistant-hash-1",
         description="Control simulation for deterministic summary."
         if with_optional_metadata
         else None,
@@ -83,37 +108,16 @@ def _create_simulation(
         created_by=normal_user_sync["id"],
         last_updated_by=admin_user_sync["id"],
         ingestion_id=ingestion.id,
+        created_at=datetime(2023, 1, 2, 0, 0, 0),
+        updated_at=datetime(2023, 1, 2, 0, 0, 0),
         run_config_deltas=(
             None
-            if is_reference
+            if is_anchor_run
             else {"compiler": {"reference": "gcc-11", "current": "gcc-12"}}
         ),
     )
     db.add(simulation)
     db.flush()
-
-    if is_reference:
-        case.reference_simulation_id = simulation.id
-    else:
-        reference = Simulation(
-            case_id=case.id,
-            execution_id=f"{execution_id}-ref",
-            compset="AQUAPLANET",
-            compset_alias="QPC4",
-            grid_name="f19_f19",
-            grid_resolution="1.9x2.5",
-            simulation_type="experimental",
-            status="completed",
-            initialization_type="startup",
-            machine_id=machine.id,
-            simulation_start_date="2023-01-01T00:00:00Z",
-            created_by=normal_user_sync["id"],
-            last_updated_by=admin_user_sync["id"],
-            ingestion_id=ingestion.id,
-        )
-        db.add(reference)
-        db.flush()
-        case.reference_simulation_id = reference.id
 
     if with_diagnostics:
         db.add(
@@ -202,13 +206,13 @@ class TestBuildSimulationSummary:
             normal_user_sync,
             admin_user_sync,
             execution_id="assistant-nonref",
-            is_reference=False,
+            is_anchor_run=False,
         )
 
         summary = build_simulation_summary(simulation)
 
         assert (
-            "non-reference run with 1 recorded configuration change(s)"
+            "run with 1 recorded configuration change(s) from its comparison anchor"
             in summary.answer
         )
         assert "simulation.run_config_deltas" in {
@@ -237,12 +241,15 @@ class TestBuildSimulationSummary:
             "This summary uses only metadata already stored in SimBoard. It does not use retrieval, diagnostics interpretation, or LLM reasoning."
         ]
 
-    def test_non_reference_without_deltas_adds_explicit_caveat(self) -> None:
+    def test_non_anchor_without_deltas_adds_explicit_caveat(self) -> None:
         summary = build_simulation_summary(
             SimulationSnapshot(
                 simulation=SnapshotSimulationFields(
                     id="simulation-1",
                     execution_id="assistant-nonref-no-deltas",
+                    case_hash="hash-1",
+                    is_anchor_run=False,
+                    anchor_simulation_id="anchor-1",
                     compset="AQUAPLANET",
                     compset_alias="QPC4",
                     grid_name="f19_f19",
@@ -252,21 +259,38 @@ class TestBuildSimulationSummary:
                     initialization_type="startup",
                     simulation_start_date="2023-01-01T00:00:00Z",
                 ),
-                case=SnapshotCaseFields(
-                    name="assistant_case",
-                    reference_simulation_id="reference-1",
-                ),
+                case=SnapshotCaseFields(name="assistant_case"),
             )
         )
 
         assert (
-            "It is a non-reference run with no recorded configuration differences."
+            "It has no recorded configuration differences from its comparison anchor."
             in summary.answer
         )
         assert (
-            "This non-reference simulation has no recorded configuration differences in SimBoard metadata."
+            "This simulation has no recorded configuration differences from its comparison anchor in SimBoard metadata."
             in summary.caveats
         )
+
+    def test_hashless_legacy_run_mentions_missing_anchor(self) -> None:
+        summary = build_simulation_summary(
+            SimulationSnapshot(
+                simulation=SnapshotSimulationFields(
+                    id="simulation-legacy",
+                    execution_id="assistant-legacy",
+                    compset="AQUAPLANET",
+                    compset_alias="QPC4",
+                    grid_name="f19_f19",
+                    grid_resolution="1.9x2.5",
+                    simulation_type="experimental",
+                    status="completed",
+                    initialization_type="startup",
+                ),
+                case=SnapshotCaseFields(name="assistant_case"),
+            )
+        )
+
+        assert "legacy run without a comparison anchor" in summary.answer
 
     def test_missing_start_date_adds_caveat_and_default_followup(self) -> None:
         summary = build_simulation_summary(

--- a/backend/tests/features/assistant/test_service.py
+++ b/backend/tests/features/assistant/test_service.py
@@ -260,11 +260,11 @@ class TestBuildSimulationSummary:
         )
 
         assert (
-            "It is a non-reference run, but SimBoard does not currently record any configuration deltas for it."
+            "It is a non-reference run with no recorded configuration differences."
             in summary.answer
         )
         assert (
-            "This non-reference simulation has no recorded configuration deltas in SimBoard metadata."
+            "This non-reference simulation has no recorded configuration differences in SimBoard metadata."
             in summary.caveats
         )
 

--- a/backend/tests/features/assistant/test_snapshot.py
+++ b/backend/tests/features/assistant/test_snapshot.py
@@ -22,6 +22,9 @@ def _make_snapshot() -> SimulationSnapshot:
         simulation=SnapshotSimulationFields(
             id="simulation-1",
             execution_id="assistant-snapshot-exec",
+            case_hash="hash-1",
+            is_anchor_run=False,
+            anchor_simulation_id="anchor-1",
             description="Description " * 5,
             compset="AQUAPLANET",
             compset_alias="QPC4",

--- a/backend/tests/features/ingestion/test_api.py
+++ b/backend/tests/features/ingestion/test_api.py
@@ -2062,10 +2062,9 @@ class TestIngestFromHpcUploadEndpoint:
 
 
 class TestIngestionApiCoverage:
-    def test_set_reference_simulations_skips_non_uuid_case_id(self):
-        """Covers defensive skip when a created simulation has a non-UUID case_id."""
+    def test_set_reference_simulations_is_now_a_no_op(self):
+        """Legacy helper should no-op after removing case-level reference semantics."""
         db = MagicMock(spec=Session)
-        db.query.return_value.filter.return_value.all.return_value = []
 
         sim = Simulation(case_id="not-a-uuid", id=uuid.uuid4())
 

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -1516,6 +1516,90 @@ class TestReferenceRunIngestion:
         assert deltas["compiler"]["reference"] == "gcc-11"
         assert deltas["compiler"]["current"] == "gcc-12"
 
+    def test_same_case_hash_subgroup_uses_first_run_as_baseline(
+        self, db: Session
+    ) -> None:
+        """Runs with the same CASE_HASH diff against the first subgroup run."""
+        self._create_machine(db, "test-machine")
+
+        mock_simulations = {
+            "/path/to/1081185.251218-200945": self._make_metadata(
+                execution_id="1081185.251218-200945",
+                simulation_start_date="2020-01-01",
+                case_hash="hash-A",
+                compiler="gcc-11",
+            ),
+            "/path/to/1081186.251218-200946": self._make_metadata(
+                execution_id="1081186.251218-200946",
+                simulation_start_date="2020-06-01",
+                case_hash="hash-A",
+                compiler="gcc-12",
+            ),
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            result = ingest_archive(Path("/tmp/a.zip"), Path("/tmp/o"), db)
+
+        by_execution_id = {sim.execution_id: sim for sim in result.simulations}
+        assert result.created_count == 2
+        assert by_execution_id["1081185.251218-200945"].run_config_deltas is None
+        assert by_execution_id["1081186.251218-200946"].run_config_deltas == {
+            "compiler": {"reference": "gcc-11", "current": "gcc-12"}
+        }
+
+    def test_different_case_hash_subgroups_use_independent_baselines(
+        self, db: Session
+    ) -> None:
+        """Different CASE_HASH values should not cross-contaminate deltas."""
+        self._create_machine(db, "test-machine")
+
+        mock_simulations = {
+            "/path/to/1081185.251218-200945": self._make_metadata(
+                execution_id="1081185.251218-200945",
+                simulation_start_date="2020-01-01",
+                case_hash="hash-A",
+                compiler="gcc-11",
+            ),
+            "/path/to/1081186.251218-200946": self._make_metadata(
+                execution_id="1081186.251218-200946",
+                simulation_start_date="2020-06-01",
+                case_hash="hash-A",
+                compiler="gcc-12",
+            ),
+            "/path/to/1081187.251218-200947": self._make_metadata(
+                execution_id="1081187.251218-200947",
+                simulation_start_date="2021-01-01",
+                case_hash="hash-B",
+                compiler="clang-16",
+            ),
+            "/path/to/1081188.251218-200948": self._make_metadata(
+                execution_id="1081188.251218-200948",
+                simulation_start_date="2021-06-01",
+                case_hash="hash-B",
+                compiler="clang-17",
+            ),
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            result = ingest_archive(Path("/tmp/a.zip"), Path("/tmp/o"), db)
+
+        by_execution_id = {sim.execution_id: sim for sim in result.simulations}
+        assert result.created_count == 4
+        assert by_execution_id["1081185.251218-200945"].run_config_deltas is None
+        assert by_execution_id["1081187.251218-200947"].run_config_deltas is None
+        assert by_execution_id["1081186.251218-200946"].run_config_deltas == {
+            "compiler": {"reference": "gcc-11", "current": "gcc-12"}
+        }
+        assert by_execution_id["1081188.251218-200948"].run_config_deltas == {
+            "compiler": {"reference": "clang-16", "current": "clang-17"}
+        }
+
     def test_no_delta_when_configs_identical(self, db: Session) -> None:
         """Non-reference runs with identical config have run_config_deltas=None."""
         self._create_machine(db, "test-machine")
@@ -1723,6 +1807,382 @@ class TestReferenceRunIngestion:
         assert "compiler" in new_sim.run_config_deltas
         assert new_sim.run_config_deltas["compiler"]["reference"] == "gcc-11"
         assert new_sim.run_config_deltas["compiler"]["current"] == "gcc-12"
+
+    def test_incremental_ingestion_new_hash_subgroup_becomes_baseline(
+        self, db: Session
+    ) -> None:
+        """A new CASE_HASH subgroup should not diff against the case-wide reference."""
+        machine = self._create_machine(db, "test-machine")
+
+        user = User(
+            email="test@example.com",
+            is_active=True,
+            is_verified=True,
+        )
+        db.add(user)
+        db.commit()
+
+        ingestion = Ingestion(
+            source_type=IngestionSourceType.HPC_PATH,
+            source_reference="/archive",
+            status=IngestionStatus.SUCCESS,
+            machine_id=machine.id,
+            triggered_by=user.id,
+        )
+        db.add(ingestion)
+        db.commit()
+
+        case = Case(name="case1")
+        db.add(case)
+        db.flush()
+
+        sim = Simulation(
+            case_id=case.id,
+            execution_id="1081192.251218-200952",
+            case_hash="hash-A",
+            compset="FHIST",
+            compset_alias="test_alias",
+            grid_name="grid1",
+            grid_resolution="0.9x1.25",
+            machine_id=machine.id,
+            simulation_start_date=datetime(2020, 1, 1),
+            initialization_type="test",
+            status=SimulationStatus.CREATED,
+            simulation_type=SimulationType.UNKNOWN,
+            created_by=user.id,
+            last_updated_by=user.id,
+            ingestion_id=ingestion.id,
+            compiler="gcc-11",
+            created_at=datetime(2020, 1, 1, 0, 0, 0),
+            updated_at=datetime(2020, 1, 1, 0, 0, 0),
+        )
+        db.add(sim)
+        db.flush()
+
+        assert sim.id is not None
+        case.reference_simulation_id = sim.id
+        db.commit()
+
+        mock_simulations = {
+            "/path/to/1081193.251218-200953": self._make_metadata(
+                execution_id="1081193.251218-200953",
+                simulation_start_date="2020-06-01",
+                case_hash="hash-B",
+                compiler="gcc-12",
+            ),
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            result = ingest_archive(Path("/tmp/a.zip"), Path("/tmp/o"), db)
+
+        assert result.created_count == 1
+        assert result.simulations[0].run_config_deltas is None
+
+    def test_incremental_ingestion_uses_persisted_hash_subgroup_baseline(
+        self, db: Session
+    ) -> None:
+        """Hashed runs should diff against earliest persisted subgroup baseline."""
+        machine = self._create_machine(db, "test-machine")
+
+        user = User(
+            email="test@example.com",
+            is_active=True,
+            is_verified=True,
+        )
+        db.add(user)
+        db.commit()
+
+        ingestion = Ingestion(
+            source_type=IngestionSourceType.HPC_PATH,
+            source_reference="/archive",
+            status=IngestionStatus.SUCCESS,
+            machine_id=machine.id,
+            triggered_by=user.id,
+        )
+        db.add(ingestion)
+        db.commit()
+
+        case = Case(name="case1")
+        db.add(case)
+        db.flush()
+
+        case_reference = Simulation(
+            case_id=case.id,
+            execution_id="1081192.251218-200952",
+            case_hash="hash-A",
+            compset="FHIST",
+            compset_alias="test_alias",
+            grid_name="grid1",
+            grid_resolution="0.9x1.25",
+            machine_id=machine.id,
+            simulation_start_date=datetime(2020, 1, 1),
+            initialization_type="test",
+            status=SimulationStatus.CREATED,
+            simulation_type=SimulationType.UNKNOWN,
+            created_by=user.id,
+            last_updated_by=user.id,
+            ingestion_id=ingestion.id,
+            compiler="gcc-11",
+            created_at=datetime(2020, 1, 1, 0, 0, 0),
+            updated_at=datetime(2020, 1, 1, 0, 0, 0),
+        )
+        subgroup_baseline = Simulation(
+            case_id=case.id,
+            execution_id="1081193.251218-200953",
+            case_hash="hash-B",
+            compset="FHIST",
+            compset_alias="test_alias",
+            grid_name="grid1",
+            grid_resolution="0.9x1.25",
+            machine_id=machine.id,
+            simulation_start_date=datetime(2020, 2, 1),
+            initialization_type="test",
+            status=SimulationStatus.CREATED,
+            simulation_type=SimulationType.UNKNOWN,
+            created_by=user.id,
+            last_updated_by=user.id,
+            ingestion_id=ingestion.id,
+            compiler="clang-16",
+            created_at=datetime(2020, 2, 1, 0, 0, 0),
+            updated_at=datetime(2020, 2, 1, 0, 0, 0),
+        )
+        db.add(case_reference)
+        db.add(subgroup_baseline)
+        db.flush()
+
+        assert case_reference.id is not None
+        case.reference_simulation_id = case_reference.id
+        db.commit()
+
+        mock_simulations = {
+            "/path/to/1081194.251218-200954": self._make_metadata(
+                execution_id="1081194.251218-200954",
+                simulation_start_date="2020-06-01",
+                case_hash="hash-B",
+                compiler="clang-17",
+            ),
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            result = ingest_archive(Path("/tmp/a.zip"), Path("/tmp/o"), db)
+
+        assert result.created_count == 1
+        assert result.simulations[0].run_config_deltas == {
+            "compiler": {"reference": "clang-16", "current": "clang-17"}
+        }
+
+    def test_duplicate_hash_run_does_not_seed_new_hash_from_case_reference(
+        self, db: Session
+    ) -> None:
+        """A duplicate in one hash subgroup must not contaminate another subgroup."""
+        machine = self._create_machine(db, "test-machine")
+
+        user = User(
+            email="test@example.com",
+            is_active=True,
+            is_verified=True,
+        )
+        db.add(user)
+        db.commit()
+
+        ingestion = Ingestion(
+            source_type=IngestionSourceType.HPC_PATH,
+            source_reference="/archive",
+            status=IngestionStatus.SUCCESS,
+            machine_id=machine.id,
+            triggered_by=user.id,
+        )
+        db.add(ingestion)
+        db.commit()
+
+        case = Case(name="case1")
+        db.add(case)
+        db.flush()
+
+        sim = Simulation(
+            case_id=case.id,
+            execution_id="1081192.251218-200952",
+            case_hash="hash-A",
+            compset="FHIST",
+            compset_alias="test_alias",
+            grid_name="grid1",
+            grid_resolution="0.9x1.25",
+            machine_id=machine.id,
+            simulation_start_date=datetime(2020, 1, 1),
+            initialization_type="test",
+            status=SimulationStatus.CREATED,
+            simulation_type=SimulationType.UNKNOWN,
+            created_by=user.id,
+            last_updated_by=user.id,
+            ingestion_id=ingestion.id,
+            compiler="gcc-11",
+            created_at=datetime(2020, 1, 1, 0, 0, 0),
+            updated_at=datetime(2020, 1, 1, 0, 0, 0),
+        )
+        db.add(sim)
+        db.flush()
+
+        assert sim.id is not None
+        case.reference_simulation_id = sim.id
+        db.commit()
+
+        mock_simulations = {
+            "/path/to/1081192.251218-200952": self._make_metadata(
+                execution_id="1081192.251218-200952",
+                simulation_start_date="2020-01-01",
+                case_hash="hash-A",
+                compiler="gcc-11",
+            ),
+            "/path/to/1081193.251218-200953": self._make_metadata(
+                execution_id="1081193.251218-200953",
+                simulation_start_date="2020-06-01",
+                case_hash="hash-B",
+                compiler="gcc-12",
+            ),
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            result = ingest_archive(Path("/tmp/a.zip"), Path("/tmp/o"), db)
+
+        assert result.duplicate_count == 1
+        assert result.created_count == 1
+        assert result.simulations[0].run_config_deltas is None
+
+    def test_duplicate_non_baseline_hash_run_uses_authoritative_subgroup_baseline(
+        self, db: Session
+    ) -> None:
+        """Duplicate hashed runs should seed from persisted subgroup baseline only."""
+        machine = self._create_machine(db, "test-machine")
+
+        user = User(
+            email="test@example.com",
+            is_active=True,
+            is_verified=True,
+        )
+        db.add(user)
+        db.commit()
+
+        ingestion = Ingestion(
+            source_type=IngestionSourceType.HPC_PATH,
+            source_reference="/archive",
+            status=IngestionStatus.SUCCESS,
+            machine_id=machine.id,
+            triggered_by=user.id,
+        )
+        db.add(ingestion)
+        db.commit()
+
+        case = Case(name="case1")
+        db.add(case)
+        db.flush()
+
+        case_reference = Simulation(
+            case_id=case.id,
+            execution_id="1081192.251218-200952",
+            case_hash="hash-A",
+            compset="FHIST",
+            compset_alias="test_alias",
+            grid_name="grid1",
+            grid_resolution="0.9x1.25",
+            machine_id=machine.id,
+            simulation_start_date=datetime(2020, 1, 1),
+            initialization_type="test",
+            status=SimulationStatus.CREATED,
+            simulation_type=SimulationType.UNKNOWN,
+            created_by=user.id,
+            last_updated_by=user.id,
+            ingestion_id=ingestion.id,
+            compiler="gcc-11",
+            created_at=datetime(2020, 1, 1, 0, 0, 0),
+            updated_at=datetime(2020, 1, 1, 0, 0, 0),
+        )
+        subgroup_baseline = Simulation(
+            case_id=case.id,
+            execution_id="1081193.251218-200953",
+            case_hash="hash-B",
+            compset="FHIST",
+            compset_alias="test_alias",
+            grid_name="grid1",
+            grid_resolution="0.9x1.25",
+            machine_id=machine.id,
+            simulation_start_date=datetime(2020, 2, 1),
+            initialization_type="test",
+            status=SimulationStatus.CREATED,
+            simulation_type=SimulationType.UNKNOWN,
+            created_by=user.id,
+            last_updated_by=user.id,
+            ingestion_id=ingestion.id,
+            compiler="gcc-21",
+            created_at=datetime(2020, 2, 1, 0, 0, 0),
+            updated_at=datetime(2020, 2, 1, 0, 0, 0),
+        )
+        subgroup_non_baseline = Simulation(
+            case_id=case.id,
+            execution_id="1081194.251218-200954",
+            case_hash="hash-B",
+            compset="FHIST",
+            compset_alias="test_alias",
+            grid_name="grid1",
+            grid_resolution="0.9x1.25",
+            machine_id=machine.id,
+            simulation_start_date=datetime(2020, 3, 1),
+            initialization_type="test",
+            status=SimulationStatus.CREATED,
+            simulation_type=SimulationType.UNKNOWN,
+            created_by=user.id,
+            last_updated_by=user.id,
+            ingestion_id=ingestion.id,
+            compiler="gcc-22",
+            run_config_deltas={
+                "compiler": {"reference": "gcc-21", "current": "gcc-22"}
+            },
+            created_at=datetime(2020, 3, 1, 0, 0, 0),
+            updated_at=datetime(2020, 3, 1, 0, 0, 0),
+        )
+        db.add(case_reference)
+        db.add(subgroup_baseline)
+        db.add(subgroup_non_baseline)
+        db.flush()
+
+        assert case_reference.id is not None
+        case.reference_simulation_id = case_reference.id
+        db.commit()
+
+        mock_simulations = {
+            "/path/to/1081194.251218-200954": self._make_metadata(
+                execution_id="1081194.251218-200954",
+                simulation_start_date="2020-03-01",
+                case_hash="hash-B",
+                compiler="gcc-22",
+            ),
+            "/path/to/1081195.251218-200955": self._make_metadata(
+                execution_id="1081195.251218-200955",
+                simulation_start_date="2020-06-01",
+                case_hash="hash-B",
+                compiler="gcc-23",
+            ),
+        }
+
+        with patch(
+            "app.features.ingestion.ingest.main_parser",
+            return_value=(_parsed_simulations_from_mapping(mock_simulations), 0),
+        ):
+            result = ingest_archive(Path("/tmp/a.zip"), Path("/tmp/o"), db)
+
+        assert result.duplicate_count == 1
+        assert result.created_count == 1
+        assert result.simulations[0].run_config_deltas == {
+            "compiler": {"reference": "gcc-21", "current": "gcc-23"}
+        }
 
     def test_incremental_ingestion_normalizes_git_url_for_delta(
         self, db: Session

--- a/backend/tests/features/ingestion/test_ingest.py
+++ b/backend/tests/features/ingestion/test_ingest.py
@@ -1443,8 +1443,7 @@ class TestReferenceRunIngestion:
         return base
 
     def test_reference_run_selected_from_multiple_runs(self, db: Session) -> None:
-        """First run per case is reference (None deltas), subsequent runs
-        with config differences get a delta dict."""
+        """First hashed subgroup run is anchor; later subgroup run records deltas."""
         self._create_machine(db, "test-machine")
 
         # Two runs with the same case_name but different compilers
@@ -1452,11 +1451,13 @@ class TestReferenceRunIngestion:
             "/path/to/1081183.251218-200943": self._make_metadata(
                 execution_id="1081183.251218-200943",
                 simulation_start_date="2020-01-01",
+                case_hash="hash-ingest-1",
                 compiler="gcc-11",
             ),
             "/path/to/1081184.251218-200944": self._make_metadata(
                 execution_id="1081184.251218-200944",
                 simulation_start_date="2020-06-01",
+                case_hash="hash-ingest-1",
                 compiler="gcc-12",
             ),
         }
@@ -1479,18 +1480,20 @@ class TestReferenceRunIngestion:
         assert len(non_reference) == 1
 
     def test_config_delta_stored_for_non_reference_run(self, db: Session) -> None:
-        """Non-reference runs with config differences record deltas as a dict."""
+        """Hashed non-anchor runs with config differences record deltas as a dict."""
         self._create_machine(db, "test-machine")
 
         mock_simulations = {
             "/path/to/1081185.251218-200945": self._make_metadata(
                 execution_id="1081185.251218-200945",
                 simulation_start_date="2020-01-01",
+                case_hash="hash-ingest-2",
                 compiler="gcc-11",
             ),
             "/path/to/1081186.251218-200946": self._make_metadata(
                 execution_id="1081186.251218-200946",
                 simulation_start_date="2020-06-01",
+                case_hash="hash-ingest-2",
                 compiler="gcc-12",
             ),
         }
@@ -1729,7 +1732,7 @@ class TestReferenceRunIngestion:
         """A new run under an existing case records config delta."""
         machine = self._create_machine(db, "test-machine")
 
-        # Pre-populate DB with a reference simulation
+        # Pre-populate DB with a hashed subgroup anchor simulation
         user = User(
             email="test@example.com",
             is_active=True,
@@ -1755,6 +1758,7 @@ class TestReferenceRunIngestion:
         sim = Simulation(
             case_id=case.id,
             execution_id="1081192.251218-200952",
+            case_hash="hash-A",
             compset="FHIST",
             compset_alias="test_alias",
             grid_name="grid1",
@@ -1772,21 +1776,18 @@ class TestReferenceRunIngestion:
         db.add(sim)
         db.flush()
 
-        # Set reference_simulation_id on the case
-        assert sim.id is not None
-        case.reference_simulation_id = sim.id
-        db.commit()
-
         # Ingest archive containing the existing run plus a new one
         mock_simulations = {
             "/path/to/1081192.251218-200952": self._make_metadata(
                 execution_id="1081192.251218-200952",
                 simulation_start_date="2020-01-01",
+                case_hash="hash-A",
                 compiler="gcc-11",
             ),
             "/path/to/1081193.251218-200953": self._make_metadata(
                 execution_id="1081193.251218-200953",
                 simulation_start_date="2020-06-01",
+                case_hash="hash-A",
                 compiler="gcc-12",
             ),
         }
@@ -1858,10 +1859,6 @@ class TestReferenceRunIngestion:
         )
         db.add(sim)
         db.flush()
-
-        assert sim.id is not None
-        case.reference_simulation_id = sim.id
-        db.commit()
 
         mock_simulations = {
             "/path/to/1081193.251218-200953": self._make_metadata(
@@ -1953,10 +1950,6 @@ class TestReferenceRunIngestion:
         db.add(subgroup_baseline)
         db.flush()
 
-        assert case_reference.id is not None
-        case.reference_simulation_id = case_reference.id
-        db.commit()
-
         mock_simulations = {
             "/path/to/1081194.251218-200954": self._make_metadata(
                 execution_id="1081194.251218-200954",
@@ -2027,10 +2020,6 @@ class TestReferenceRunIngestion:
         )
         db.add(sim)
         db.flush()
-
-        assert sim.id is not None
-        case.reference_simulation_id = sim.id
-        db.commit()
 
         mock_simulations = {
             "/path/to/1081192.251218-200952": self._make_metadata(
@@ -2153,10 +2142,6 @@ class TestReferenceRunIngestion:
         db.add(subgroup_non_baseline)
         db.flush()
 
-        assert case_reference.id is not None
-        case.reference_simulation_id = case_reference.id
-        db.commit()
-
         mock_simulations = {
             "/path/to/1081194.251218-200954": self._make_metadata(
                 execution_id="1081194.251218-200954",
@@ -2215,6 +2200,7 @@ class TestReferenceRunIngestion:
         sim = Simulation(
             case_id=case.id,
             execution_id="1081194.251218-200953",
+            case_hash="hash-git",
             compset="FHIST",
             compset_alias="test_alias",
             grid_name="grid1",
@@ -2232,14 +2218,11 @@ class TestReferenceRunIngestion:
         db.add(sim)
         db.flush()
 
-        assert sim.id is not None
-        case.reference_simulation_id = sim.id
-        db.commit()
-
         mock_simulations = {
             "/path/to/1081194.251218-200956": self._make_metadata(
                 execution_id="1081194.251218-200956",
                 simulation_start_date="2020-06-01",
+                case_hash="hash-git",
                 git_repository_url="git@github.com:E3SM-Project/E3SM.git",
             ),
         }
@@ -2285,6 +2268,7 @@ class TestReferenceRunIngestion:
         sim = Simulation(
             case_id=case.id,
             execution_id="1081194.251218-200954",
+            case_hash="hash-sim-type",
             compset="FHIST",
             compset_alias="test_alias",
             grid_name="grid1",
@@ -2301,18 +2285,16 @@ class TestReferenceRunIngestion:
         db.add(sim)
         db.flush()
 
-        assert sim.id is not None
-        case.reference_simulation_id = sim.id
-        db.commit()
-
         mock_simulations = {
             "/path/to/1081194.251218-200954": self._make_metadata(
                 execution_id="1081194.251218-200954",
                 simulation_start_date="2020-01-01",
+                case_hash="hash-sim-type",
             ),
             "/path/to/1081194.251218-200955": self._make_metadata(
                 execution_id="1081194.251218-200955",
                 simulation_start_date="2020-06-01",
+                case_hash="hash-sim-type",
             ),
         }
 
@@ -2433,10 +2415,6 @@ class TestReferenceRunIngestion:
         db.add(sim)
         db.flush()
 
-        assert sim.id is not None
-        case.reference_simulation_id = sim.id
-        db.commit()
-
         mock_simulations = {
             "/path/to/1081193.251218-200953": self._make_metadata(
                 execution_id="1081193.251218-200953",
@@ -2552,13 +2530,9 @@ class TestIngestHelpers:
         assert updated.case_group == "groupA"
         mock_warning.assert_called_once()
 
-    def test_get_reference_metadata_caches_missing_persisted_reference(self) -> None:
+    def test_get_reference_metadata_for_case_returns_none(self) -> None:
         case = MagicMock(spec=Case)
         case.id = uuid4()
-        case.reference_simulation_id = uuid4()
-
-        db = MagicMock(spec=Session)
-        db.query.return_value.filter.return_value.first.return_value = None
 
         reference_cache: dict[str, SimulationConfigSnapshot] = {}
         persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
@@ -2568,93 +2542,10 @@ class TestIngestHelpers:
             case_name="missing_reference_case",
             reference_cache=reference_cache,
             persisted_reference_cache=persisted_reference_cache,
-            db=db,
+            db=MagicMock(spec=Session),
         )
 
         assert result is None
-        assert case.id in persisted_reference_cache
-        assert persisted_reference_cache[case.id] is None
-
-    def test_get_reference_metadata_uses_persisted_cache_on_second_lookup(
-        self, db: Session
-    ) -> None:
-        machine = Machine(
-            name="cache-test-machine",
-            site="Test Site",
-            architecture="x86_64",
-            scheduler="SLURM",
-            gpu=False,
-        )
-        db.add(machine)
-
-        user = User(
-            email="cache-test@example.com",
-            is_active=True,
-            is_verified=True,
-        )
-        db.add(user)
-        db.commit()
-
-        ingestion = Ingestion(
-            source_type=IngestionSourceType.HPC_PATH,
-            source_reference="/archive",
-            status=IngestionStatus.SUCCESS,
-            machine_id=machine.id,
-            triggered_by=user.id,
-        )
-        db.add(ingestion)
-        db.commit()
-
-        case = Case(name="reference_cache_case")
-        db.add(case)
-        db.flush()
-
-        sim = Simulation(
-            case_id=case.id,
-            execution_id="1082000.260305-120000",
-            compset="FHIST",
-            compset_alias="test_alias",
-            grid_name="grid1",
-            grid_resolution="0.9x1.25",
-            machine_id=machine.id,
-            simulation_start_date=datetime(2020, 1, 1),
-            initialization_type="test",
-            status=SimulationStatus.CREATED,
-            simulation_type=SimulationType.UNKNOWN,
-            created_by=user.id,
-            last_updated_by=user.id,
-            ingestion_id=ingestion.id,
-            compiler="gcc-11",
-        )
-        db.add(sim)
-        db.flush()
-
-        assert sim.id is not None
-        case.reference_simulation_id = sim.id
-        db.commit()
-
-        reference_cache: dict[str, SimulationConfigSnapshot] = {}
-        persisted_reference_cache: dict[UUID, SimulationConfigSnapshot | None] = {}
-
-        first = _get_reference_metadata_for_case(
-            case=case,
-            case_name=case.name,
-            reference_cache=reference_cache,
-            persisted_reference_cache=persisted_reference_cache,
-            db=db,
-        )
-        assert first is not None
-        assert first.compiler == "gcc-11"
-
-        with patch.object(db, "query", side_effect=AssertionError):
-            second = _get_reference_metadata_for_case(
-                case=case,
-                case_name=case.name,
-                reference_cache=reference_cache,
-                persisted_reference_cache=persisted_reference_cache,
-                db=db,
-            )
-        assert second == first
 
     def test_get_known_case_hash_uses_persisted_cache_on_second_lookup(
         self,
@@ -2662,7 +2553,6 @@ class TestIngestHelpers:
         case = MagicMock(spec=Case)
         case.id = uuid4()
         case.name = "case_hash_cache_case"
-        case.reference_simulation_id = uuid4()
 
         db = MagicMock(spec=Session)
         case_hash_cache: dict[str, str] = {}
@@ -2730,7 +2620,7 @@ class TestIngestHelpers:
         assert case_hash_cache == {"case_hash_case": "matching-hash"}
         mock_info.assert_not_called()
 
-    def test_track_case_hash_grouping_uses_in_batch_hash_when_reference_hash_missing(
+    def test_track_case_hash_grouping_uses_in_batch_hash_when_persisted_hash_missing(
         self,
     ) -> None:
         first_parsed = ParsedSimulation(
@@ -2788,15 +2678,11 @@ class TestIngestHelpers:
         case = MagicMock(spec=Case)
         case.id = uuid4()
         case.name = "case_hash_case"
-        case.reference_simulation_id = uuid4()
-
-        reference_simulation = MagicMock(spec=Simulation)
-        reference_simulation.case_hash = None
 
         db = MagicMock(spec=Session)
-        db.query.return_value.filter.return_value.first.return_value = (
-            reference_simulation
-        )
+        (
+            db.query.return_value.filter.return_value.order_by.return_value.limit.return_value.scalar.return_value
+        ) = None
 
         case_hash_cache: dict[str, str] = {}
         persisted_case_hash_cache: dict[UUID, str | None] = {}

--- a/backend/tests/features/simulation/test_api.py
+++ b/backend/tests/features/simulation/test_api.py
@@ -115,9 +115,6 @@ class TestListCases:
         )
         db.add(sim1)
         db.flush()
-        # Set reference
-        assert sim1.id is not None
-        case.reference_simulation_id = sim1.id
         db.add(sim2)
         db.commit()
 
@@ -128,7 +125,6 @@ class TestListCases:
 
         case_data = data[0]
         assert case_data["name"] == "test_case_nested"
-        assert case_data["referenceSimulationId"] == str(sim1.id)
         assert case_data["machineNames"] == [machine.name]
         assert case_data["hpcUsernames"] == []
 
@@ -142,7 +138,8 @@ class TestListCases:
             assert "executionId" in s
             assert "caseHash" in s
             assert "status" in s
-            assert "isReference" in s
+            assert "isAnchorRun" in s
+            assert "anchorSimulationId" in s
             assert "changeCount" in s
             assert "simulationStartDate" in s
             # Must NOT include heavy fields
@@ -154,12 +151,14 @@ class TestListCases:
             assert "runConfigDeltas" not in s
             assert "createdByUser" not in s
 
-        # Verify reference and change_count derivation
+        # Verify anchor and change_count derivation
         exec_ids = {s["executionId"]: s for s in sims}
-        assert exec_ids["case-nested-exec-1"]["isReference"] is True
+        assert exec_ids["case-nested-exec-1"]["isAnchorRun"] is True
+        assert exec_ids["case-nested-exec-1"]["anchorSimulationId"] == str(sim1.id)
         assert exec_ids["case-nested-exec-1"]["caseHash"] == "nested-hash-1"
         assert exec_ids["case-nested-exec-1"]["changeCount"] == 0
-        assert exec_ids["case-nested-exec-2"]["isReference"] is False
+        assert exec_ids["case-nested-exec-2"]["isAnchorRun"] is True
+        assert exec_ids["case-nested-exec-2"]["anchorSimulationId"] == str(sim2.id)
         assert exec_ids["case-nested-exec-2"]["caseHash"] == "nested-hash-2"
         assert exec_ids["case-nested-exec-2"]["changeCount"] == 1
 
@@ -224,8 +223,6 @@ class TestGetCase:
         )
         db.add(sim)
         db.flush()
-        assert sim.id is not None
-        case.reference_simulation_id = sim.id
         db.commit()
 
         res = client.get(f"{API_BASE}/cases/{case.id}")
@@ -237,7 +234,8 @@ class TestGetCase:
         assert data["hpcUsernames"] == []
         assert data["simulations"][0]["executionId"] == "case-detail-exec-1"
         assert data["simulations"][0]["caseHash"] == "detail-hash-1"
-        assert data["simulations"][0]["isReference"] is True
+        assert data["simulations"][0]["isAnchorRun"] is True
+        assert data["simulations"][0]["anchorSimulationId"] == str(sim.id)
 
     def test_endpoint_raises_404_if_case_not_found(self, client):
         res = client.get(f"{API_BASE}/cases/{uuid4()}")
@@ -319,7 +317,7 @@ class TestCreateSimulation:
         assert res.status_code == 400
         assert "not found" in res.json()["detail"].lower()
 
-    def test_first_manual_create_sets_reference_on_case(
+    def test_manual_create_with_missing_case_hash_has_no_anchor(
         self, client, db: Session
     ) -> None:
         machine = db.query(Machine).first()
@@ -345,12 +343,9 @@ class TestCreateSimulation:
         assert res.status_code == 201
         data = res.json()
 
-        assert data["isReference"] is True
+        assert data["isAnchorRun"] is False
+        assert data["anchorSimulationId"] is None
         assert data["runConfigDeltas"] is None
-
-        db.refresh(case)
-        assert case.reference_simulation_id is not None
-        assert str(case.reference_simulation_id) == data["id"]
 
     def test_create_simulation_raises_500_when_reload_fails(self) -> None:
         case_id = uuid4()

--- a/backend/tests/features/simulation/test_schemas.py
+++ b/backend/tests/features/simulation/test_schemas.py
@@ -440,21 +440,45 @@ class TestSimulationSummaryOutSchema:
     def test_case_hash_schema_descriptions_reflect_grouping_semantics(self):
         create_schema = SimulationCreate.model_json_schema()
         create_description = create_schema["properties"]["caseHash"]["description"]
+        create_delta_description = create_schema["properties"]["runConfigDeltas"][
+            "description"
+        ]
         assert (
             "group related executions or sub-cases within a case" in create_description
         )
         assert "not top-level case identity" in create_description
+        assert "stored baseline for its case or case-hash subgroup" in (
+            create_delta_description
+        )
 
         summary_schema = SimulationSummaryOut.model_json_schema()
         summary_description = summary_schema["properties"]["caseHash"]["description"]
+        summary_change_description = summary_schema["properties"]["changeCount"][
+            "description"
+        ]
         assert (
             "group related executions or sub-cases within a case" in summary_description
+        )
+        assert "recorded configuration differences for this run" in (
+            summary_change_description
         )
 
         simulation_out_schema = SimulationOut.model_json_schema()
         out_description = simulation_out_schema["properties"]["caseHash"]["description"]
+        out_delta_description = simulation_out_schema["properties"]["runConfigDeltas"][
+            "description"
+        ]
+        out_change_description = simulation_out_schema["properties"]["changeCount"][
+            "description"
+        ]
         assert "group related executions or sub-cases within a case" in out_description
         assert "not top-level case identity" in out_description
+        assert "stored baseline for its case or case-hash subgroup" in (
+            out_delta_description
+        )
+        assert "recorded configuration differences for this run" in (
+            out_change_description
+        )
 
     def test_valid_summary_fields(self):
         summary = SimulationSummaryOut(

--- a/backend/tests/features/simulation/test_schemas.py
+++ b/backend/tests/features/simulation/test_schemas.py
@@ -116,7 +116,8 @@ class TestSimulationOutSchema:
             "case_name": "test_case",
             "execution_id": "1081156.251218-200923",
             "case_hash": "abc123",
-            "is_reference": True,
+            "is_anchor_run": True,
+            "anchor_simulation_id": uuid4(),
             "change_count": 0,
             "compset": "AQUAPLANET",
             "compset_alias": "QPC4",
@@ -200,7 +201,8 @@ class TestSimulationOutSchema:
             "case_name": "test_case",
             "execution_id": "1081156.251218-200923",
             "case_hash": "abc123",
-            "is_reference": False,
+            "is_anchor_run": False,
+            "anchor_simulation_id": uuid4(),
             "change_count": 2,
             "compset": "AQUAPLANET",
             "compset_alias": "QPC4",
@@ -299,7 +301,8 @@ class TestSimulationOutSchema:
             case_id=uuid4(),
             case_name="test_case",
             execution_id="1081156.251218-200923",
-            is_reference=True,
+            is_anchor_run=True,
+            anchor_simulation_id=uuid4(),
             change_count=0,
             compset="AQUAPLANET",
             compset_alias="QPC4",
@@ -374,7 +377,8 @@ class TestSimulationOutSchema:
             case_id=uuid4(),
             case_name="test_case",
             execution_id="1081156.251218-200923",
-            is_reference=True,
+            is_anchor_run=True,
+            anchor_simulation_id=uuid4(),
             change_count=0,
             compset="AQUAPLANET",
             compset_alias="QPC4",
@@ -447,8 +451,9 @@ class TestSimulationSummaryOutSchema:
             "group related executions or sub-cases within a case" in create_description
         )
         assert "not top-level case identity" in create_description
-        assert "stored baseline for its case or case-hash subgroup" in (
-            create_delta_description
+        assert (
+            "comparison anchor in the same case-hash subgroup"
+            in create_delta_description
         )
 
         summary_schema = SimulationSummaryOut.model_json_schema()
@@ -473,8 +478,8 @@ class TestSimulationSummaryOutSchema:
         ]
         assert "group related executions or sub-cases within a case" in out_description
         assert "not top-level case identity" in out_description
-        assert "stored baseline for its case or case-hash subgroup" in (
-            out_delta_description
+        assert (
+            "comparison anchor in the same case-hash subgroup" in out_delta_description
         )
         assert "recorded configuration differences for this run" in (
             out_change_description
@@ -486,28 +491,33 @@ class TestSimulationSummaryOutSchema:
             execution_id="1081156.251218-200923",
             case_hash=None,
             status="created",
-            is_reference=True,
+            is_anchor_run=False,
+            anchor_simulation_id=None,
             change_count=0,
             simulation_start_date=datetime(2023, 1, 1, 0, 0, 0),
             simulation_end_date=None,
         )
-        assert summary.is_reference is True
+        assert summary.is_anchor_run is False
+        assert summary.anchor_simulation_id is None
         assert summary.case_hash is None
         assert summary.change_count == 0
         assert summary.simulation_end_date is None
 
-    def test_non_reference_with_changes(self):
+    def test_non_anchor_with_changes(self):
+        anchor_id = uuid4()
         summary = SimulationSummaryOut(
             id=uuid4(),
             execution_id="1081290.251218-211543",
             case_hash="hash-2",
             status="completed",
-            is_reference=False,
+            is_anchor_run=False,
+            anchor_simulation_id=anchor_id,
             change_count=3,
             simulation_start_date=datetime(2023, 1, 1, 0, 0, 0),
             simulation_end_date=datetime(2023, 12, 31, 0, 0, 0),
         )
-        assert summary.is_reference is False
+        assert summary.is_anchor_run is False
+        assert summary.anchor_simulation_id == anchor_id
         assert summary.case_hash == "hash-2"
         assert summary.change_count == 3
         assert summary.simulation_end_date == datetime(2023, 12, 31, 0, 0, 0)
@@ -516,28 +526,30 @@ class TestSimulationSummaryOutSchema:
 class TestCaseOutSchema:
     def test_case_out_with_nested_simulations(self):
         sim_id = uuid4()
+        other_id = uuid4()
         case_out = CaseOut(
             id=uuid4(),
             name="v3.LR.historical_0121",
             case_group="ensemble_v3",
-            reference_simulation_id=sim_id,
             simulations=[
                 SimulationSummaryOut(
                     id=sim_id,
                     execution_id="1081156.251218-200923",
                     case_hash="hash-1",
                     status="completed",
-                    is_reference=True,
+                    is_anchor_run=True,
+                    anchor_simulation_id=sim_id,
                     change_count=0,
                     simulation_start_date=datetime(2023, 1, 1, 0, 0, 0),
                     simulation_end_date=datetime(2023, 12, 31, 0, 0, 0),
                 ),
                 SimulationSummaryOut(
-                    id=uuid4(),
+                    id=other_id,
                     execution_id="1081290.251218-211543",
                     case_hash="hash-2",
                     status="completed",
-                    is_reference=False,
+                    is_anchor_run=False,
+                    anchor_simulation_id=other_id,
                     change_count=2,
                     simulation_start_date=datetime(2023, 2, 1, 0, 0, 0),
                     simulation_end_date=None,
@@ -551,7 +563,8 @@ class TestCaseOutSchema:
         assert case_out.name == "v3.LR.historical_0121"
         assert case_out.case_group == "ensemble_v3"
         assert len(case_out.simulations) == 2
-        assert case_out.simulations[0].is_reference is True
+        assert case_out.simulations[0].is_anchor_run is True
+        assert case_out.simulations[0].anchor_simulation_id == sim_id
         assert case_out.simulations[0].case_hash == "hash-1"
         assert case_out.machine_names == ["chrysalis"]
         assert case_out.hpc_usernames == ["ac.tvo"]
@@ -563,14 +576,12 @@ class TestCaseOutSchema:
             id=uuid4(),
             name="empty_case",
             case_group=None,
-            reference_simulation_id=None,
             simulations=[],
             machine_names=[],
             hpc_usernames=[],
             created_at=datetime(2023, 1, 1, 0, 0, 0),
             updated_at=datetime(2023, 1, 2, 0, 0, 0),
         )
-        assert case_out.reference_simulation_id is None
         assert case_out.simulations == []
         assert case_out.machine_names == []
         assert case_out.hpc_usernames == []

--- a/frontend/src/features/browse/BrowsePage.tsx
+++ b/frontend/src/features/browse/BrowsePage.tsx
@@ -19,6 +19,12 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  applyBrowseUrlState,
+  hasDeprecatedBrowseSearchParams,
+  normalizeBrowseSearchParams,
+  resetBrowseUrlState,
+} from '@/features/browse/browseSearchParams';
 import { BrowseFiltersSidePanel } from '@/features/browse/components/BrowseFiltersSidePanel';
 import { SimulationResultCards } from '@/features/browse/components/SimulationResults/SimulationResultsCards';
 import { SimulationResultsTable } from '@/features/browse/components/SimulationResults/SimulationResultsTable';
@@ -59,9 +65,6 @@ export interface FilterState {
   compiler: string[];
   status: string[];
 
-  // Reference Status
-  referenceStatus: string;
-
   // Metadata & Provenance
   gitTag: string[];
   createdBy: string[];
@@ -93,9 +96,6 @@ const createEmptyFilters = (): FilterState => ({
   compiler: [],
   status: [],
 
-  // Reference Status
-  referenceStatus: '',
-
   // Metadata & Provenance
   gitTag: [],
   createdBy: [],
@@ -103,13 +103,12 @@ const createEmptyFilters = (): FilterState => ({
 });
 
 const FILTER_KEYS = Object.keys(createEmptyFilters()) as (keyof FilterState)[];
-const MULTI_SELECT_FILTER_KEYS = FILTER_KEYS.filter((key) => key !== 'referenceStatus');
+const MULTI_SELECT_FILTER_KEYS = FILTER_KEYS;
 
 const areStringArraysEqual = (left: string[], right: string[]): boolean =>
   left.length === right.length && left.every((value, index) => value === right[index]);
 
 const areFiltersEqual = (left: FilterState, right: FilterState): boolean =>
-  left.referenceStatus === right.referenceStatus &&
   MULTI_SELECT_FILTER_KEYS.every((key) =>
     areStringArraysEqual(left[key] as string[], right[key] as string[]),
   );
@@ -296,9 +295,6 @@ export const BrowsePage = ({
         }
       }
 
-      if (appliedFilters.referenceStatus === 'reference' && !record.isReference) return false;
-      if (appliedFilters.referenceStatus === 'non-reference' && record.isReference) return false;
-
       return true;
     });
   }, [simulations, appliedFilters]);
@@ -359,12 +355,6 @@ export const BrowsePage = ({
       }
     });
 
-    const referenceStatus = searchParams.get('referenceStatus');
-    next.referenceStatus =
-      referenceStatus !== null && ['', 'reference', 'non-reference'].includes(referenceStatus)
-        ? referenceStatus
-        : '';
-
     setAppliedFilters((current) => (areFiltersEqual(current, next) ? current : next));
 
     // Sync view, page, pageSize from URL (handles back/forward navigation).
@@ -372,6 +362,14 @@ export const BrowsePage = ({
     setPage(parsePage(searchParams));
     setPageSize(parsePageSize(searchParams));
   }, [searchParams]);
+
+  useEffect(() => {
+    if (!hasDeprecatedBrowseSearchParams(searchParams)) {
+      return;
+    }
+
+    setSearchParams(normalizeBrowseSearchParams(searchParams), { replace: true });
+  }, [searchParams, setSearchParams]);
 
   // Reset page to 1 when filters/case change (skip the initial URL→state sync).
   const prevPageResetSignature = useRef<string | null>(null);
@@ -381,7 +379,7 @@ export const BrowsePage = ({
     });
 
     if (prevPageResetSignature.current === null) {
-      // First render — record reference without resetting page.
+      // First render — record initial state without resetting page.
       prevPageResetSignature.current = currentSignature;
       return;
     }
@@ -409,38 +407,16 @@ export const BrowsePage = ({
     }
 
     setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-
-        for (const key of FILTER_KEYS) {
-          const value = appliedFilters[key];
-          if (Array.isArray(value) && value.length) {
-            next.set(key, serializeArrayFilter(value));
-          } else if (typeof value === 'string' && value) {
-            next.set(key, value);
-          } else {
-            next.delete(key);
-          }
-        }
-
-        if (viewMode === 'grid') {
-          next.set('view', 'grid');
-        } else {
-          next.delete('view');
-        }
-        if (page > 1) {
-          next.set('page', String(page));
-        } else {
-          next.delete('page');
-        }
-        if (pageSize !== 25) {
-          next.set('pageSize', String(pageSize));
-        } else {
-          next.delete('pageSize');
-        }
-
-        return next;
-      },
+      (prev) =>
+        applyBrowseUrlState({
+          currentParams: prev,
+          filters: appliedFilters,
+          filterKeys: FILTER_KEYS,
+          page,
+          pageSize,
+          serializeArrayFilter,
+          viewMode,
+        }),
       { replace: true },
     );
   }, [appliedFilters, viewMode, page, pageSize, setSearchParams]);
@@ -450,16 +426,7 @@ export const BrowsePage = ({
     skipNextFilterUrlSync.current = true;
     setAppliedFilters(createEmptyFilters());
     setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-
-        FILTER_KEYS.forEach((key) => {
-          next.delete(key);
-        });
-
-        next.delete('page');
-        return next;
-      },
+      (prev) => resetBrowseUrlState({ currentParams: prev, filterKeys: FILTER_KEYS }),
       { replace: true },
     );
   };

--- a/frontend/src/features/browse/browseSearchParams.ts
+++ b/frontend/src/features/browse/browseSearchParams.ts
@@ -1,0 +1,89 @@
+const DEFAULT_BROWSE_PAGE_SIZE = 25;
+
+export const DEPRECATED_BROWSE_PARAM_KEYS = ['referenceStatus'] as const;
+
+type BrowseFilterValue = string | string[];
+
+interface ApplyBrowseUrlStateOptions<TFilterKey extends string> {
+  currentParams: URLSearchParams;
+  filters: Record<TFilterKey, BrowseFilterValue>;
+  filterKeys: readonly TFilterKey[];
+  page: number;
+  pageSize: number;
+  serializeArrayFilter: (values: string[]) => string;
+  viewMode: 'grid' | 'table';
+}
+
+interface ResetBrowseUrlStateOptions {
+  currentParams: URLSearchParams;
+  filterKeys: readonly string[];
+}
+
+export const hasDeprecatedBrowseSearchParams = (params: URLSearchParams) =>
+  DEPRECATED_BROWSE_PARAM_KEYS.some((key) => params.has(key));
+
+export const normalizeBrowseSearchParams = (currentParams: URLSearchParams) => {
+  const next = new URLSearchParams(currentParams);
+
+  DEPRECATED_BROWSE_PARAM_KEYS.forEach((key) => {
+    next.delete(key);
+  });
+
+  return next;
+};
+
+export const applyBrowseUrlState = <TFilterKey extends string>({
+  currentParams,
+  filters,
+  filterKeys,
+  page,
+  pageSize,
+  serializeArrayFilter,
+  viewMode,
+}: ApplyBrowseUrlStateOptions<TFilterKey>) => {
+  const next = normalizeBrowseSearchParams(currentParams);
+
+  for (const key of filterKeys) {
+    const value = filters[key];
+
+    if (Array.isArray(value) && value.length > 0) {
+      next.set(key, serializeArrayFilter(value));
+    } else if (typeof value === 'string' && value) {
+      next.set(key, value);
+    } else {
+      next.delete(key);
+    }
+  }
+
+  if (viewMode === 'grid') {
+    next.set('view', 'grid');
+  } else {
+    next.delete('view');
+  }
+
+  if (page > 1) {
+    next.set('page', String(page));
+  } else {
+    next.delete('page');
+  }
+
+  if (pageSize !== DEFAULT_BROWSE_PAGE_SIZE) {
+    next.set('pageSize', String(pageSize));
+  } else {
+    next.delete('pageSize');
+  }
+
+  return next;
+};
+
+export const resetBrowseUrlState = ({ currentParams, filterKeys }: ResetBrowseUrlStateOptions) => {
+  const next = normalizeBrowseSearchParams(currentParams);
+
+  filterKeys.forEach((key) => {
+    next.delete(key);
+  });
+
+  next.delete('page');
+
+  return next;
+};

--- a/frontend/src/features/browse/components/BrowseFiltersSidePanel.tsx
+++ b/frontend/src/features/browse/components/BrowseFiltersSidePanel.tsx
@@ -180,34 +180,6 @@ export const BrowseFiltersSidePanel = ({
               : option.label
           }
         />
-
-        <div>
-          <label className={filterLabelClassName}>Reference Status</label>
-          <div className="space-y-1.5">
-            {[
-              { value: '', label: 'All' },
-              { value: 'reference', label: 'Reference Only' },
-              { value: 'non-reference', label: 'Non-Reference Only' },
-            ].map((opt) => (
-              <div key={opt.value} className="flex items-center gap-2">
-                <input
-                  type="radio"
-                  id={`reference-${opt.value || 'all'}`}
-                  name="referenceStatus"
-                  checked={appliedFilters.referenceStatus === opt.value}
-                  onChange={() => handleChange('referenceStatus', opt.value)}
-                  className="h-4 w-4"
-                />
-                <label
-                  htmlFor={`reference-${opt.value || 'all'}`}
-                  className="text-sm text-slate-700"
-                >
-                  {opt.label}
-                </label>
-              </div>
-            ))}
-          </div>
-        </div>
       </CollapsibleGroup>
 
       {/* Provenance*/}

--- a/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { getBrowseAnchorStatusLabel } from '@/features/browse/components/SimulationResults/anchorStatus';
 import { suppressNextBrowseInteraction } from '@/features/browse/components/SimulationResults/selectionGuard';
 import { getArtifactsByKind } from '@/types/artifact';
 import type { SimulationOut } from '@/types/index';
@@ -146,14 +147,9 @@ export const SimulationBrowseDetailsDialog = ({
                 </div>
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
-                    Reference
+                    Anchor
                   </p>
-                  <p className="mt-1 text-sm text-slate-700">
-                    {simulation.isReference ? 'Yes' : 'No'}
-                    {!simulation.isReference && simulation.changeCount > 0
-                      ? ` (${simulation.changeCount} changes)`
-                      : ''}
-                  </p>
+                  <p className="mt-1 text-sm text-slate-700">{getBrowseAnchorStatusLabel(simulation)}</p>
                 </div>
               </div>
             </section>

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultCard.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { TableCellText } from '@/components/ui/table-cell-text';
+import { getBrowseAnchorStatusLabel } from '@/features/browse/components/SimulationResults/anchorStatus';
 import { SimulationBrowseDetailsDialog } from '@/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog';
 import type { SimulationOut } from '@/types/index';
 
@@ -178,12 +179,7 @@ export const SimulationResultCard = ({
                 variant="secondary"
                 className="flex items-center gap-1 border border-slate-200 bg-slate-50 px-2 py-1 text-sm text-slate-700"
               >
-                Reference: {simulation.isReference ? 'Yes' : 'No'}
-                {!simulation.isReference && simulation.changeCount > 0 && (
-                  <span className="ml-1 text-xs text-muted-foreground">
-                    (Changes: {simulation.changeCount})
-                  </span>
-                )}
+                {getBrowseAnchorStatusLabel(simulation)}
               </Badge>
               <Badge
                 className={`text-xs px-2 py-1 ${

--- a/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
+++ b/frontend/src/features/browse/components/SimulationResults/SimulationResultsTable.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/ui/table';
 import { TableCellText } from '@/components/ui/table-cell-text';
 import { BrowseToolbar } from '@/features/browse/components/BrowseToolbar';
+import { getBrowseAnchorStatusLabel } from '@/features/browse/components/SimulationResults/anchorStatus';
 import { SimulationBrowseDetailsDialog } from '@/features/browse/components/SimulationResults/SimulationBrowseDetailsDialog';
 import type { SimulationOut } from '@/types/index';
 
@@ -147,22 +148,11 @@ const columns: ColumnDef<SimulationOut>[] = [
     meta: { width: 220 },
   },
   {
-    accessorKey: 'isReference',
-    header: renderSortableHeader('Reference'),
-    cell: ({ row }) => {
-      const isReference = row.original.isReference;
-      const changeCount = row.original.changeCount;
-      return (
-        <div>
-          {isReference ? 'Yes' : 'No'}
-          {!isReference && changeCount > 0 && (
-            <span className="ml-1 text-slate-400">({changeCount})</span>
-          )}
-        </div>
-      );
-    },
+    accessorKey: 'anchorSimulationId',
+    header: renderSortableHeader('Anchor'),
+    cell: ({ row }) => <div>{getBrowseAnchorStatusLabel(row.original)}</div>,
     enableSorting: true,
-    meta: { width: 110 },
+    meta: { width: 240 },
   },
   {
     accessorKey: 'campaign',

--- a/frontend/src/features/browse/components/SimulationResults/anchorStatus.ts
+++ b/frontend/src/features/browse/components/SimulationResults/anchorStatus.ts
@@ -1,0 +1,21 @@
+import type { SimulationOut } from '@/types';
+
+export const getBrowseAnchorStatusLabel = (simulation: SimulationOut) => {
+  if (simulation.anchorSimulationId == null) {
+    return 'No comparison anchor';
+  }
+
+  if (simulation.isAnchorRun) {
+    return 'Anchor run';
+  }
+
+  if (simulation.caseHash == null) {
+    return 'No comparison anchor';
+  }
+
+  if (simulation.changeCount > 0) {
+    return `${simulation.changeCount} changes from anchor run`;
+  }
+
+  return 'No recorded changes from anchor run';
+};

--- a/frontend/src/features/simulations/CaseDetailsPage.tsx
+++ b/frontend/src/features/simulations/CaseDetailsPage.tsx
@@ -21,7 +21,9 @@ import {
   formatCaseDate,
   formatCaseHashLabel,
   formatSimulationDateRange,
+  getAnchorStatusLabel,
   getDefaultExpandedGroupKeys,
+  getGroupChangeSummaryLabel,
   getSimulationSummaryDateWindow,
   groupSimulationSummaries,
   matchesSimulationGroupFilter,
@@ -241,7 +243,14 @@ export const CaseDetailsPage = ({
     [groupFilterMode, normalizedCaseHashQuery, sortedSimulationGroups],
   );
   const filteredFlatSimulations = useMemo(
-    () => filteredSimulationGroups.flatMap((group) => group.simulations),
+    () =>
+      filteredSimulationGroups
+        .flatMap((group) => group.simulations)
+        .sort(
+          (left, right) =>
+            new Date(right.summary.simulationStartDate).getTime() -
+            new Date(left.summary.simulationStartDate).getTime(),
+        ),
     [filteredSimulationGroups],
   );
   const visibleSimulationIds = useMemo(
@@ -710,11 +719,11 @@ export const CaseDetailsPage = ({
                                   className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                                 >
                                   {summary.executionId}
-                                  {summary.isReference ? (
+                                  {summary.isAnchorRun ? (
                                     <span
                                       className="inline-flex items-center"
-                                      title="Reference simulation"
-                                      aria-label="Reference simulation"
+                                      title="Anchor run"
+                                      aria-label="Anchor run"
                                     >
                                       <Pin className="h-3.5 w-3.5 text-amber-600" />
                                     </span>
@@ -732,9 +741,7 @@ export const CaseDetailsPage = ({
                                 </span>
                               </TableCell>
                               <TableCell className="align-top text-sm text-slate-700">
-                                {summary.isReference
-                                  ? 'Reference baseline'
-                                  : `${summary.changeCount} changes`}
+                                {getAnchorStatusLabel(summary)}
                               </TableCell>
                               <TableCell className="align-top">
                                 <TableCellText
@@ -807,8 +814,8 @@ export const CaseDetailsPage = ({
                             const groupInitializationSummary = summarizeDistinctValues(
                               group.simulations.map(({ details }) => details?.initializationType),
                             );
-                            const maxChangeCount = Math.max(
-                              ...group.simulations.map(({ summary }) => summary.changeCount),
+                            const groupChangeSummaryLabel = getGroupChangeSummaryLabel(
+                              group.simulations.map(({ summary }) => summary),
                             );
                             const showInitializationColumn =
                               countDistinctValues(
@@ -879,7 +886,7 @@ export const CaseDetailsPage = ({
                                     <TableCellText value={groupInitializationSummary} lines={1} />
                                   </TableCell>
                                   <TableCell className="align-top text-sm font-medium text-slate-700">
-                                    Up to {maxChangeCount} changes
+                                    {groupChangeSummaryLabel}
                                   </TableCell>
                                   <TableCell className="align-top text-sm text-slate-700">
                                     {groupRunWindow}
@@ -959,11 +966,11 @@ export const CaseDetailsPage = ({
                                                         className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                                                       >
                                                         {summary.executionId}
-                                                        {summary.isReference ? (
+                                                        {summary.isAnchorRun ? (
                                                           <span
                                                             className="inline-flex items-center"
-                                                            title="Reference simulation"
-                                                            aria-label="Reference simulation"
+                                                            title="Anchor run"
+                                                            aria-label="Anchor run"
                                                           >
                                                             <Pin className="h-3.5 w-3.5 text-amber-600" />
                                                           </span>
@@ -971,9 +978,7 @@ export const CaseDetailsPage = ({
                                                       </Link>
                                                     </TableCell>
                                                     <TableCell className="align-top text-sm text-slate-700">
-                                                      {summary.isReference
-                                                        ? 'Reference baseline'
-                                                        : `${summary.changeCount} changes`}
+                                                      {getAnchorStatusLabel(summary)}
                                                     </TableCell>
                                                     {showInitializationColumn ? (
                                                       <TableCell className="align-top">

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -115,7 +115,7 @@ const getSimulationChangeTitle = (simulation: CaseSimulationListItem) => {
     }
   }
 
-  return `${simulation.changeCount} changes from reference`;
+  return `${simulation.changeCount} recorded configuration changes`;
 };
 
 export const CasesPage = ({ simulations }: CasesPageProps) => {

--- a/frontend/src/features/simulations/CasesPage.tsx
+++ b/frontend/src/features/simulations/CasesPage.tsx
@@ -33,13 +33,13 @@ import { TableCellText } from '@/components/ui/table-cell-text';
 import {
   formatCaseDate,
   formatCaseHashLabel,
+  getAnchorStatusLabel,
   MISSING_CASE_HASH_LABEL,
 } from '@/features/simulations/caseUtils';
 import { useCases } from '@/features/simulations/hooks/useCases';
 import { cn } from '@/lib/utils';
 import type { CaseOut, SimulationOut, SimulationSummaryOut } from '@/types';
 
-type ReferenceFilter = 'all' | 'with-reference' | 'without-reference';
 type ActiveFilterKey =
   | 'caseName'
   | 'hpcUsername'
@@ -50,8 +50,7 @@ type ActiveFilterKey =
   | 'compiler'
   | 'gitTag'
   | 'createdBy'
-  | 'caseGroup'
-  | 'reference';
+  | 'caseGroup';
 
 interface CasesPageProps {
   simulations: SimulationOut[];
@@ -97,10 +96,6 @@ const sortStringValues = (values: string[]) =>
 
 const sortCaseSimulations = (caseSimulations: CaseSimulationListItem[]) =>
   [...caseSimulations].sort((left, right) => {
-    if (left.isReference !== right.isReference) {
-      return left.isReference ? -1 : 1;
-    }
-
     return (
       new Date(right.simulationStartDate).getTime() - new Date(left.simulationStartDate).getTime()
     );
@@ -128,7 +123,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   const [simulationFilters, setSimulationFilters] = useState<CaseSimulationFilters>(
     createEmptySimulationFilters,
   );
-  const [referenceFilter, setReferenceFilter] = useState<ReferenceFilter>('all');
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const [expandedCaseId, setExpandedCaseId] = useState<string | null>(null);
   const [sorting, setSorting] = useState<SortingState>([
@@ -279,7 +273,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
   const hasActiveFilters =
     caseNameFilter.trim().length > 0 ||
     caseGroupFilter.length > 0 ||
-    referenceFilter !== 'all' ||
     hasActiveSimulationFilters;
   const advancedFilterCount = useMemo(
     () =>
@@ -292,9 +285,8 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         simulationFilters.gitTag,
         simulationFilters.createdBy,
         caseGroupFilter,
-        referenceFilter !== 'all' ? referenceFilter : '',
       ].filter(Boolean).length,
-    [referenceFilter, caseGroupFilter, simulationFilters],
+    [caseGroupFilter, simulationFilters],
   );
   const matchingSimulationsByCaseId = useMemo(() => {
     const matchingMap = new Map<string, SimulationOut[]>();
@@ -408,23 +400,8 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
 
     if (caseGroupFilter) filters.push({ key: 'caseGroup', label: 'Group', value: caseGroupFilter });
 
-    if (referenceFilter !== 'all') {
-      filters.push({
-        key: 'reference',
-        label: 'Reference',
-        value: referenceFilter === 'with-reference' ? 'Present' : 'Missing',
-      });
-    }
-
     return filters;
-  }, [
-    referenceFilter,
-    caseGroupFilter,
-    caseNameFilter,
-    creatorOptions,
-    machineOptions,
-    simulationFilters,
-  ]);
+  }, [caseGroupFilter, caseNameFilter, creatorOptions, machineOptions, simulationFilters]);
 
   const setSimulationFilter = (key: keyof CaseSimulationFilters, value: string) => {
     setSimulationFilters((current) => ({
@@ -438,7 +415,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
     setCaseNameFilter('');
     setCaseGroupFilter('');
     setSimulationFilters(createEmptySimulationFilters());
-    setReferenceFilter('all');
     setShowAdvancedFilters(false);
     table.setPageIndex(0);
   };
@@ -450,9 +426,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         break;
       case 'caseGroup':
         setCaseGroupFilter('');
-        break;
-      case 'reference':
-        setReferenceFilter('all');
         break;
       default:
         setSimulationFilters((current) => ({
@@ -473,25 +446,13 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
         normalizedNameFilter.length === 0 ||
         caseRecord.name.toLowerCase().includes(normalizedNameFilter);
       const matchesGroup = !caseGroupFilter || caseRecord.caseGroup === caseGroupFilter;
-      const hasReferenceSimulation = caseRecord.referenceSimulationId != null;
-      const matchesReference =
-        referenceFilter === 'all' ||
-        (referenceFilter === 'with-reference' && hasReferenceSimulation) ||
-        (referenceFilter === 'without-reference' && !hasReferenceSimulation);
       const matchesSimulationFilters =
         !hasActiveSimulationFilters ||
         (matchingSimulationsByCaseId.get(caseRecord.id)?.length ?? 0) > 0;
 
-      return matchesName && matchesGroup && matchesReference && matchesSimulationFilters;
+      return matchesName && matchesGroup && matchesSimulationFilters;
     });
-  }, [
-    caseGroupFilter,
-    cases,
-    referenceFilter,
-    caseNameFilter,
-    hasActiveSimulationFilters,
-    matchingSimulationsByCaseId,
-  ]);
+  }, [caseGroupFilter, cases, caseNameFilter, hasActiveSimulationFilters, matchingSimulationsByCaseId]);
 
   const visibleRunCount = useMemo(
     () =>
@@ -684,7 +645,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                 ? 'Showing case-level run summaries because full simulation details are unavailable.'
                 : hasActiveSimulationFilters
                   ? `${matchingCaseSimulations.length} of ${allCaseSimulations.length} runs match the current filters.`
-                  : 'Reference runs are pinned first. Open the case page for full context.'}
+                  : 'Runs are ordered newest first. Open the case page for subgroup anchor context.'}
             </p>
           </div>
           <Button variant="outline" size="sm" asChild>
@@ -715,11 +676,11 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                         className="inline-flex items-center gap-1 font-mono text-xs text-blue-600 hover:underline"
                       >
                         {simulation.executionId}
-                        {simulation.isReference && (
+                        {simulation.isAnchorRun && (
                           <span
                             className="inline-flex items-center"
-                            title="Reference simulation"
-                            aria-label="Reference simulation"
+                            title="Anchor run"
+                            aria-label="Anchor run"
                           >
                             <Pin className="h-3.5 w-3.5 text-amber-600" />
                           </span>
@@ -735,18 +696,12 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                       </span>
                     </TableCell>
                     <TableCell className="align-top">
-                      {simulation.isReference ? (
-                        <span
-                          className="text-sm font-medium text-slate-700"
-                          title="Reference simulation"
-                        >
-                          Reference
-                        </span>
-                      ) : (
-                        <Badge variant="secondary" title={getSimulationChangeTitle(simulation)}>
-                          {simulation.changeCount}
-                        </Badge>
-                      )}
+                      <span
+                        className="text-sm font-medium text-slate-700"
+                        title={getSimulationChangeTitle(simulation)}
+                      >
+                        {getAnchorStatusLabel(simulation)}
+                      </span>
                     </TableCell>
                     <TableCell className="align-top">
                       {`${formatCaseDate(simulation.simulationStartDate)} → ${formatCaseDate(
@@ -789,7 +744,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                 <h1 className="text-3xl font-semibold tracking-tight text-slate-950">Cases</h1>
                 <p className="max-w-3xl text-sm leading-6 text-slate-600 sm:text-[15px]">
                   Find the cases behind your runs. Start with HPC username or machine, then refine
-                  by campaign, version context, and reference state.
+                  by campaign, version context, and subgroup anchor metadata.
                 </p>
               </div>
             </div>
@@ -989,7 +944,7 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                       <div className="space-y-1">
                         <p className="text-sm font-medium text-slate-900">Case settings</p>
                         <p className="text-xs text-slate-500">
-                          Narrow the result set using case-level metadata and reference state.
+                          Narrow the result set using case-level metadata.
                         </p>
                       </div>
                       <div className="grid gap-3">
@@ -1003,27 +958,6 @@ export const CasesPage = ({ simulations }: CasesPageProps) => {
                             table.setPageIndex(0);
                           },
                         })}
-                        <div className="space-y-2">
-                          <label className="text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
-                            Reference state
-                          </label>
-                          <Select
-                            value={referenceFilter}
-                            onValueChange={(value: ReferenceFilter) => {
-                              setReferenceFilter(value);
-                              table.setPageIndex(0);
-                            }}
-                          >
-                            <SelectTrigger className="h-10 rounded-xl border-slate-200 bg-white shadow-none">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="all">All reference states</SelectItem>
-                              <SelectItem value="with-reference">Reference present</SelectItem>
-                              <SelectItem value="without-reference">Reference missing</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </div>
                       </div>
                     </div>
                   </div>

--- a/frontend/src/features/simulations/SimulationsPage.tsx
+++ b/frontend/src/features/simulations/SimulationsPage.tsx
@@ -40,6 +40,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { TableCellText } from '@/components/ui/table-cell-text';
+import { getAnchorChangeCount, getAnchorStatusLabel } from '@/features/simulations/caseUtils';
 import { cn } from '@/lib/utils';
 import type { SimulationOut } from '@/types/index';
 
@@ -151,23 +152,21 @@ export const SimulationsPage = ({ simulations }: SimulationsPageProps) => {
         size: 380,
       },
       {
-        accessorKey: 'isReference',
-        header: 'Reference',
-        cell: ({ row }) =>
-          row.original.isReference ? (
-            <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-              Reference
-            </Badge>
-          ) : null,
-        size: 100,
+        accessorKey: 'anchorSimulationId',
+        header: 'Anchor',
+        cell: ({ row }) => <TableCellText value={getAnchorStatusLabel(row.original)} />,
+        size: 220,
       },
       {
         accessorKey: 'changeCount',
         header: 'Changes',
-        cell: ({ row }) =>
-          row.original.changeCount > 0 ? (
-            <Badge variant="secondary">{row.original.changeCount}</Badge>
-          ) : null,
+        cell: ({ row }) => {
+          const changeCount = getAnchorChangeCount(row.original);
+
+          return changeCount != null && changeCount > 0 ? (
+            <Badge variant="secondary">{changeCount}</Badge>
+          ) : null;
+        },
         size: 80,
       },
       {

--- a/frontend/src/features/simulations/caseUtils.ts
+++ b/frontend/src/features/simulations/caseUtils.ts
@@ -19,6 +19,21 @@ export interface SimulationSummaryDateWindow {
   endDate: string | null;
 }
 
+interface AnchorStatusLike {
+  caseHash?: string | null;
+  isAnchorRun: boolean;
+  anchorSimulationId: string | null;
+  changeCount: number;
+}
+
+export const hasComparisonAnchor = (simulation: AnchorStatusLike) =>
+  simulation.caseHash != null &&
+  simulation.anchorSimulationId != null &&
+  !simulation.isAnchorRun;
+
+export const getAnchorChangeCount = (simulation: AnchorStatusLike) =>
+  hasComparisonAnchor(simulation) ? simulation.changeCount : null;
+
 export const formatCaseDate = (value?: string | null) => {
   if (!value) return '—';
 
@@ -71,16 +86,46 @@ export const getSimulationSummaryDateWindow = (
 
 export const sortSimulationSummaries = (simulations: SimulationSummaryOut[]) =>
   [...simulations].sort((left, right) => {
-    if (left.isReference !== right.isReference) {
-      return left.isReference ? -1 : 1;
-    }
-
     return (
       new Date(right.simulationStartDate).getTime() - new Date(left.simulationStartDate).getTime()
     );
   });
 
-export const formatCaseHashLabel = (caseHash: string | null, maxLength = 18) => {
+export const getAnchorStatusLabel = (simulation: AnchorStatusLike) => {
+  if (simulation.anchorSimulationId == null) {
+    return 'No comparison anchor';
+  }
+
+  if (simulation.isAnchorRun) {
+    return 'Anchor run';
+  }
+
+  const comparisonChangeCount = getAnchorChangeCount(simulation);
+
+  if (comparisonChangeCount == null) {
+    return 'No comparison anchor';
+  }
+
+  if (comparisonChangeCount > 0) {
+    return `${comparisonChangeCount} changes from anchor run`;
+  }
+
+  return 'No recorded changes from anchor run';
+};
+
+export const getGroupChangeSummaryLabel = (simulations: AnchorStatusLike[]) => {
+  const changeCounts = simulations
+    .map((simulation) => getAnchorChangeCount(simulation))
+    .filter((value): value is number => value != null);
+
+  if (changeCounts.length === 0) {
+    return 'No comparison anchor';
+  }
+
+  return `Up to ${Math.max(...changeCounts)} changes`;
+};
+
+export const formatCaseHashLabel = (caseHash: string | null | undefined, maxLength = 18) => {
   if (!caseHash) return MISSING_CASE_HASH_LABEL;
   if (caseHash.length <= maxLength) return caseHash;
 
@@ -146,7 +191,16 @@ export const groupSimulationSummaries = (
       caseHash: group.caseHash,
       label: group.label,
       isFallback: group.isFallback,
-      simulations: group.simulations,
+      simulations: [...group.simulations].sort((left, right) => {
+        if (!group.isFallback && left.isAnchorRun !== right.isAnchorRun) {
+          return left.isAnchorRun ? -1 : 1;
+        }
+
+        return (
+          new Date(right.simulationStartDate).getTime() -
+          new Date(left.simulationStartDate).getTime()
+        );
+      }),
     }));
 };
 

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -14,6 +14,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { getAnchorChangeCount, getAnchorStatusLabel } from '@/features/simulations/caseUtils';
 import { SimulationPathCard } from '@/features/simulations/components/SimulationPathCard';
 import {
   SimulationSummaryLauncher,
@@ -133,6 +134,7 @@ export const SimulationDetailsView = ({
   const [activeTab, setActiveTab] = useState('summary');
   const [isAdvancedMetadataOpen, setIsAdvancedMetadataOpen] = useState(false);
   const [notes, setNotes] = useState(simulation.notesMarkdown || '');
+  const anchorChangeCount = getAnchorChangeCount(simulation);
   const performanceLinks = simulation.groupedLinks.performance ?? [];
   const outputArtifacts = getArtifactsByKind(
     simulation.artifacts,
@@ -273,12 +275,12 @@ export const SimulationDetailsView = ({
                         <ReadonlyInput value={simulation.caseGroup} />
                       </FieldRow>
                     )}
-                    <FieldRow label="Reference">
-                      <span className="text-sm">{simulation.isReference ? 'Yes' : 'No'}</span>
+                    <FieldRow label="Anchor">
+                      <span className="text-sm">{getAnchorStatusLabel(simulation)}</span>
                     </FieldRow>
-                    {!simulation.isReference && (
+                    {anchorChangeCount != null && (
                       <FieldRow label="Recorded config changes">
-                        <span className="text-sm">{simulation.changeCount}</span>
+                        <span className="text-sm">{anchorChangeCount}</span>
                       </FieldRow>
                     )}
                     <FieldRow label="Model Version">
@@ -336,7 +338,7 @@ export const SimulationDetailsView = ({
                 </Card>
               </div>
 
-              {!simulation.isReference && (
+              {anchorChangeCount != null && (
                 <Card>
                   <CardHeader className="pb-2">
                     <CardTitle className="text-base">Configuration Differences</CardTitle>
@@ -352,7 +354,7 @@ export const SimulationDetailsView = ({
                                 Field
                               </th>
                               <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                Reference
+                                Anchor run
                               </th>
                               <th className="p-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
                                 Current

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -277,7 +277,7 @@ export const SimulationDetailsView = ({
                       <span className="text-sm">{simulation.isReference ? 'Yes' : 'No'}</span>
                     </FieldRow>
                     {!simulation.isReference && (
-                      <FieldRow label="Changes vs reference">
+                      <FieldRow label="Recorded config changes">
                         <span className="text-sm">{simulation.changeCount}</span>
                       </FieldRow>
                     )}

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -48,7 +48,6 @@ export interface CaseOut {
   id: string;
   name: string;
   caseGroup: string | null;
-  referenceSimulationId: string | null;
   simulations: SimulationSummaryOut[];
   machineNames: string[];
   hpcUsernames: string[];
@@ -65,7 +64,8 @@ export interface SimulationSummaryOut {
   executionId: string;
   caseHash: string | null;
   status: string;
-  isReference: boolean;
+  isAnchorRun: boolean;
+  anchorSimulationId: string | null;
   changeCount: number;
   simulationStartDate: string;
   simulationEndDate: string | null;
@@ -151,7 +151,8 @@ export interface SimulationOut extends SimulationCreate {
   id: string;
   caseName: string;
   caseGroup: string | null;
-  isReference: boolean;
+  isAnchorRun: boolean;
+  anchorSimulationId: string | null;
   changeCount: number;
 
   // Provenance & submission

--- a/frontend/tests/browseSearchParams.test.mjs
+++ b/frontend/tests/browseSearchParams.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyBrowseUrlState,
+  hasDeprecatedBrowseSearchParams,
+  normalizeBrowseSearchParams,
+  resetBrowseUrlState,
+} from '../src/features/browse/browseSearchParams.ts';
+
+test('normalizeBrowseSearchParams removes deprecated referenceStatus on initialization', () => {
+  const params = new URLSearchParams('referenceStatus=with-reference&status=complete');
+
+  const next = normalizeBrowseSearchParams(params);
+
+  assert.equal(next.has('referenceStatus'), false);
+  assert.equal(next.get('status'), 'complete');
+});
+
+test('applyBrowseUrlState removes deprecated referenceStatus during filter sync', () => {
+  const next = applyBrowseUrlState({
+    currentParams: new URLSearchParams('referenceStatus=with-reference&view=grid&page=3'),
+    filters: {
+      status: ['failed'],
+      createdBy: [],
+    },
+    filterKeys: ['status', 'createdBy'],
+    page: 1,
+    pageSize: 25,
+    serializeArrayFilter: (values) => values.join(','),
+    viewMode: 'table',
+  });
+
+  assert.equal(next.has('referenceStatus'), false);
+  assert.equal(next.get('status'), 'failed');
+  assert.equal(next.has('view'), false);
+  assert.equal(next.has('page'), false);
+});
+
+test('resetBrowseUrlState removes deprecated referenceStatus during reset', () => {
+  const initial = new URLSearchParams('referenceStatus=with-reference&status=complete&page=2');
+
+  assert.equal(hasDeprecatedBrowseSearchParams(initial), true);
+
+  const next = resetBrowseUrlState({
+    currentParams: initial,
+    filterKeys: ['status'],
+  });
+
+  assert.equal(next.has('referenceStatus'), false);
+  assert.equal(next.has('status'), false);
+  assert.equal(next.has('page'), false);
+});

--- a/frontend/tests/caseUtils.test.mjs
+++ b/frontend/tests/caseUtils.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getAnchorChangeCount,
+  getAnchorStatusLabel,
+  getGroupChangeSummaryLabel,
+} from '../src/features/simulations/caseUtils.ts';
+
+test('getAnchorChangeCount hides stale changeCount for hashless simulations', () => {
+  const simulation = {
+    caseHash: null,
+    isAnchorRun: false,
+    anchorSimulationId: 'anchor-1',
+    changeCount: 4,
+  };
+
+  assert.equal(getAnchorChangeCount(simulation), null);
+  assert.equal(getAnchorStatusLabel(simulation), 'No comparison anchor');
+});
+
+test('getAnchorChangeCount preserves changeCount for anchored non-hashless simulations', () => {
+  const simulation = {
+    caseHash: 'case-hash',
+    isAnchorRun: false,
+    anchorSimulationId: 'anchor-1',
+    changeCount: 2,
+  };
+
+  assert.equal(getAnchorChangeCount(simulation), 2);
+});
+
+test('getGroupChangeSummaryLabel uses non-comparison copy for hashless fallback groups', () => {
+  const label = getGroupChangeSummaryLabel([
+    {
+      caseHash: null,
+      isAnchorRun: false,
+      anchorSimulationId: 'anchor-1',
+      changeCount: 7,
+    },
+    {
+      caseHash: null,
+      isAnchorRun: false,
+      anchorSimulationId: 'anchor-2',
+      changeCount: 3,
+    },
+  ]);
+
+  assert.equal(label, 'No comparison anchor');
+});


### PR DESCRIPTION
## Summary
This PR expands backend assistant and ingestion capabilities, updates simulation anchor/config-delta handling, and refreshes related frontend browse/details flows.

Closes #195

## Assistant
- Add assistant API, orchestration, registry, snapshot, and service flows
- Add LLM generator support and regression coverage for assistant endpoints and orchestration behavior

## Ingestion
- Extend ingestion APIs, schemas, and state tracking
- Add HPC upload and NERSC archive ingestion support
- Track processed execution IDs and expand ingestion test coverage

## Simulation and Browse
- Resolve anchor runs by `case_id` + `case_hash` subgroup instead of case-wide reference simulation
- Remove case reference simulation persistence and add migration coverage for new anchor behavior
- Update simulation schemas, assistant wording, and frontend labels for recorded configuration differences
- Refresh browse search-param handling and simulation details/browse UI state

## Docs and Tooling
- Update env examples, Makefile/config, and dependency lockfiles
- Add and reorganize backend, deploy, developer, and ingestion documentation
- Add MkDocs/Read the Docs related project updates

## Validation
- Pre-commit passes locally
- Backend and frontend regression coverage updated for touched areas

## Deployment Notes
- Includes database migrations for ingestion state changes and simulation reference removal