### PR TITLE
[SimEdit]: Allow editing uploaded simulations from the Simulation Details page

### DIFF
--- a/backend/app/features/simulation/api.py
+++ b/backend/app/features/simulation/api.py
@@ -16,12 +16,22 @@ from app.features.simulation.schemas import (
     SimulationOut,
     SimulationSummaryCapabilitiesOut,
     SimulationSummaryOut,
+    SimulationUpdate,
 )
 from app.features.user.manager import current_active_user
 from app.features.user.models import User
 
 simulation_router = APIRouter(prefix="/simulations", tags=["Simulations"])
 case_router = APIRouter(prefix="/cases", tags=["Cases"])
+
+
+def _simulation_detail_query(db: Session):
+    return db.query(Simulation).options(
+        joinedload(Simulation.case),
+        joinedload(Simulation.machine),
+        selectinload(Simulation.artifacts),
+        selectinload(Simulation.links),
+    )
 
 
 @case_router.get(
@@ -256,15 +266,7 @@ def create_simulation(
 
     # Re-query with relationships loaded
     sim_loaded = (
-        db.query(Simulation)
-        .options(
-            joinedload(Simulation.case),
-            joinedload(Simulation.machine),
-            selectinload(Simulation.artifacts),
-            selectinload(Simulation.links),
-        )
-        .filter(Simulation.id == sim.id)
-        .one_or_none()
+        _simulation_detail_query(db).filter(Simulation.id == sim.id).one_or_none()
     )
 
     if sim_loaded is None:
@@ -336,6 +338,59 @@ def list_simulations(
     return [_simulation_to_out(s) for s in sims]
 
 
+@simulation_router.patch(
+    "/{sim_id}",
+    response_model=SimulationOut,
+    responses={
+        200: {"description": "Simulation updated successfully."},
+        401: {"description": "Unauthorized."},
+        404: {"description": "Simulation not found."},
+        422: {"description": "Validation error."},
+        500: {"description": "Internal server error."},
+    },
+)
+def update_simulation(
+    sim_id: UUID,
+    payload: SimulationUpdate,
+    db: Session = Depends(get_database_session),
+    user: User = Depends(current_active_user),
+) -> SimulationOut:
+    """Partially update allowed simulation metadata fields."""
+    sim = db.query(Simulation).filter(Simulation.id == sim_id).one_or_none()
+
+    if sim is None:
+        raise HTTPException(status_code=404, detail="Simulation not found")
+
+    now = datetime.now(timezone.utc)
+    updates = payload.model_dump(by_alias=False, exclude_unset=True)
+
+    if "git_repository_url" in updates and updates["git_repository_url"] is not None:
+        updates["git_repository_url"] = str(updates["git_repository_url"])
+
+    for field, value in updates.items():
+        setattr(sim, field, value)
+
+    sim.last_updated_by = user.id
+    sim.updated_at = now
+
+    with transaction(db):
+        db.add(sim)
+        db.flush()
+
+    db.expire_all()
+    sim_loaded = (
+        _simulation_detail_query(db).filter(Simulation.id == sim_id).one_or_none()
+    )
+
+    if sim_loaded is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to load updated simulation.",
+        )
+
+    return _simulation_to_out(sim_loaded)
+
+
 @simulation_router.get(
     "/{sim_id}",
     response_model=SimulationOut,
@@ -367,17 +422,7 @@ def get_simulation(sim_id: UUID, db: Session = Depends(get_database_session)):
     HTTPException
         If the simulation with the given ID is not found, raises a 404 HTTP exception.
     """
-    sim = (
-        db.query(Simulation)
-        .options(
-            joinedload(Simulation.case),
-            joinedload(Simulation.machine),
-            selectinload(Simulation.artifacts),
-            selectinload(Simulation.links),
-        )
-        .filter(Simulation.id == sim_id)
-        .one_or_none()
-    )
+    sim = _simulation_detail_query(db).filter(Simulation.id == sim_id).one_or_none()
 
     if not sim:
         raise HTTPException(status_code=404, detail="Simulation not found")

--- a/backend/app/features/simulation/schemas.py
+++ b/backend/app/features/simulation/schemas.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Annotated, Any
 from uuid import UUID
 
-from pydantic import Field, HttpUrl, computed_field
+from pydantic import ConfigDict, Field, HttpUrl, computed_field
 
 from app.common.schemas.base import CamelInBaseModel, CamelOutBaseModel
 from app.features.machine.schemas import MachineOut
@@ -270,6 +270,71 @@ class SimulationCreate(CamelInBaseModel):
         Field(
             default_factory=list,
             description="Optional list of external links associated with the simulation",
+        ),
+    ]
+
+
+class SimulationUpdate(CamelInBaseModel):
+    """Schema for narrow v1 simulation metadata updates."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    description: Annotated[
+        str | None, Field(None, description="Optional description of the simulation")
+    ]
+    campaign: Annotated[
+        str | None,
+        Field(
+            None, description="Campaign or run grouping (e.g. historical, amip, tuning)"
+        ),
+    ]
+    experiment_type: Annotated[
+        ExperimentType | str | None,
+        Field(
+            None,
+            description=(
+                "High-level experiment category (e.g. historical, amip, piControl). "
+                "Often aligned with CMIP experiment identifiers."
+            ),
+        ),
+    ]
+    compiler: Annotated[
+        str | None, Field(None, description="Optional compiler used for the simulation")
+    ]
+    hpc_username: Annotated[
+        str | None,
+        Field(
+            None,
+            description="HPC username for provenance (trusted, informational only)",
+        ),
+    ]
+    key_features: Annotated[
+        str | None, Field(None, description="Optional key features of the simulation")
+    ]
+    known_issues: Annotated[
+        str | None, Field(None, description="Optional known issues with the simulation")
+    ]
+    notes_markdown: Annotated[
+        str | None,
+        Field(None, description="Optional additional notes in markdown format"),
+    ]
+    git_repository_url: Annotated[
+        HttpUrl | None, Field(None, description="Optional Git repository URL")
+    ]
+    git_branch: Annotated[
+        str | None,
+        Field(
+            None, description="Optional Git branch name associated with the simulation"
+        ),
+    ]
+    git_tag: Annotated[
+        str | None, Field(None, description="Optional Git tag for the simulation")
+    ]
+    git_commit_hash: Annotated[
+        str | None,
+        Field(
+            None,
+            description="Optional Git commit hash associated with the simulation",
         ),
     ]
 

--- a/backend/tests/features/simulation/test_api.py
+++ b/backend/tests/features/simulation/test_api.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -46,6 +47,75 @@ def _create_case(db: Session, name: str = "test_case") -> Case:
     db.flush()
 
     return case
+
+
+def _create_ingestion(
+    db: Session,
+    machine_id,
+    user_id,
+    source_reference: str = "test_simulation_ingestion",
+) -> Ingestion:
+    ingestion = Ingestion(
+        source_type=IngestionSourceType.BROWSER_UPLOAD,
+        source_reference=source_reference,
+        machine_id=machine_id,
+        triggered_by=user_id,
+        status=IngestionStatus.SUCCESS,
+        created_count=1,
+        duplicate_count=0,
+        error_count=0,
+    )
+    db.add(ingestion)
+    db.flush()
+
+    return ingestion
+
+
+def _create_simulation_record(
+    db: Session,
+    *,
+    case: Case,
+    machine_id,
+    ingestion_id,
+    created_by,
+    last_updated_by,
+    execution_id: str = "patch-test-exec-1",
+    description: str | None = "Original description",
+    updated_at: datetime | None = None,
+) -> Simulation:
+    sim = Simulation(
+        case_id=case.id,
+        execution_id=execution_id,
+        description=description,
+        compset="AQUAPLANET",
+        compset_alias="QPC4",
+        grid_name="f19_f19",
+        grid_resolution="1.9x2.5",
+        initialization_type="startup",
+        simulation_type="experimental",
+        status="created",
+        campaign="campaign-original",
+        experiment_type="historical",
+        machine_id=machine_id,
+        simulation_start_date="2023-01-01T00:00:00Z",
+        compiler="gcc",
+        key_features="Original features",
+        known_issues="Original issues",
+        notes_markdown="Original notes",
+        git_repository_url="https://example.com/original",
+        git_branch="main",
+        git_tag="v1.0",
+        git_commit_hash="abc123",
+        hpc_username="old-user",
+        created_by=created_by,
+        last_updated_by=last_updated_by,
+        ingestion_id=ingestion_id,
+        updated_at=updated_at or datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    db.add(sim)
+    db.flush()
+
+    return sim
 
 
 class TestListCases:
@@ -792,6 +862,144 @@ class TestGetSimulation:
         res = client.get(f"{API_BASE}/simulations/{uuid4()}")
         assert res.status_code == 404
         assert res.json() == {"detail": "Simulation not found"}
+
+
+class TestUpdateSimulation:
+    def test_endpoint_updates_sparse_metadata_and_audit_fields(
+        self, client, db: Session, normal_user_sync, admin_user_sync
+    ):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        case = _create_case(db, "test_case_patch")
+        ingestion = _create_ingestion(
+            db,
+            machine.id,
+            normal_user_sync["id"],
+            source_reference="test_simulation_patch",
+        )
+        original_updated_at = datetime.now(timezone.utc) - timedelta(days=2)
+        sim = _create_simulation_record(
+            db,
+            case=case,
+            machine_id=machine.id,
+            ingestion_id=ingestion.id,
+            created_by=normal_user_sync["id"],
+            last_updated_by=admin_user_sync["id"],
+            updated_at=original_updated_at,
+        )
+        db.commit()
+
+        payload = {
+            "description": "Updated description",
+            "campaign": "campaign-updated",
+            "gitRepositoryUrl": "https://example.com/updated",
+            "notesMarkdown": "Updated notes",
+        }
+
+        res = client.patch(f"{API_BASE}/simulations/{sim.id}", json=payload)
+
+        assert res.status_code == 200
+        data = res.json()
+        assert data["description"] == payload["description"]
+        assert data["campaign"] == payload["campaign"]
+        assert data["gitRepositoryUrl"] == payload["gitRepositoryUrl"]
+        assert data["notesMarkdown"] == payload["notesMarkdown"]
+        assert data["compiler"] == "gcc"
+        assert data["gitTag"] == "v1.0"
+        assert data["hpcUsername"] == "old-user"
+        assert data["lastUpdatedBy"] == str(normal_user_sync["id"])
+        assert data["lastUpdatedByUser"]["email"] == normal_user_sync["email"]
+        assert data["updatedAt"] != original_updated_at.isoformat()
+
+        db.expire_all()
+        updated_sim = db.query(Simulation).filter(Simulation.id == sim.id).one()
+        assert updated_sim.description == payload["description"]
+        assert updated_sim.campaign == payload["campaign"]
+        assert updated_sim.git_repository_url == payload["gitRepositoryUrl"]
+        assert updated_sim.notes_markdown == payload["notesMarkdown"]
+        assert updated_sim.compiler == "gcc"
+        assert updated_sim.git_tag == "v1.0"
+        assert updated_sim.last_updated_by == normal_user_sync["id"]
+        assert updated_sim.updated_at > original_updated_at
+
+    def test_endpoint_returns_401_without_authentication(
+        self, client, db: Session, normal_user_sync
+    ):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        case = _create_case(db, "test_case_patch_unauth")
+        ingestion = _create_ingestion(
+            db,
+            machine.id,
+            normal_user_sync["id"],
+            source_reference="test_simulation_patch_unauth",
+        )
+        sim = _create_simulation_record(
+            db,
+            case=case,
+            machine_id=machine.id,
+            ingestion_id=ingestion.id,
+            created_by=normal_user_sync["id"],
+            last_updated_by=normal_user_sync["id"],
+            execution_id="patch-test-unauth",
+        )
+        db.commit()
+
+        app.dependency_overrides.pop(current_active_user, None)
+
+        res = client.patch(
+            f"{API_BASE}/simulations/{sim.id}",
+            json={"description": "Should fail"},
+        )
+
+        assert res.status_code == 401
+
+    def test_endpoint_returns_404_when_simulation_not_found(self, client):
+        res = client.patch(
+            f"{API_BASE}/simulations/{uuid4()}",
+            json={"description": "Missing simulation"},
+        )
+
+        assert res.status_code == 404
+        assert res.json() == {"detail": "Simulation not found"}
+
+    def test_endpoint_rejects_out_of_scope_fields(
+        self, client, db: Session, normal_user_sync
+    ):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        case = _create_case(db, "test_case_patch_scope")
+        ingestion = _create_ingestion(
+            db,
+            machine.id,
+            normal_user_sync["id"],
+            source_reference="test_simulation_patch_scope",
+        )
+        sim = _create_simulation_record(
+            db,
+            case=case,
+            machine_id=machine.id,
+            ingestion_id=ingestion.id,
+            created_by=normal_user_sync["id"],
+            last_updated_by=normal_user_sync["id"],
+            execution_id="patch-test-scope",
+        )
+        db.commit()
+
+        res = client.patch(
+            f"{API_BASE}/simulations/{sim.id}",
+            json={"caseName": "mutated-case-name"},
+        )
+
+        assert res.status_code == 422
+
+        db.expire_all()
+        unchanged_sim = db.query(Simulation).filter(Simulation.id == sim.id).one()
+        assert unchanged_sim.description == "Original description"
+        assert unchanged_sim.case_id == case.id
 
 
 class TestSimulationBrowserIncludesCaseMetadata:

--- a/backend/tests/features/simulation/test_schemas.py
+++ b/backend/tests/features/simulation/test_schemas.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from uuid import uuid4
 
-from pydantic import HttpUrl
+import pytest
+from pydantic import HttpUrl, ValidationError
 
 from app.common.schemas.utils import to_snake_case
 from app.features.machine.schemas import MachineOut
@@ -15,6 +16,7 @@ from app.features.simulation.schemas import (
     SimulationOut,
     SimulationSummaryCapabilitiesOut,
     SimulationSummaryOut,
+    SimulationUpdate,
 )
 from app.features.user.schemas import UserPreview
 
@@ -101,6 +103,37 @@ class TestSimulationCreateSchema:
                         )
             else:
                 assert getattr(simulation_create, snake_case_key) == value
+
+
+class TestSimulationUpdateSchema:
+    def test_accepts_allowed_optional_fields(self):
+        payload = {
+            "description": "Updated description",
+            "campaign": "campaign-1",
+            "experimentType": "historical",
+            "compiler": "intel",
+            "hpcUsername": "sim-user",
+            "keyFeatures": "feature a\nfeature b",
+            "knownIssues": "issue a",
+            "notesMarkdown": "## Notes",
+            "gitRepositoryUrl": HttpUrl("https://example.com/repo"),
+            "gitBranch": "main",
+            "gitTag": "v2.0",
+            "gitCommitHash": "abc123def456",
+        }
+
+        update = SimulationUpdate(**payload)
+
+        for key, value in payload.items():
+            assert getattr(update, to_snake_case(key)) == value
+
+    def test_rejects_invalid_url(self):
+        with pytest.raises(ValidationError):
+            SimulationUpdate(gitRepositoryUrl="not-a-url")
+
+    def test_rejects_out_of_scope_field(self):
+        with pytest.raises(ValidationError):
+            SimulationUpdate(caseName="new-case")
 
 
 class TestSimulationOutSchema:

--- a/frontend/src/features/simulations/SimulationDetailsPage.tsx
+++ b/frontend/src/features/simulations/SimulationDetailsPage.tsx
@@ -1,17 +1,63 @@
+import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 
 import { useAuth } from '@/auth/hooks/useAuth';
-import { resolvePaceExecution } from '@/features/simulations/api/api';
+import { resolvePaceExecution, updateSimulation } from '@/features/simulations/api/api';
 import { SimulationDetailsView } from '@/features/simulations/components/SimulationDetailsView';
 import { useSimulation } from '@/features/simulations/hooks/useSimulation';
 import { useSimulationSummary } from '@/features/simulations/hooks/useSimulationSummary';
+import { toast } from '@/hooks/use-toast';
+import type { SimulationOut, SimulationUpdate } from '@/types';
 
-export const SimulationDetailsPage = () => {
+const MAX_COMPARE_SELECTION = 5;
+
+interface SimulationDetailsPageProps {
+  selectedSimulationIds: string[];
+  setSelectedSimulationIds: (ids: string[]) => void;
+}
+
+const getUpdateErrorMessage = (error: unknown): string => {
+  if (axios.isAxiosError(error)) {
+    const detail = error.response?.data?.detail;
+
+    if (typeof detail === 'string') {
+      return detail;
+    }
+
+    if (Array.isArray(detail)) {
+      const messages = detail
+        .map((item) => {
+          const field = Array.isArray(item?.loc) ? item.loc[item.loc.length - 1] : null;
+          const message = typeof item?.msg === 'string' ? item.msg : null;
+
+          if (!message) return null;
+          if (typeof field !== 'string') return message;
+
+          return `${field}: ${message}`;
+        })
+        .filter((message): message is string => Boolean(message));
+
+      if (messages.length > 0) {
+        return messages.join(' ');
+      }
+    }
+  }
+
+  return error instanceof Error ? error.message : 'Failed to update simulation.';
+};
+
+export const SimulationDetailsPage = ({
+  selectedSimulationIds,
+  setSelectedSimulationIds,
+}: SimulationDetailsPageProps) => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
-  const { data: simulation, loading, error } = useSimulation(id ?? '');
+  const { data: fetchedSimulation, loading, error } = useSimulation(id ?? '');
   const { isAuthenticated, loading: authLoading, loginWithGithub } = useAuth();
+  const [simulation, setSimulation] = useState<SimulationOut | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [paceExperimentId, setPaceExperimentId] = useState<string | null>(null);
   const [isResolvingPace, setIsResolvingPace] = useState(false);
   const [paceResolutionAttempted, setPaceResolutionAttempted] = useState(false);
@@ -26,6 +72,7 @@ export const SimulationDetailsPage = () => {
       : normalizedBackHref.startsWith('/simulations')
         ? 'Back to Simulations'
         : 'Back to Runs';
+  const canEdit = !authLoading && isAuthenticated;
   const currentSimulation = simulation?.id === id ? simulation : null;
   const executionId = currentSimulation?.executionId?.trim() ?? '';
   const llmSummaryAvailable = currentSimulation?.summaryCapabilities?.llmAvailable ?? false;
@@ -35,6 +82,18 @@ export const SimulationDetailsPage = () => {
   const summary = useSimulationSummary(id ?? '', {
     autoGenerate: shouldAutoGenerateSummary,
   });
+
+  useEffect(() => {
+    if (fetchedSimulation?.id === id) {
+      setSimulation(fetchedSimulation);
+      setSaveError(null);
+      return;
+    }
+
+    if (!loading && !error) {
+      setSimulation(null);
+    }
+  }, [error, fetchedSimulation, id, loading]);
 
   useEffect(() => {
     if (!executionId) {
@@ -71,6 +130,50 @@ export const SimulationDetailsPage = () => {
       cancelled = true;
     };
   }, [executionId]);
+
+  const handleSave = async (payload: SimulationUpdate): Promise<boolean> => {
+    if (!id) return false;
+
+    setIsSaving(true);
+    setSaveError(null);
+
+    try {
+      const updatedSimulation = await updateSimulation(id, payload);
+      setSimulation(updatedSimulation);
+      return true;
+    } catch (saveErr) {
+      setSaveError(getUpdateErrorMessage(saveErr));
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleToggleCompare = () => {
+    if (!currentSimulation) return;
+
+    if (selectedSimulationIds.includes(currentSimulation.id)) {
+      setSelectedSimulationIds(
+        selectedSimulationIds.filter((simulationId) => simulationId !== currentSimulation.id),
+      );
+      return;
+    }
+
+    if (selectedSimulationIds.length >= MAX_COMPARE_SELECTION) {
+      toast({
+        title: 'Compare list full',
+        description: `You can compare up to ${MAX_COMPARE_SELECTION} runs at a time.`,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setSelectedSimulationIds([...selectedSimulationIds, currentSimulation.id]);
+    toast({
+      title: 'Added to compare',
+      description: `${currentSimulation.executionId} is now in your compare list.`,
+    });
+  };
 
   if (!id) {
     return (
@@ -119,6 +222,9 @@ export const SimulationDetailsPage = () => {
   return (
     <SimulationDetailsView
       simulation={currentSimulation}
+      isCompareSelected={selectedSimulationIds.includes(currentSimulation.id)}
+      compareSelectionCount={selectedSimulationIds.length}
+      maxCompareSelection={MAX_COMPARE_SELECTION}
       backHref={backHref}
       backLabel={backLabel}
       paceLink={paceLink}
@@ -132,6 +238,12 @@ export const SimulationDetailsPage = () => {
       summaryLastDurationMs={summary.lastDurationMs}
       onGenerateSummary={summary.generate}
       canGenerateSummary
+      onToggleCompare={handleToggleCompare}
+      canEdit={canEdit}
+      isSaving={isSaving}
+      saveError={saveError}
+      onSave={handleSave}
+      onClearSaveError={() => setSaveError(null)}
       llmSummaryAvailable={llmSummaryAvailable}
       autoGenerateDeterministicOnLoad={shouldAutoGenerateSummary}
       showLoginForAiSummary={showLoginForAiSummary}

--- a/frontend/src/features/simulations/api/api.ts
+++ b/frontend/src/features/simulations/api/api.ts
@@ -4,6 +4,7 @@ import type {
   SimulationCreate,
   SimulationOut,
   SimulationSummaryResponseOut,
+  SimulationUpdate,
 } from '@/types';
 
 export const SIMULATIONS_URL = '/simulations';
@@ -34,6 +35,15 @@ export const getSimulationById = async (id: string): Promise<SimulationOut> => {
   const res = await api.get<SimulationOut>(`${SIMULATIONS_URL}/${id}`, {
     headers: { 'Cache-Control': 'no-cache' },
   });
+
+  return res.data;
+};
+
+export const updateSimulation = async (
+  id: string,
+  data: SimulationUpdate,
+): Promise<SimulationOut> => {
+  const res = await api.patch<SimulationOut>(`${SIMULATIONS_URL}/${id}`, data);
 
   return res.data;
 };

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, ChevronDown, CircleHelp } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { SimulationStatusBadge } from '@/components/shared/SimulationStatusBadge';
@@ -21,20 +21,28 @@ import {
 } from '@/features/simulations/components/SimulationSummaryPanel';
 import { SimulationTypeBadge } from '@/features/simulations/components/SimulationTypeBadge';
 import { cn } from '@/lib/utils';
-import type { SimulationOut, SimulationSummaryResponseOut } from '@/types';
+import type { SimulationOut, SimulationSummaryResponseOut, SimulationUpdate } from '@/types';
 import { getArtifactsByKind } from '@/types/artifact';
 import { formatDate, getSimulationDuration } from '@/utils/utils';
 
 // -------------------- Types --------------------
 interface SimulationDetailsViewProps {
   simulation: SimulationOut;
+  isCompareSelected?: boolean;
+  compareSelectionCount?: number;
+  maxCompareSelection?: number;
   canEdit?: boolean;
+  isSaving?: boolean;
+  saveError?: string | null;
   backHref?: string;
   backLabel?: string;
   paceLink?: {
     href: string;
     label: string;
   } | null;
+  onToggleCompare?: () => void;
+  onSave?: (payload: SimulationUpdate) => Promise<boolean> | boolean;
+  onClearSaveError?: () => void;
   isResolvingPace?: boolean;
   showPaceFallbackInfo?: boolean;
   summary?: SimulationSummaryResponseOut | null;
@@ -56,12 +64,26 @@ interface SimulationDetailsViewProps {
 const FieldRow = ({ label, children }: { label: string; children: React.ReactNode }) => (
   <div className="grid grid-cols-12 items-center gap-2">
     <Label className="col-span-3 md:col-span-2 text-xs text-muted-foreground">{label}</Label>
-    <div className="col-span-9 md:col-span-10">{children}</div>
+    <div className="col-span-9 min-w-0 md:col-span-10">{children}</div>
   </div>
 );
 
 const ReadonlyInput = ({ value, className }: { value?: string | null; className?: string }) => (
-  <Input value={value || '—'} readOnly className={cn('h-8 text-sm', className)} />
+  <div
+    className={cn(
+      'flex min-h-8 min-w-0 items-center truncate rounded-md border border-border/60 bg-muted/35 px-3 py-1.5 text-sm text-foreground/90',
+      className,
+    )}
+    title={value ?? undefined}
+  >
+    {value || '—'}
+  </div>
+);
+
+const ReadonlyText = ({ value, className }: { value?: string | null; className?: string }) => (
+  <p className={cn('min-w-0 truncate text-sm text-foreground/90', className)} title={value ?? undefined}>
+    {value || '—'}
+  </p>
 );
 
 const UserDisplay = ({
@@ -87,13 +109,93 @@ const ReadonlyTextBlock = ({ value, className }: { value?: string | null; classN
   </div>
 );
 
+const EDITABLE_FIELDS = [
+  'description',
+  'campaign',
+  'experimentType',
+  'compiler',
+  'hpcUsername',
+  'keyFeatures',
+  'knownIssues',
+  'notesMarkdown',
+  'gitRepositoryUrl',
+  'gitBranch',
+  'gitTag',
+  'gitCommitHash',
+] as const;
+
+type EditableField = (typeof EDITABLE_FIELDS)[number];
+type EditableFormState = Record<EditableField, string>;
+
+const SINGLE_LINE_FIELDS: ReadonlySet<EditableField> = new Set([
+  'campaign',
+  'experimentType',
+  'compiler',
+  'hpcUsername',
+  'gitRepositoryUrl',
+  'gitBranch',
+  'gitTag',
+  'gitCommitHash',
+]);
+
+const toEditableFormState = (simulation: SimulationOut): EditableFormState => ({
+  description: simulation.description ?? '',
+  campaign: simulation.campaign ?? '',
+  experimentType: simulation.experimentType ?? '',
+  compiler: simulation.compiler ?? '',
+  hpcUsername: simulation.hpcUsername ?? '',
+  keyFeatures: simulation.keyFeatures ?? '',
+  knownIssues: simulation.knownIssues ?? '',
+  notesMarkdown: simulation.notesMarkdown ?? '',
+  gitRepositoryUrl: simulation.gitRepositoryUrl ?? '',
+  gitBranch: simulation.gitBranch ?? '',
+  gitTag: simulation.gitTag ?? '',
+  gitCommitHash: simulation.gitCommitHash ?? '',
+});
+
+const normalizeEditableValue = (field: EditableField, value: string): string | null => {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  return SINGLE_LINE_FIELDS.has(field) ? trimmed : value;
+};
+
+const buildUpdatePayload = (
+  simulation: SimulationOut,
+  formState: EditableFormState,
+): SimulationUpdate => {
+  const payload: SimulationUpdate = {};
+
+  for (const field of EDITABLE_FIELDS) {
+    const nextValue = normalizeEditableValue(field, formState[field]);
+    const currentValue = simulation[field] ?? null;
+
+    if (nextValue !== currentValue) {
+      payload[field] = nextValue;
+    }
+  }
+
+  return payload;
+};
+
 // -------------------- View Component --------------------
 export const SimulationDetailsView = ({
   simulation,
+  isCompareSelected = false,
+  compareSelectionCount: compareSelectionCountProp = 0,
+  maxCompareSelection: maxCompareSelectionProp = 5,
   canEdit = false,
+  isSaving = false,
+  saveError = null,
   backHref = '/browse',
   backLabel = 'Back to Runs',
   paceLink = null,
+  onToggleCompare,
+  onSave,
+  onClearSaveError,
   isResolvingPace = false,
   showPaceFallbackInfo = false,
   summary = null,
@@ -111,8 +213,11 @@ export const SimulationDetailsView = ({
   onLoginForSummary,
 }: SimulationDetailsViewProps) => {
   const [activeTab, setActiveTab] = useState('summary');
+  const [isEditing, setIsEditing] = useState(false);
   const [isAdvancedMetadataOpen, setIsAdvancedMetadataOpen] = useState(false);
-  const [notes, setNotes] = useState(simulation.notesMarkdown || '');
+  const [formState, setFormState] = useState<EditableFormState>(() =>
+    toEditableFormState(simulation),
+  );
   const performanceLinks = simulation.groupedLinks.performance ?? [];
   const outputArtifacts = getArtifactsByKind(
     simulation.artifacts,
@@ -158,7 +263,63 @@ export const SimulationDetailsView = ({
       date: '2024-02-15T13:45:00Z',
       text: 'The sea-ice diagnostics will be added later.',
     },
-  ]);
+    ]);
+
+  useEffect(() => {
+    setFormState(toEditableFormState(simulation));
+    setIsEditing(false);
+  }, [simulation]);
+
+  useEffect(() => {
+    if (!canEdit) {
+      setFormState(toEditableFormState(simulation));
+      setIsEditing(false);
+    }
+  }, [canEdit, simulation]);
+
+  const updateField = (field: EditableField, value: string) => {
+    onClearSaveError?.();
+    setFormState((current) => ({
+      ...current,
+      [field]: value,
+    }));
+  };
+
+  const handleCancelEdit = () => {
+    onClearSaveError?.();
+    setFormState(toEditableFormState(simulation));
+    setIsEditing(false);
+  };
+
+  const handleSave = async () => {
+    if (!onSave) return;
+
+    const payload = buildUpdatePayload(simulation, formState);
+
+    if (Object.keys(payload).length === 0) {
+      onClearSaveError?.();
+      setIsEditing(false);
+      return;
+    }
+
+    const saved = await onSave(payload);
+
+    if (saved) {
+      setIsEditing(false);
+    }
+  };
+
+  const hasUnsavedChanges = Object.keys(buildUpdatePayload(simulation, formState)).length > 0;
+  const compareSelectionCount = compareSelectionCountProp ?? 0;
+  const maxCompareSelection = maxCompareSelectionProp ?? 5;
+  const isCompareActionDisabled =
+    !isCompareSelected && compareSelectionCount >= maxCompareSelection;
+  const compareActionLabel = isCompareSelected
+    ? 'Remove from Comparison'
+    : 'Add to Comparison';
+  const compareActionTooltip = isCompareActionDisabled
+    ? `Compare list is full. Remove one of the ${maxCompareSelection} selected runs first.`
+    : undefined;
 
   const addComment = () => {
     if (!newComment.trim()) return;
@@ -203,12 +364,52 @@ export const SimulationDetailsView = ({
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" asChild>
-            <Link to="/compare">Add to Compare</Link>
-          </Button>
-          <Button disabled={!canEdit}>Save</Button>
+          {compareActionTooltip ? (
+            <TooltipProvider delayDuration={150}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span tabIndex={0}>
+                    <Button variant="outline" onClick={onToggleCompare} disabled={isCompareActionDisabled}>
+                      {compareActionLabel}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>{compareActionTooltip}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            <Button variant="outline" onClick={onToggleCompare}>
+              {compareActionLabel}
+            </Button>
+          )}
+          {!isEditing &&
+            (canEdit ? (
+              <Button onClick={() => setIsEditing(true)}>Edit</Button>
+            ) : (
+              <TooltipProvider delayDuration={150}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span tabIndex={0}>
+                      <Button disabled>Edit</Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Login required</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ))}
+          {canEdit && isEditing && (
+            <>
+              <Button variant="outline" onClick={handleCancelEdit} disabled={isSaving}>
+                Cancel
+              </Button>
+              <Button onClick={handleSave} disabled={isSaving || !hasUnsavedChanges}>
+                {isSaving ? 'Saving…' : 'Save Changes'}
+              </Button>
+            </>
+          )}
         </div>
       </div>
+      {isEditing && saveError && <div className="text-sm text-red-600">{saveError}</div>}
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
@@ -275,14 +476,30 @@ export const SimulationDetailsView = ({
                       <ReadonlyInput value={simulation.initializationType ?? undefined} />
                     </FieldRow>
                     <FieldRow label="Compiler">
-                      <ReadonlyInput value={simulation.compiler ?? undefined} />
+                      {isEditing ? (
+                        <Input
+                          value={formState.compiler}
+                          onChange={(event) => updateField('compiler', event.target.value)}
+                          className="h-8 text-sm"
+                        />
+                      ) : (
+                        <ReadonlyInput value={simulation.compiler ?? undefined} />
+                      )}
                     </FieldRow>
-                    {simulation.description && (
+                    {(isEditing || simulation.description) && (
                       <div className="pt-2">
                         <Label className="mb-1 block text-xs text-muted-foreground">
                           Description
                         </Label>
-                        <ReadonlyTextBlock value={simulation.description} />
+                        {isEditing ? (
+                          <Textarea
+                            value={formState.description}
+                            onChange={(event) => updateField('description', event.target.value)}
+                            className="min-h-[120px]"
+                          />
+                        ) : (
+                          <ReadonlyTextBlock value={simulation.description} />
+                        )}
                       </div>
                     )}
                   </CardContent>
@@ -299,10 +516,26 @@ export const SimulationDetailsView = ({
                       <ReadonlyInput value={simulation.status} />
                     </FieldRow>
                     <FieldRow label="Campaign ID">
-                      <ReadonlyInput value={simulation.campaign} />
+                      {isEditing ? (
+                        <Input
+                          value={formState.campaign}
+                          onChange={(event) => updateField('campaign', event.target.value)}
+                          className="h-8 text-sm"
+                        />
+                      ) : (
+                        <ReadonlyInput value={simulation.campaign} />
+                      )}
                     </FieldRow>
                     <FieldRow label="Experiment Type ID">
-                      <ReadonlyInput value={simulation.experimentType} />
+                      {isEditing ? (
+                        <Input
+                          value={formState.experimentType}
+                          onChange={(event) => updateField('experimentType', event.target.value)}
+                          className="h-8 text-sm"
+                        />
+                      ) : (
+                        <ReadonlyInput value={simulation.experimentType} />
+                      )}
                     </FieldRow>
                     <FieldRow label="Machine">
                       <ReadonlyInput value={simulation.machine.name} />
@@ -401,13 +634,7 @@ export const SimulationDetailsView = ({
                       <Label className="min-w-[100px] text-xs text-muted-foreground">
                         Simulation UUID:
                       </Label>
-                      <ReadonlyInput
-                        value={
-                          simulation.id
-                            ? `${simulation.id.slice(0, 8)}…${simulation.id.slice(-6)}`
-                            : undefined
-                        }
-                      />
+                      <ReadonlyInput value={simulation.id} />
                       {simulation.id && (
                         <Button
                           variant="outline"
@@ -424,13 +651,7 @@ export const SimulationDetailsView = ({
                       <Label className="min-w-[100px] text-xs text-muted-foreground">
                         Case ID:
                       </Label>
-                      <ReadonlyInput
-                        value={
-                          simulation.caseId
-                            ? `${simulation.caseId.slice(0, 8)}…${simulation.caseId.slice(-6)}`
-                            : undefined
-                        }
-                      />
+                      <ReadonlyInput value={simulation.caseId} />
                       {simulation.caseId && (
                         <Button
                           variant="outline"
@@ -447,13 +668,7 @@ export const SimulationDetailsView = ({
                       <Label className="min-w-[100px] text-xs text-muted-foreground">
                         Machine ID:
                       </Label>
-                      <ReadonlyInput
-                        value={
-                          simulation.machineId
-                            ? `${simulation.machineId.slice(0, 8)}…${simulation.machineId.slice(-6)}`
-                            : undefined
-                        }
-                      />
+                      <ReadonlyInput value={simulation.machineId} />
                       {simulation.machineId && (
                         <Button
                           variant="outline"
@@ -471,67 +686,127 @@ export const SimulationDetailsView = ({
                       <Label className="min-w-[100px] text-xs text-muted-foreground">
                         Git Repository:
                       </Label>
-                      {simulation.gitRepositoryUrl ? (
-                        <a
-                          href={simulation.gitRepositoryUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-sm text-blue-600 hover:underline"
-                        >
-                          {simulation.gitRepositoryUrl}
-                        </a>
+                      {isEditing ? (
+                        <Input
+                          type="url"
+                          value={formState.gitRepositoryUrl}
+                          onChange={(event) => updateField('gitRepositoryUrl', event.target.value)}
+                          className="h-8 text-sm"
+                        />
                       ) : (
-                        <p className="text-sm">—</p>
+                        <>
+                          {simulation.gitRepositoryUrl ? (
+                            <a
+                              href={simulation.gitRepositoryUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="block min-w-0 truncate text-sm text-blue-600 hover:underline"
+                              title={simulation.gitRepositoryUrl}
+                            >
+                              {simulation.gitRepositoryUrl}
+                            </a>
+                          ) : (
+                            <p className="text-sm">—</p>
+                          )}
+                        </>
                       )}
                     </div>
                     <div className="flex items-center gap-2">
                       <Label className="min-w-[100px] text-xs text-muted-foreground">
                         Git Branch:
                       </Label>
-                      <p className="text-sm">{simulation.gitBranch ?? '—'}</p>
+                      {isEditing ? (
+                        <Input
+                          value={formState.gitBranch}
+                          onChange={(event) => updateField('gitBranch', event.target.value)}
+                          className="h-8 text-sm"
+                        />
+                      ) : (
+                        <ReadonlyText value={simulation.gitBranch} />
+                      )}
                     </div>
                     <div className="flex items-center gap-2">
                       <Label className="min-w-[100px] text-xs text-muted-foreground">
                         Git Tag:
                       </Label>
-                      <p className="text-sm">{simulation.gitTag ?? '—'}</p>
+                      {isEditing ? (
+                        <Input
+                          value={formState.gitTag}
+                          onChange={(event) => updateField('gitTag', event.target.value)}
+                          className="h-8 text-sm"
+                        />
+                      ) : (
+                        <ReadonlyText value={simulation.gitTag} />
+                      )}
                     </div>
                     <div className="flex items-center gap-2">
                       <Label className="min-w-[100px] text-xs text-muted-foreground">
                         Git Commit Hash:
                       </Label>
-                      <p className="text-sm">{simulation.gitCommitHash ?? '—'}</p>
+                      {isEditing ? (
+                        <Input
+                          value={formState.gitCommitHash}
+                          onChange={(event) => updateField('gitCommitHash', event.target.value)}
+                          className="h-8 text-sm"
+                        />
+                      ) : (
+                        <ReadonlyText value={simulation.gitCommitHash} />
+                      )}
                     </div>
                     <div className="flex items-center gap-2">
                       <Label className="min-w-[100px] text-xs text-muted-foreground">
                         HPC Username:
                       </Label>
-                      <p className="text-sm">{simulation.hpcUsername ?? '—'}</p>
+                      {isEditing ? (
+                        <Input
+                          value={formState.hpcUsername}
+                          onChange={(event) => updateField('hpcUsername', event.target.value)}
+                          className="h-8 text-sm"
+                        />
+                      ) : (
+                        <ReadonlyText value={simulation.hpcUsername} />
+                      )}
                     </div>
                   </CardContent>
                 </Card>
               </div>
 
-              {(simulation.keyFeatures || simulation.knownIssues) && (
+              {(isEditing || simulation.keyFeatures || simulation.knownIssues) && (
                 <Card>
                   <CardHeader className="pb-2">
                     <CardTitle className="text-base">Scientific Metadata</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    {simulation.keyFeatures && (
+                    {(isEditing || simulation.keyFeatures) && (
                       <div>
                         <Label className="mb-1 block text-xs text-muted-foreground">
                           Key Features
                         </Label>
-                        <ReadonlyTextBlock value={simulation.keyFeatures} />
+                        {isEditing ? (
+                          <Textarea
+                            value={formState.keyFeatures}
+                            onChange={(event) => updateField('keyFeatures', event.target.value)}
+                            className="min-h-[120px]"
+                          />
+                        ) : (
+                          <ReadonlyTextBlock value={simulation.keyFeatures} />
+                        )}
                       </div>
                     )}
-                    {simulation.knownIssues && (
+                    {(isEditing || simulation.knownIssues) && (
                       <div>
                         <Label className="mb-1 block text-xs text-muted-foreground">
                           Known Issues
                         </Label>
-                        <ReadonlyTextBlock value={simulation.knownIssues} />
+                        {isEditing ? (
+                          <Textarea
+                            value={formState.knownIssues}
+                            onChange={(event) => updateField('knownIssues', event.target.value)}
+                            className="min-h-[120px]"
+                          />
+                        ) : (
+                          <ReadonlyTextBlock value={simulation.knownIssues} />
+                        )}
                       </div>
                     )}
                   </CardContent>
@@ -762,22 +1037,37 @@ export const SimulationDetailsView = ({
                   <CardTitle className="text-base">Notes</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-3">
-                  <Textarea
-                    placeholder="Add notes..."
-                    value={notes}
-                    onChange={(e) => setNotes(e.target.value)}
-                    className="min-h-[120px]"
-                    readOnly={!canEdit}
-                  />
+                  {isEditing ? (
+                    <Textarea
+                      placeholder="Add notes..."
+                      value={formState.notesMarkdown}
+                      onChange={(event) => updateField('notesMarkdown', event.target.value)}
+                      className="min-h-[160px]"
+                    />
+                  ) : (
+                    <ReadonlyTextBlock value={simulation.notesMarkdown} className="min-h-[160px]" />
+                  )}
                   {!canEdit && (
                     <p className="text-xs text-muted-foreground">
-                      A user account with write privilege is required to update this simulation
-                      page.
+                      Log in to edit simulation metadata. This page stays read-only when signed out.
                     </p>
                   )}
-                  <div>
-                    <Button disabled={!canEdit}>Save</Button>
-                  </div>
+                  {canEdit && isEditing && (
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="text-xs text-muted-foreground">
+                        Save updates description, provenance, and notes fields only.
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button variant="outline" onClick={handleCancelEdit} disabled={isSaving}>
+                          Cancel
+                        </Button>
+                        <Button onClick={handleSave} disabled={isSaving || !hasUnsavedChanges}>
+                          {isSaving ? 'Saving…' : 'Save Changes'}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                  {isEditing && saveError && <p className="text-sm text-red-600">{saveError}</p>}
                 </CardContent>
               </Card>
 
@@ -812,16 +1102,19 @@ export const SimulationDetailsView = ({
                   <Separator />
                   <div className="flex items-start gap-2">
                     <Textarea
-                      placeholder="Add a comment ..."
+                      placeholder="Comments editing coming later ..."
                       className="min-h-[80px]"
                       value={newComment}
                       onChange={(e) => setNewComment(e.target.value)}
-                      readOnly={!canEdit}
+                      readOnly
                     />
-                    <Button onClick={addComment} className="shrink-0" disabled={!canEdit}>
+                    <Button onClick={addComment} className="shrink-0" disabled>
                       Post
                     </Button>
                   </div>
+                  <p className="text-xs text-muted-foreground">
+                    Comments are out of scope for this v1 metadata editor.
+                  </p>
                 </div>
               </div>
             </div>

--- a/frontend/src/features/simulations/routes.tsx
+++ b/frontend/src/features/simulations/routes.tsx
@@ -37,6 +37,11 @@ export const simulationsRoutes = ({
   },
   {
     path: '/simulations/:id',
-    element: <SimulationDetailsPage />,
+    element: (
+      <SimulationDetailsPage
+        selectedSimulationIds={selectedSimulationIds}
+        setSelectedSimulationIds={setSelectedSimulationIds}
+      />
+    ),
   },
 ];

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -129,6 +129,25 @@ export interface SimulationCreate {
   artifacts: ArtifactIn[];
   links: ExternalLinkIn[];
 }
+
+export type SimulationUpdate = Partial<
+  Pick<
+    SimulationCreate,
+    | 'description'
+    | 'campaign'
+    | 'experimentType'
+    | 'compiler'
+    | 'hpcUsername'
+    | 'keyFeatures'
+    | 'knownIssues'
+    | 'notesMarkdown'
+    | 'gitRepositoryUrl'
+    | 'gitBranch'
+    | 'gitTag'
+    | 'gitCommitHash'
+  >
+>;
+
 // Extends SimulationCreate with optional fields for file paths.
 export interface SimulationCreateForm extends SimulationCreate {
   outputPath?: string | null;


### PR DESCRIPTION
## Description
Truncate overflowing simulation detail fields, preserve the full values on hover, and wire the simulation details page to the edit/save flow.

- Added truncation and hover titles to long read-only fields.
- Kept full IDs and repository URLs available through hover text and copy actions.
- Updated the simulation edit flow and backend tests for the metadata update path.

- Closes #70

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [x] Tests added or updated (if needed)
- [x] All tests pass (locally and CI/CD)
- [ ] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)
<!--
  Add any special deployment or migration steps here.
-->
