### PR TITLE
[SimEdit]: Support editing simulation artifacts and links

### DIFF
--- a/backend/app/features/simulation/api.py
+++ b/backend/app/features/simulation/api.py
@@ -25,15 +25,6 @@ simulation_router = APIRouter(prefix="/simulations", tags=["Simulations"])
 case_router = APIRouter(prefix="/cases", tags=["Cases"])
 
 
-def _simulation_detail_query(db: Session):
-    return db.query(Simulation).options(
-        joinedload(Simulation.case),
-        joinedload(Simulation.machine),
-        selectinload(Simulation.artifacts),
-        selectinload(Simulation.links),
-    )
-
-
 @case_router.get(
     "",
     response_model=list[CaseOut],
@@ -139,60 +130,6 @@ def get_case(case_id: UUID, db: Session = Depends(get_database_session)) -> Case
     return resp
 
 
-def _case_to_out(case: Case) -> CaseOut:
-    """Convert a Case ORM instance to CaseOut with nested SimulationSummaryOut.
-
-    Parameters
-    ----------
-    case : Case
-        The Case ORM instance to convert.
-
-    Returns
-    -------
-    CaseOut
-        The corresponding CaseOut schema instance with nested
-        SimulationSummaryOut
-    """
-    summaries = []
-    machine_names = sorted(
-        {
-            sim.machine.name
-            for sim in case.simulations
-            if sim.machine is not None and sim.machine.name
-        },
-        key=lambda name: name.lower(),
-    )
-    hpc_usernames = sorted(
-        {sim.hpc_username for sim in case.simulations if sim.hpc_username},
-        key=lambda username: username.lower(),
-    )
-
-    for sim in case.simulations:
-        summaries.append(
-            SimulationSummaryOut(
-                id=sim.id,
-                execution_id=sim.execution_id,
-                case_hash=sim.case_hash,
-                status=sim.status,
-                simulation_start_date=sim.simulation_start_date,
-                simulation_end_date=sim.simulation_end_date,
-            )
-        )
-
-    result = CaseOut(
-        id=case.id,
-        name=case.name,
-        case_group=case.case_group,
-        simulations=summaries,
-        machine_names=machine_names,
-        hpc_usernames=hpc_usernames,
-        created_at=case.created_at,
-        updated_at=case.updated_at,
-    )
-
-    return result
-
-
 @simulation_router.post(
     "",
     response_model=SimulationOut,
@@ -249,16 +186,10 @@ def create_simulation(
     sim.ingestion = ingestion
 
     if payload.artifacts:
-        for artifact in payload.artifacts:
-            artifact_data = artifact.model_dump(by_alias=False, exclude_unset=True)
-            artifact_data["uri"] = str(artifact.uri)
-            sim.artifacts.append(Artifact(**artifact_data))
+        sim.artifacts.extend(_build_artifact_models(payload.artifacts))
 
     if payload.links:
-        for link in payload.links:
-            link_data = link.model_dump(by_alias=False, exclude_unset=True)
-            link_data["url"] = str(link.url)
-            sim.links.append(ExternalLink(**link_data))
+        sim.links.extend(_build_external_link_models(payload.links))
 
     with transaction(db):
         db.add(sim)
@@ -363,9 +294,17 @@ def update_simulation(
 
     now = datetime.now(timezone.utc)
     updates = payload.model_dump(by_alias=False, exclude_unset=True)
+    updates.pop("artifacts", None)
+    updates.pop("links", None)
 
     for field, value in updates.items():
         setattr(sim, field, value)
+
+    if "artifacts" in payload.model_fields_set:
+        sim.artifacts = _build_artifact_models(payload.artifacts or [])
+
+    if "links" in payload.model_fields_set:
+        sim.links = _build_external_link_models(payload.links or [])
 
     sim.last_updated_by = user.id
     sim.updated_at = now
@@ -425,6 +364,91 @@ def get_simulation(sim_id: UUID, db: Session = Depends(get_database_session)):
         raise HTTPException(status_code=404, detail="Simulation not found")
 
     return _simulation_to_out(sim)
+
+
+def _case_to_out(case: Case) -> CaseOut:
+    """Convert a Case ORM instance to CaseOut with nested SimulationSummaryOut.
+
+    Parameters
+    ----------
+    case : Case
+        The Case ORM instance to convert.
+
+    Returns
+    -------
+    CaseOut
+        The corresponding CaseOut schema instance with nested
+        SimulationSummaryOut
+    """
+    summaries = []
+    machine_names = sorted(
+        {
+            sim.machine.name
+            for sim in case.simulations
+            if sim.machine is not None and sim.machine.name
+        },
+        key=lambda name: name.lower(),
+    )
+    hpc_usernames = sorted(
+        {sim.hpc_username for sim in case.simulations if sim.hpc_username},
+        key=lambda username: username.lower(),
+    )
+
+    for sim in case.simulations:
+        summaries.append(
+            SimulationSummaryOut(
+                id=sim.id,
+                execution_id=sim.execution_id,
+                case_hash=sim.case_hash,
+                status=sim.status,
+                simulation_start_date=sim.simulation_start_date,
+                simulation_end_date=sim.simulation_end_date,
+            )
+        )
+
+    result = CaseOut(
+        id=case.id,
+        name=case.name,
+        case_group=case.case_group,
+        simulations=summaries,
+        machine_names=machine_names,
+        hpc_usernames=hpc_usernames,
+        created_at=case.created_at,
+        updated_at=case.updated_at,
+    )
+
+    return result
+
+
+def _build_artifact_models(artifacts: list) -> list[Artifact]:
+    models: list[Artifact] = []
+
+    for artifact in artifacts:
+        artifact_data = artifact.model_dump(by_alias=False, exclude_unset=True)
+        artifact_data["uri"] = str(artifact.uri)
+        models.append(Artifact(**artifact_data))
+
+    return models
+
+
+def _build_external_link_models(links: list) -> list[ExternalLink]:
+    models: list[ExternalLink] = []
+
+    for link in links:
+        link_data = link.model_dump(by_alias=False, exclude_unset=True)
+        link_data["url"] = str(link.url)
+        models.append(ExternalLink(**link_data))
+
+    return models
+
+
+def _simulation_detail_query(db: Session):
+    return db.query(Simulation).options(
+        joinedload(Simulation.case),
+        joinedload(Simulation.machine),
+        selectinload(Simulation.artifacts),
+        selectinload(Simulation.links),
+    )
 
 
 def _simulation_to_out(sim: Simulation) -> SimulationOut:

--- a/backend/app/features/simulation/schemas.py
+++ b/backend/app/features/simulation/schemas.py
@@ -19,6 +19,40 @@ from app.features.user.schemas import UserPreview
 KNOWN_EXPERIMENT_TYPES = {e.value for e in ExperimentType}
 
 
+def _normalize_optional_label(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    stripped = value.strip()
+    return stripped or None
+
+
+def _normalize_required_resource_value(value: str, *, field_name: str) -> str:
+    stripped = value.strip()
+
+    if not stripped:
+        msg = f"{field_name} must be a non-empty string."
+        raise ValueError(msg)
+
+    return stripped
+
+
+def _validate_unique_resources(items: list[Any], *, value_attr: str) -> list[Any]:
+    seen: set[tuple[str, str]] = set()
+
+    for item in items:
+        value = getattr(item, value_attr)
+        normalized_key = (item.kind.value, str(value))
+
+        if normalized_key in seen:
+            msg = f"Duplicate {item.kind.value} {value_attr} values are not allowed."
+            raise ValueError(msg)
+
+        seen.add(normalized_key)
+
+    return items
+
+
 class ExternalLinkCreate(CamelInBaseModel):
     """Schema for creating a new External Link."""
 
@@ -29,6 +63,11 @@ class ExternalLinkCreate(CamelInBaseModel):
     label: Annotated[
         str | None, Field(None, description="An optional label for the external link.")
     ]
+
+    @field_validator("label", mode="before")
+    @classmethod
+    def normalize_label(cls, value: str | None) -> str | None:
+        return _normalize_optional_label(value)
 
 
 class ExternalLinkOut(CamelOutBaseModel):
@@ -69,6 +108,16 @@ class ArtifactCreate(CamelInBaseModel):
     label: Annotated[
         str | None, Field(None, description="An optional label for the artifact.")
     ]
+
+    @field_validator("uri", mode="before")
+    @classmethod
+    def normalize_uri(cls, value: str) -> str:
+        return _normalize_required_resource_value(value, field_name="uri")
+
+    @field_validator("label", mode="before")
+    @classmethod
+    def normalize_label(cls, value: str | None) -> str | None:
+        return _normalize_optional_label(value)
 
 
 class ArtifactOut(CamelOutBaseModel):
@@ -273,6 +322,20 @@ class SimulationCreate(CamelInBaseModel):
         ),
     ]
 
+    @field_validator("artifacts")
+    @classmethod
+    def validate_unique_artifacts(
+        cls, value: list[ArtifactCreate]
+    ) -> list[ArtifactCreate]:
+        return _validate_unique_resources(value, value_attr="uri")
+
+    @field_validator("links")
+    @classmethod
+    def validate_unique_links(
+        cls, value: list[ExternalLinkCreate]
+    ) -> list[ExternalLinkCreate]:
+        return _validate_unique_resources(value, value_attr="url")
+
 
 class SimulationUpdate(CamelInBaseModel):
     """Schema for narrow v1 simulation metadata updates."""
@@ -282,6 +345,14 @@ class SimulationUpdate(CamelInBaseModel):
     @field_validator("simulation_type", "status", mode="before")
     @classmethod
     def reject_null_enum_updates(cls, value: Any) -> Any:
+        if value is None:
+            msg = "Field may be omitted for PATCH requests, but cannot be null."
+            raise ValueError(msg)
+        return value
+
+    @field_validator("artifacts", "links", mode="before")
+    @classmethod
+    def reject_null_resource_updates(cls, value: Any) -> Any:
         if value is None:
             msg = "Field may be omitted for PATCH requests, but cannot be null."
             raise ValueError(msg)
@@ -330,6 +401,38 @@ class SimulationUpdate(CamelInBaseModel):
         str | None,
         Field(None, description="Optional additional notes in markdown format"),
     ]
+    artifacts: Annotated[
+        list[ArtifactCreate] | None,
+        Field(
+            None,
+            description="Full replacement list of artifacts associated with the simulation",
+        ),
+    ]
+    links: Annotated[
+        list[ExternalLinkCreate] | None,
+        Field(
+            None,
+            description="Full replacement list of external links associated with the simulation",
+        ),
+    ]
+
+    @field_validator("artifacts")
+    @classmethod
+    def validate_update_artifacts(
+        cls, value: list[ArtifactCreate] | None
+    ) -> list[ArtifactCreate] | None:
+        if value is None:
+            return value
+        return _validate_unique_resources(value, value_attr="uri")
+
+    @field_validator("links")
+    @classmethod
+    def validate_update_links(
+        cls, value: list[ExternalLinkCreate] | None
+    ) -> list[ExternalLinkCreate] | None:
+        if value is None:
+            return value
+        return _validate_unique_resources(value, value_attr="url")
 
 
 class SimulationSummaryOut(CamelOutBaseModel):

--- a/backend/app/features/simulation/schemas.py
+++ b/backend/app/features/simulation/schemas.py
@@ -27,7 +27,11 @@ def _normalize_optional_label(value: str | None) -> str | None:
     return stripped or None
 
 
-def _normalize_required_resource_value(value: str, *, field_name: str) -> str:
+def _normalize_required_resource_value(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        msg = f"{field_name} must be a non-empty string."
+        raise ValueError(msg)
+
     stripped = value.strip()
 
     if not stripped:
@@ -111,7 +115,7 @@ class ArtifactCreate(CamelInBaseModel):
 
     @field_validator("uri", mode="before")
     @classmethod
-    def normalize_uri(cls, value: str) -> str:
+    def normalize_uri(cls, value: Any) -> str:
         return _normalize_required_resource_value(value, field_name="uri")
 
     @field_validator("label", mode="before")

--- a/backend/tests/features/simulation/test_api.py
+++ b/backend/tests/features/simulation/test_api.py
@@ -14,7 +14,7 @@ from app.features.ingestion.models import Ingestion
 from app.features.machine.models import Machine
 from app.features.simulation.api import create_simulation, update_simulation
 from app.features.simulation.enums import SimulationStatus, SimulationType
-from app.features.simulation.models import Case, Simulation
+from app.features.simulation.models import Artifact, Case, ExternalLink, Simulation
 from app.features.simulation.schemas import SimulationCreate, SimulationUpdate
 from app.features.user.manager import current_active_user
 from app.features.user.models import User, UserRole
@@ -929,6 +929,167 @@ class TestUpdateSimulation:
         assert updated_sim.last_updated_by == normal_user_sync["id"]
         assert updated_sim.updated_at > original_updated_at
 
+    def test_endpoint_replaces_artifacts_and_links(
+        self, client, db: Session, normal_user_sync
+    ):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        case = _create_case(db, "test_case_patch_resources")
+        ingestion = _create_ingestion(
+            db,
+            machine.id,
+            normal_user_sync["id"],
+            source_reference="test_simulation_patch_resources",
+        )
+        sim = _create_simulation_record(
+            db,
+            case=case,
+            machine_id=machine.id,
+            ingestion_id=ingestion.id,
+            created_by=normal_user_sync["id"],
+            last_updated_by=normal_user_sync["id"],
+            execution_id="patch-test-resources",
+        )
+        sim.artifacts.extend(
+            [
+                Artifact(kind="output", uri="/tmp/output-old", label="Old output"),
+                Artifact(kind="archive", uri="/tmp/archive-old", label="Old archive"),
+            ]
+        )
+        sim.links.extend(
+            [
+                ExternalLink(
+                    kind="diagnostic",
+                    url="https://example.com/diagnostic-old",
+                    label="Old diagnostic",
+                ),
+                ExternalLink(
+                    kind="performance",
+                    url="https://example.com/performance-old",
+                    label="Old performance",
+                ),
+            ]
+        )
+        db.commit()
+
+        payload = {
+            "artifacts": [
+                {
+                    "kind": "output",
+                    "uri": "  /tmp/output-new  ",
+                    "label": "  New output  ",
+                },
+                {
+                    "kind": "run_script",
+                    "uri": "s3://bucket/run.sh",
+                    "label": "Run script",
+                },
+            ],
+            "links": [
+                {
+                    "kind": "diagnostic",
+                    "url": "https://example.com/diagnostic-new",
+                    "label": "Updated diagnostics",
+                },
+                {
+                    "kind": "docs",
+                    "url": "https://example.com/docs/new",
+                    "label": "Docs",
+                },
+            ],
+        }
+
+        res = client.patch(f"{API_BASE}/simulations/{sim.id}", json=payload)
+
+        assert res.status_code == 200
+        data = res.json()
+        assert {artifact["uri"] for artifact in data["artifacts"]} == {
+            "/tmp/output-new",
+            "s3://bucket/run.sh",
+        }
+        assert {artifact["kind"] for artifact in data["artifacts"]} == {
+            "output",
+            "run_script",
+        }
+        assert data["groupedArtifacts"]["output"][0]["label"] == "New output"
+        assert (
+            data["groupedLinks"]["diagnostic"][0]["url"]
+            == "https://example.com/diagnostic-new"
+        )
+        assert data["groupedLinks"]["docs"][0]["label"] == "Docs"
+
+        db.expire_all()
+        updated_sim = db.query(Simulation).filter(Simulation.id == sim.id).one()
+        assert {
+            (artifact.kind.value, artifact.uri) for artifact in updated_sim.artifacts
+        } == {
+            ("output", "/tmp/output-new"),
+            ("run_script", "s3://bucket/run.sh"),
+        }
+        assert {(link.kind.value, link.url) for link in updated_sim.links} == {
+            ("diagnostic", "https://example.com/diagnostic-new"),
+            ("docs", "https://example.com/docs/new"),
+        }
+        assert db.query(Artifact).filter(Artifact.simulation_id == sim.id).count() == 2
+        assert (
+            db.query(ExternalLink).filter(ExternalLink.simulation_id == sim.id).count()
+            == 2
+        )
+
+    def test_endpoint_can_clear_artifacts_and_links(
+        self, client, db: Session, normal_user_sync
+    ):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        case = _create_case(db, "test_case_patch_clear_resources")
+        ingestion = _create_ingestion(
+            db,
+            machine.id,
+            normal_user_sync["id"],
+            source_reference="test_simulation_patch_clear_resources",
+        )
+        sim = _create_simulation_record(
+            db,
+            case=case,
+            machine_id=machine.id,
+            ingestion_id=ingestion.id,
+            created_by=normal_user_sync["id"],
+            last_updated_by=normal_user_sync["id"],
+            execution_id="patch-test-clear-resources",
+        )
+        sim.artifacts.append(
+            Artifact(kind="output", uri="/tmp/output-old", label="Old output")
+        )
+        sim.links.append(
+            ExternalLink(
+                kind="diagnostic",
+                url="https://example.com/diagnostic-old",
+                label="Old diagnostic",
+            )
+        )
+        db.commit()
+
+        res = client.patch(
+            f"{API_BASE}/simulations/{sim.id}",
+            json={"artifacts": [], "links": []},
+        )
+
+        assert res.status_code == 200
+        data = res.json()
+        assert data["artifacts"] == []
+        assert data["links"] == []
+        assert data["groupedArtifacts"] == {}
+        assert data["groupedLinks"] == {}
+
+        db.expire_all()
+        assert db.query(Artifact).filter(Artifact.simulation_id == sim.id).count() == 0
+        assert (
+            db.query(ExternalLink).filter(ExternalLink.simulation_id == sim.id).count()
+            == 0
+        )
+
     def test_endpoint_returns_401_without_authentication(
         self, client, db: Session, normal_user_sync
     ):
@@ -1051,6 +1212,55 @@ class TestUpdateSimulation:
         assert unchanged_sim.status == SimulationStatus.CREATED
         assert unchanged_sim.simulation_type == SimulationType.EXPERIMENTAL
         assert unchanged_sim.updated_at == original_updated_at
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"links": [{"kind": "diagnostic", "url": "not-a-url", "label": "Bad"}]},
+            {"artifacts": [{"kind": "output", "uri": "   ", "label": "Bad"}]},
+            {
+                "links": [
+                    {
+                        "kind": "docs",
+                        "url": "https://example.com/docs",
+                        "label": "One",
+                    },
+                    {
+                        "kind": "docs",
+                        "url": "https://example.com/docs",
+                        "label": "Two",
+                    },
+                ]
+            },
+        ],
+    )
+    def test_endpoint_rejects_invalid_resource_payloads(
+        self, client, db: Session, normal_user_sync, payload
+    ):
+        machine = db.query(Machine).first()
+        assert machine is not None
+
+        case = _create_case(db, "test_case_patch_invalid_resources")
+        ingestion = _create_ingestion(
+            db,
+            machine.id,
+            normal_user_sync["id"],
+            source_reference="test_simulation_patch_invalid_resources",
+        )
+        sim = _create_simulation_record(
+            db,
+            case=case,
+            machine_id=machine.id,
+            ingestion_id=ingestion.id,
+            created_by=normal_user_sync["id"],
+            last_updated_by=normal_user_sync["id"],
+            execution_id="patch-test-invalid-resources",
+        )
+        db.commit()
+
+        res = client.patch(f"{API_BASE}/simulations/{sim.id}", json=payload)
+
+        assert res.status_code == 422
 
     def test_update_simulation_raises_500_when_reload_fails(self) -> None:
         sim_id = uuid4()

--- a/backend/tests/features/simulation/test_api.py
+++ b/backend/tests/features/simulation/test_api.py
@@ -1218,6 +1218,8 @@ class TestUpdateSimulation:
         [
             {"links": [{"kind": "diagnostic", "url": "not-a-url", "label": "Bad"}]},
             {"artifacts": [{"kind": "output", "uri": "   ", "label": "Bad"}]},
+            {"artifacts": [{"kind": "output", "uri": None, "label": "Bad"}]},
+            {"artifacts": [{"kind": "output", "uri": 123, "label": "Bad"}]},
             {
                 "links": [
                     {

--- a/backend/tests/features/simulation/test_schemas.py
+++ b/backend/tests/features/simulation/test_schemas.py
@@ -17,6 +17,7 @@ from app.features.simulation.schemas import (
     SimulationSummaryCapabilitiesOut,
     SimulationSummaryOut,
     SimulationUpdate,
+    _normalize_optional_label,
 )
 from app.features.user.schemas import UserPreview
 
@@ -106,6 +107,9 @@ class TestSimulationCreateSchema:
 
 
 class TestSimulationUpdateSchema:
+    def test_normalize_optional_label_accepts_none(self):
+        assert _normalize_optional_label(None) is None
+
     def test_accepts_allowed_optional_fields(self):
         payload = {
             "simulationType": "production",
@@ -147,9 +151,80 @@ class TestSimulationUpdateSchema:
         with pytest.raises(ValidationError):
             SimulationUpdate(**{field_name: None})
 
+    @pytest.mark.parametrize("field_name", ["artifacts", "links"])
+    def test_rejects_explicit_null_for_resource_fields(self, field_name: str):
+        with pytest.raises(ValueError):
+            SimulationUpdate.reject_null_resource_updates(None)
+
     def test_rejects_out_of_scope_field(self):
         with pytest.raises(ValidationError):
             SimulationUpdate(caseName="new-case")
+
+    def test_accepts_resource_replacement_payloads(self):
+        update = SimulationUpdate(
+            artifacts=[
+                {
+                    "kind": "archive",
+                    "uri": "  /global/cfs/project/archive/run-1  ",
+                    "label": "  Main archive  ",
+                }
+            ],
+            links=[
+                {
+                    "kind": "docs",
+                    "url": "https://example.com/docs/run-1",
+                    "label": "  Run docs  ",
+                }
+            ],
+        )
+
+        assert update.artifacts is not None
+        assert update.links is not None
+        assert update.artifacts[0].uri == "/global/cfs/project/archive/run-1"
+        assert update.artifacts[0].label == "Main archive"
+        assert str(update.links[0].url) == "https://example.com/docs/run-1"
+        assert update.links[0].label == "Run docs"
+
+    def test_rejects_blank_artifact_uri(self):
+        with pytest.raises(ValidationError):
+            SimulationUpdate(
+                artifacts=[{"kind": "output", "uri": "   ", "label": "Blank"}]
+            )
+
+    def test_rejects_invalid_external_link_url(self):
+        with pytest.raises(ValidationError):
+            SimulationUpdate(
+                links=[{"kind": "diagnostic", "url": "not-a-url", "label": "Bad"}]
+            )
+
+    def test_rejects_duplicate_resource_pairs(self):
+        with pytest.raises(ValidationError):
+            SimulationUpdate(
+                artifacts=[
+                    {"kind": "archive", "uri": "/tmp/archive", "label": "One"},
+                    {"kind": "archive", "uri": "/tmp/archive", "label": "Two"},
+                ]
+            )
+
+        with pytest.raises(ValidationError):
+            SimulationUpdate(
+                links=[
+                    {
+                        "kind": "docs",
+                        "url": "https://example.com/docs",
+                        "label": "One",
+                    },
+                    {
+                        "kind": "docs",
+                        "url": "https://example.com/docs",
+                        "label": "Two",
+                    },
+                ]
+            )
+
+    def test_update_resource_validators_accept_none_when_called_directly(self):
+        assert SimulationUpdate.validate_update_artifacts(None) is None
+        assert SimulationUpdate.validate_update_links(None) is None
 
 
 class TestSimulationOutSchema:

--- a/backend/tests/features/simulation/test_schemas.py
+++ b/backend/tests/features/simulation/test_schemas.py
@@ -7,6 +7,7 @@ from pydantic import HttpUrl, ValidationError
 from app.common.schemas.utils import to_snake_case
 from app.features.machine.schemas import MachineOut
 from app.features.simulation.schemas import (
+    ArtifactCreate,
     ArtifactKind,
     ArtifactOut,
     CaseOut,
@@ -153,8 +154,8 @@ class TestSimulationUpdateSchema:
 
     @pytest.mark.parametrize("field_name", ["artifacts", "links"])
     def test_rejects_explicit_null_for_resource_fields(self, field_name: str):
-        with pytest.raises(ValueError):
-            SimulationUpdate.reject_null_resource_updates(None)
+        with pytest.raises(ValidationError):
+            SimulationUpdate(**{field_name: None})
 
     def test_rejects_out_of_scope_field(self):
         with pytest.raises(ValidationError):
@@ -190,6 +191,16 @@ class TestSimulationUpdateSchema:
             SimulationUpdate(
                 artifacts=[{"kind": "output", "uri": "   ", "label": "Blank"}]
             )
+
+    @pytest.mark.parametrize("uri", [None, 123])
+    def test_artifact_create_rejects_non_string_uri(self, uri):
+        with pytest.raises(ValidationError):
+            ArtifactCreate(kind="output", uri=uri, label="Bad")
+
+    @pytest.mark.parametrize("uri", [None, 123])
+    def test_update_rejects_non_string_artifact_uri(self, uri):
+        with pytest.raises(ValidationError):
+            SimulationUpdate(artifacts=[{"kind": "output", "uri": uri, "label": "Bad"}])
 
     def test_rejects_invalid_external_link_url(self):
         with pytest.raises(ValidationError):

--- a/frontend/src/features/simulations/SimulationDetailsPage.tsx
+++ b/frontend/src/features/simulations/SimulationDetailsPage.tsx
@@ -4,7 +4,10 @@ import { useLocation, useParams } from 'react-router-dom';
 
 import { useAuth } from '@/auth/hooks/useAuth';
 import { resolvePaceExecution, updateSimulation } from '@/features/simulations/api/api';
-import { SimulationDetailsView } from '@/features/simulations/components/SimulationDetailsView';
+import {
+  SimulationDetailsView,
+  type SimulationSaveError,
+} from '@/features/simulations/components/SimulationDetailsView';
 import { useSimulation } from '@/features/simulations/hooks/useSimulation';
 import { useSimulationSummary } from '@/features/simulations/hooks/useSimulationSummary';
 import { toast } from '@/hooks/use-toast';
@@ -17,34 +20,49 @@ interface SimulationDetailsPageProps {
   setSelectedSimulationIds: (ids: string[]) => void;
 }
 
-const getUpdateErrorMessage = (error: unknown): string => {
+const getUpdateError = (error: unknown): SimulationSaveError => {
   if (axios.isAxiosError(error)) {
     const detail = error.response?.data?.detail;
 
     if (typeof detail === 'string') {
-      return detail;
+      return {
+        message: detail,
+        validationDetails: [],
+      };
     }
 
     if (Array.isArray(detail)) {
-      const messages = detail
+      const validationDetails = detail
         .map((item) => {
-          const field = Array.isArray(item?.loc) ? item.loc[item.loc.length - 1] : null;
           const message = typeof item?.msg === 'string' ? item.msg : null;
+          const loc = Array.isArray(item?.loc)
+            ? item.loc.filter(
+                (part: unknown): part is string | number =>
+                  typeof part === 'string' || typeof part === 'number',
+              )
+            : [];
 
           if (!message) return null;
-          if (typeof field !== 'string') return message;
-
-          return `${field}: ${message}`;
+          return {
+            loc,
+            msg: message,
+          };
         })
-        .filter((message): message is string => Boolean(message));
+        .filter((item): item is SimulationSaveError['validationDetails'][number] => Boolean(item));
 
-      if (messages.length > 0) {
-        return messages.join(' ');
+      if (validationDetails.length > 0) {
+        return {
+          message: 'One or more fields need attention before this simulation can be saved.',
+          validationDetails,
+        };
       }
     }
   }
 
-  return error instanceof Error ? error.message : 'Failed to update simulation.';
+  return {
+    message: error instanceof Error ? error.message : 'Failed to update simulation.',
+    validationDetails: [],
+  };
 };
 
 export const SimulationDetailsPage = ({
@@ -57,7 +75,7 @@ export const SimulationDetailsPage = ({
   const { isAuthenticated, loading: authLoading, loginWithGithub } = useAuth();
   const [simulation, setSimulation] = useState<SimulationOut | null>(null);
   const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<SimulationSaveError | null>(null);
   const [paceExperimentId, setPaceExperimentId] = useState<string | null>(null);
   const [isResolvingPace, setIsResolvingPace] = useState(false);
   const [paceResolutionAttempted, setPaceResolutionAttempted] = useState(false);
@@ -142,7 +160,7 @@ export const SimulationDetailsPage = ({
       setSimulation(updatedSimulation);
       return true;
     } catch (saveErr) {
-      setSaveError(getUpdateErrorMessage(saveErr));
+      setSaveError(getUpdateError(saveErr));
       return false;
     } finally {
       setIsSaving(false);

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -195,6 +195,23 @@ const normalizeLinkRows = (rows: EditableLinkRow[]): ExternalLinkIn[] =>
     label: normalizeOptionalText(row.label),
   }));
 
+const validateResourceRows = (
+  artifactRows: EditableArtifactRow[],
+  linkRows: EditableLinkRow[],
+): string | null => {
+  const hasBlankArtifactValue = artifactRows.some((row) => row.value.trim().length === 0);
+  if (hasBlankArtifactValue) {
+    return 'Artifact URI is required for every artifact row.';
+  }
+
+  const hasBlankLinkValue = linkRows.some((row) => row.value.trim().length === 0);
+  if (hasBlankLinkValue) {
+    return 'Link URL is required for every external link row.';
+  }
+
+  return null;
+};
+
 const areResourceListsEqual = (left: unknown, right: unknown): boolean =>
   JSON.stringify(left) === JSON.stringify(right);
 
@@ -493,6 +510,8 @@ export const SimulationDetailsView = ({
     }
   }, [canEdit, simulation]);
 
+  const resourceValidationError = validateResourceRows(artifactRows, linkRows);
+
   const updateField = (field: EditableField, value: string) => {
     onClearSaveError?.();
     setFormState((current) => ({
@@ -511,6 +530,9 @@ export const SimulationDetailsView = ({
 
   const handleSave = async () => {
     if (!onSave) return;
+    if (resourceValidationError) {
+      return;
+    }
 
     const payload = buildUpdatePayload(simulation, formState, artifactRows, linkRows);
 
@@ -657,14 +679,19 @@ export const SimulationDetailsView = ({
               <Button variant="outline" onClick={handleCancelEdit} disabled={isSaving}>
                 Cancel
               </Button>
-              <Button onClick={handleSave} disabled={isSaving || !hasUnsavedChanges}>
+              <Button
+                onClick={handleSave}
+                disabled={isSaving || !hasUnsavedChanges || resourceValidationError !== null}
+              >
                 {isSaving ? 'Saving…' : 'Save Changes'}
               </Button>
             </>
           )}
         </div>
       </div>
-      {isEditing && saveError && <div className="text-sm text-red-600">{saveError}</div>}
+      {isEditing && (resourceValidationError || saveError) && (
+        <div className="text-sm text-red-600">{resourceValidationError ?? saveError}</div>
+      )}
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
@@ -1354,13 +1381,20 @@ export const SimulationDetailsView = ({
                         <Button variant="outline" onClick={handleCancelEdit} disabled={isSaving}>
                           Cancel
                         </Button>
-                        <Button onClick={handleSave} disabled={isSaving || !hasUnsavedChanges}>
+                        <Button
+                          onClick={handleSave}
+                          disabled={isSaving || !hasUnsavedChanges || resourceValidationError !== null}
+                        >
                           {isSaving ? 'Saving…' : 'Save Changes'}
                         </Button>
                       </div>
                     </div>
                   )}
-                  {isEditing && saveError && <p className="text-sm text-red-600">{saveError}</p>}
+                  {isEditing && (resourceValidationError || saveError) && (
+                    <p className="text-sm text-red-600">
+                      {resourceValidationError ?? saveError}
+                    </p>
+                  )}
                 </CardContent>
               </Card>
 

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, ChevronDown, CircleHelp } from 'lucide-react';
+import { ArrowLeft, ChevronDown, CircleHelp, Plus, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -29,6 +29,10 @@ import {
 import { SimulationTypeBadge } from '@/features/simulations/components/SimulationTypeBadge';
 import { cn } from '@/lib/utils';
 import type {
+  ArtifactIn,
+  ArtifactKind,
+  ExternalLinkIn,
+  ExternalLinkKind,
   SimulationEditableField,
   SimulationOut,
   SimulationStatusValue,
@@ -127,6 +131,174 @@ const ReadonlyTextBlock = ({ value, className }: { value?: string | null; classN
   </div>
 );
 
+type ResourceKindOption<TKind extends string> = {
+  value: TKind;
+  label: string;
+};
+
+type EditableArtifactRow = {
+  kind: ArtifactKind;
+  label: string;
+  value: string;
+};
+
+type EditableLinkRow = {
+  kind: ExternalLinkKind;
+  label: string;
+  value: string;
+};
+
+const ARTIFACT_KIND_OPTIONS: ReadonlyArray<ResourceKindOption<ArtifactKind>> = [
+  { value: 'output', label: 'Output' },
+  { value: 'archive', label: 'Archive' },
+  { value: 'run_script', label: 'Run Script' },
+  { value: 'postprocessing_script', label: 'Post-processing Script' },
+];
+
+const EXTERNAL_LINK_KIND_OPTIONS: ReadonlyArray<ResourceKindOption<ExternalLinkKind>> = [
+  { value: 'diagnostic', label: 'Diagnostic' },
+  { value: 'performance', label: 'Performance' },
+  { value: 'docs', label: 'Docs' },
+  { value: 'other', label: 'Other' },
+];
+
+const toEditableArtifactRows = (simulation: SimulationOut): EditableArtifactRow[] =>
+  simulation.artifacts.map((artifact) => ({
+    kind: artifact.kind,
+    label: artifact.label ?? '',
+    value: artifact.uri,
+  }));
+
+const toEditableLinkRows = (simulation: SimulationOut): EditableLinkRow[] =>
+  simulation.links.map((link) => ({
+    kind: link.kind,
+    label: link.label ?? '',
+    value: link.url,
+  }));
+
+const normalizeOptionalText = (value: string): string | null => {
+  const trimmed = value.trim();
+  return trimmed || null;
+};
+
+const normalizeArtifactRows = (rows: EditableArtifactRow[]): ArtifactIn[] =>
+  rows.map((row) => ({
+    kind: row.kind,
+    uri: row.value.trim(),
+    label: normalizeOptionalText(row.label),
+  }));
+
+const normalizeLinkRows = (rows: EditableLinkRow[]): ExternalLinkIn[] =>
+  rows.map((row) => ({
+    kind: row.kind,
+    url: row.value.trim(),
+    label: normalizeOptionalText(row.label),
+  }));
+
+const areResourceListsEqual = (left: unknown, right: unknown): boolean =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+const EditableResourceList = <TKind extends string>({
+  title,
+  description,
+  items,
+  kindOptions,
+  valueLabel,
+  valuePlaceholder,
+  addLabel,
+  onAdd,
+  onKindChange,
+  onLabelChange,
+  onValueChange,
+  onRemove,
+}: {
+  title: string;
+  description?: string;
+  items: Array<{ kind: TKind; label: string; value: string }>;
+  kindOptions: ReadonlyArray<ResourceKindOption<TKind>>;
+  valueLabel: string;
+  valuePlaceholder: string;
+  addLabel: string;
+  onAdd: () => void;
+  onKindChange: (index: number, kind: TKind) => void;
+  onLabelChange: (index: number, value: string) => void;
+  onValueChange: (index: number, value: string) => void;
+  onRemove: (index: number) => void;
+}) => (
+  <div className="space-y-3">
+    <div className="flex items-start justify-between gap-3">
+      <div>
+        <Label className="text-sm font-medium">{title}</Label>
+        {description ? <p className="mt-1 text-xs text-muted-foreground">{description}</p> : null}
+      </div>
+      <Button type="button" variant="outline" size="sm" onClick={onAdd}>
+        <Plus className="mr-1 h-4 w-4" />
+        {addLabel}
+      </Button>
+    </div>
+
+    {items.length === 0 ? (
+      <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
+        No entries yet.
+      </div>
+    ) : (
+      <div className="space-y-3">
+        {items.map((item, index) => (
+          <div key={`${item.kind}-${index}`} className="rounded-md border p-3">
+            <div className="grid gap-3 md:grid-cols-[160px_minmax(0,1fr)_minmax(0,1.4fr)_auto] md:items-end">
+              <div>
+                <Label className="mb-1 block text-xs text-muted-foreground">Kind</Label>
+                <Select
+                  value={item.kind}
+                  onValueChange={(value: TKind) => onKindChange(index, value)}
+                >
+                  <SelectTrigger className="h-9 text-sm">
+                    <SelectValue placeholder="Select kind" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {kindOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label className="mb-1 block text-xs text-muted-foreground">Label</Label>
+                <Input
+                  value={item.label}
+                  onChange={(event) => onLabelChange(index, event.target.value)}
+                  placeholder="Optional label"
+                  className="h-9 text-sm"
+                />
+              </div>
+              <div>
+                <Label className="mb-1 block text-xs text-muted-foreground">{valueLabel}</Label>
+                <Input
+                  value={item.value}
+                  onChange={(event) => onValueChange(index, event.target.value)}
+                  placeholder={valuePlaceholder}
+                  className="h-9 text-sm"
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => onRemove(index)}
+                aria-label={`Remove ${title} item ${index + 1}`}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    )}
+  </div>
+);
+
 const EDITABLE_FIELDS = SIMULATION_EDITABLE_FIELDS;
 
 type EditableField = SimulationEditableField;
@@ -187,6 +359,8 @@ const normalizeEditableValue = (field: EditableField, value: string): string | n
 const buildUpdatePayload = (
   simulation: SimulationOut,
   formState: EditableFormState,
+  artifactRows: EditableArtifactRow[],
+  linkRows: EditableLinkRow[],
 ): SimulationUpdate => {
   const payload: SimulationUpdate = {};
   const mutablePayload = payload as Record<string, string | null>;
@@ -198,6 +372,18 @@ const buildUpdatePayload = (
     if (nextValue !== currentValue) {
       mutablePayload[field] = nextValue;
     }
+  }
+
+  const nextArtifacts = normalizeArtifactRows(artifactRows);
+  const currentArtifacts = normalizeArtifactRows(toEditableArtifactRows(simulation));
+  if (!areResourceListsEqual(nextArtifacts, currentArtifacts)) {
+    payload.artifacts = nextArtifacts;
+  }
+
+  const nextLinks = normalizeLinkRows(linkRows);
+  const currentLinks = normalizeLinkRows(toEditableLinkRows(simulation));
+  if (!areResourceListsEqual(nextLinks, currentLinks)) {
+    payload.links = nextLinks;
   }
 
   return payload;
@@ -240,6 +426,10 @@ export const SimulationDetailsView = ({
   const [formState, setFormState] = useState<EditableFormState>(() =>
     toEditableFormState(simulation),
   );
+  const [artifactRows, setArtifactRows] = useState<EditableArtifactRow[]>(() =>
+    toEditableArtifactRows(simulation),
+  );
+  const [linkRows, setLinkRows] = useState<EditableLinkRow[]>(() => toEditableLinkRows(simulation));
   const performanceLinks = simulation.groupedLinks.performance ?? [];
   const outputArtifacts = getArtifactsByKind(
     simulation.artifacts,
@@ -289,12 +479,16 @@ export const SimulationDetailsView = ({
 
   useEffect(() => {
     setFormState(toEditableFormState(simulation));
+    setArtifactRows(toEditableArtifactRows(simulation));
+    setLinkRows(toEditableLinkRows(simulation));
     setIsEditing(false);
   }, [simulation]);
 
   useEffect(() => {
     if (!canEdit) {
       setFormState(toEditableFormState(simulation));
+      setArtifactRows(toEditableArtifactRows(simulation));
+      setLinkRows(toEditableLinkRows(simulation));
       setIsEditing(false);
     }
   }, [canEdit, simulation]);
@@ -310,13 +504,15 @@ export const SimulationDetailsView = ({
   const handleCancelEdit = () => {
     onClearSaveError?.();
     setFormState(toEditableFormState(simulation));
+    setArtifactRows(toEditableArtifactRows(simulation));
+    setLinkRows(toEditableLinkRows(simulation));
     setIsEditing(false);
   };
 
   const handleSave = async () => {
     if (!onSave) return;
 
-    const payload = buildUpdatePayload(simulation, formState);
+    const payload = buildUpdatePayload(simulation, formState, artifactRows, linkRows);
 
     if (Object.keys(payload).length === 0) {
       onClearSaveError?.();
@@ -331,7 +527,8 @@ export const SimulationDetailsView = ({
     }
   };
 
-  const hasUnsavedChanges = Object.keys(buildUpdatePayload(simulation, formState)).length > 0;
+  const hasUnsavedChanges =
+    Object.keys(buildUpdatePayload(simulation, formState, artifactRows, linkRows)).length > 0;
   const compareSelectionCount = compareSelectionCountProp ?? 0;
   const maxCompareSelection = maxCompareSelectionProp ?? 5;
   const isCompareActionDisabled =
@@ -353,6 +550,40 @@ export const SimulationDetailsView = ({
       },
     ]);
     setNewComment('');
+  };
+
+  const updateArtifactRow = (index: number, updates: Partial<EditableArtifactRow>) => {
+    onClearSaveError?.();
+    setArtifactRows((current) =>
+      current.map((row, rowIndex) => (rowIndex === index ? { ...row, ...updates } : row)),
+    );
+  };
+
+  const updateLinkRow = (index: number, updates: Partial<EditableLinkRow>) => {
+    onClearSaveError?.();
+    setLinkRows((current) =>
+      current.map((row, rowIndex) => (rowIndex === index ? { ...row, ...updates } : row)),
+    );
+  };
+
+  const addArtifactRow = () => {
+    onClearSaveError?.();
+    setArtifactRows((current) => [...current, { kind: 'output', label: '', value: '' }]);
+  };
+
+  const addLinkRow = () => {
+    onClearSaveError?.();
+    setLinkRows((current) => [...current, { kind: 'diagnostic', label: '', value: '' }]);
+  };
+
+  const removeArtifactRow = (index: number) => {
+    onClearSaveError?.();
+    setArtifactRows((current) => current.filter((_, rowIndex) => rowIndex !== index));
+  };
+
+  const removeLinkRow = (index: number) => {
+    onClearSaveError?.();
+    setLinkRows((current) => current.filter((_, rowIndex) => rowIndex !== index));
   };
 
   return (
@@ -866,193 +1097,231 @@ export const SimulationDetailsView = ({
                   </div>
                 </CardHeader>
                 <CardContent>
-                  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-                    <div>
-                      <Label className="mb-1 block text-sm">Diagnostics</Label>
-                      {simulation.groupedLinks.diagnostic?.length ? (
-                        <ul className="list-disc pl-5 text-sm">
-                          {simulation.groupedLinks.diagnostic.map((d) => (
-                            <li key={d.url} className="flex items-center gap-2">
-                              <a
-                                className="flex items-center gap-1 text-blue-600 hover:underline"
-                                href={d.url}
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  width="16"
-                                  height="16"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                  className="inline-block"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
-                                  />
-                                </svg>
-                                {d.label}
-                              </a>
-                            </li>
-                          ))}
-                        </ul>
-                      ) : (
-                        <div className="mb-2 text-sm text-muted-foreground">
-                          Links to diagnostics will appear here once available.
+                  {isEditing ? (
+                    <div className="space-y-4">
+                      <EditableResourceList
+                        title="Saved External Links"
+                        description="Add, relabel, or remove diagnostic, performance, docs, and other links."
+                        items={linkRows}
+                        kindOptions={EXTERNAL_LINK_KIND_OPTIONS}
+                        valueLabel="URL"
+                        valuePlaceholder="https://example.com/resource"
+                        addLabel="Add link"
+                        onAdd={addLinkRow}
+                        onKindChange={(index, kind) => updateLinkRow(index, { kind })}
+                        onLabelChange={(index, value) => updateLinkRow(index, { label: value })}
+                        onValueChange={(index, value) => updateLinkRow(index, { value })}
+                        onRemove={removeLinkRow}
+                      />
+                      {paceLink ? (
+                        <div className="rounded-md border bg-muted/20 px-3 py-3 text-sm">
+                          <div className="font-medium">PACE helper link</div>
+                          <div className="mt-1 text-muted-foreground">
+                            This derived link is shown for convenience and is not saved with the
+                            simulation.
+                          </div>
+                          <a
+                            className="mt-2 inline-flex items-center gap-1 text-blue-600 hover:underline"
+                            href={paceLink.href}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {paceLink.label}
+                          </a>
                         </div>
-                      )}
+                      ) : null}
                     </div>
-                    <div>
-                      <Label className="mb-1 block text-sm">Performance</Label>
-                      {performanceLinks.length || paceLink ? (
-                        <ul className="list-disc pl-5 text-sm">
-                          {performanceLinks.map((p) => (
-                            <li key={p.url} className="flex items-center gap-2">
-                              <a
-                                className="flex items-center gap-1 text-blue-600 hover:underline"
-                                href={p.url}
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  width="16"
-                                  height="16"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                  className="inline-block"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
-                                  />
-                                </svg>
-                                {p.label}
-                              </a>
-                            </li>
-                          ))}
-                          {paceLink && (
-                            <li className="flex items-center gap-2">
-                              <a
-                                className="flex items-center gap-1 text-blue-600 hover:underline"
-                                href={paceLink.href}
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  width="16"
-                                  height="16"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                  className="inline-block"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
-                                  />
-                                </svg>
-                                {paceLink.label}
-                              </a>
-                              {isResolvingPace && (
-                                <>
-                                  <Spinner className="size-3 text-muted-foreground" />
-                                  <TooltipProvider delayDuration={150}>
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <button
-                                          type="button"
-                                          aria-label="PACE link resolution status"
-                                          className="text-muted-foreground hover:text-foreground"
-                                        >
-                                          <CircleHelp className="size-3" />
-                                        </button>
-                                      </TooltipTrigger>
-                                      <TooltipContent>
-                                        Checking for a direct PACE experiment link
-                                      </TooltipContent>
-                                    </Tooltip>
-                                  </TooltipProvider>
-                                </>
-                              )}
-                              {!isResolvingPace && showPaceFallbackInfo && (
-                                <TooltipProvider delayDuration={150}>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <button
-                                        type="button"
-                                        aria-label="PACE link fallback information"
-                                        className="text-muted-foreground hover:text-foreground"
-                                      >
-                                        <CircleHelp className="size-3" />
-                                      </button>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      Direct PACE experiment link not found. Search results may
-                                      still contain this run.
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </TooltipProvider>
-                              )}
-                            </li>
-                          )}
-                        </ul>
-                      ) : (
-                        <div className="mb-2 text-sm text-muted-foreground">
-                          Links to performance metrics will appear here once available.
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                  <div>
-                    {Object.entries(simulation.groupedLinks)
-                      .filter(([key]) => key !== 'diagnostic' && key !== 'performance')
-                      .map(([key, linkList]) => (
-                        <div key={key} className="mb-4">
-                          <h4 className="text-sm font-medium capitalize">{key}</h4>
-                          <ul className="list-disc pl-5 text-sm">
-                            {linkList.map((link) => (
-                              <li key={link.url} className="flex items-center gap-2">
-                                <a
-                                  className="flex items-center gap-1 text-blue-600 hover:underline"
-                                  href={link.url}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                >
-                                  <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    width="16"
-                                    height="16"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                    className="inline-block"
+                  ) : (
+                    <>
+                      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                        <div>
+                          <Label className="mb-1 block text-sm">Diagnostics</Label>
+                          {simulation.groupedLinks.diagnostic?.length ? (
+                            <ul className="list-disc pl-5 text-sm">
+                              {simulation.groupedLinks.diagnostic.map((d) => (
+                                <li key={d.url} className="flex items-center gap-2">
+                                  <a
+                                    className="flex items-center gap-1 text-blue-600 hover:underline"
+                                    href={d.url}
+                                    target="_blank"
+                                    rel="noreferrer"
                                   >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      strokeWidth={2}
-                                      d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
-                                    />
-                                  </svg>
-                                  {link.label}
-                                </a>
-                              </li>
-                            ))}
-                          </ul>
+                                    <svg
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      width="16"
+                                      height="16"
+                                      fill="none"
+                                      viewBox="0 0 24 24"
+                                      stroke="currentColor"
+                                      className="inline-block"
+                                    >
+                                      <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
+                                      />
+                                    </svg>
+                                    {d.label}
+                                  </a>
+                                </li>
+                              ))}
+                            </ul>
+                          ) : (
+                            <div className="mb-2 text-sm text-muted-foreground">
+                              Links to diagnostics will appear here once available.
+                            </div>
+                          )}
                         </div>
-                      ))}
-                  </div>
+                        <div>
+                          <Label className="mb-1 block text-sm">Performance</Label>
+                          {performanceLinks.length || paceLink ? (
+                            <ul className="list-disc pl-5 text-sm">
+                              {performanceLinks.map((p) => (
+                                <li key={p.url} className="flex items-center gap-2">
+                                  <a
+                                    className="flex items-center gap-1 text-blue-600 hover:underline"
+                                    href={p.url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                  >
+                                    <svg
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      width="16"
+                                      height="16"
+                                      fill="none"
+                                      viewBox="0 0 24 24"
+                                      stroke="currentColor"
+                                      className="inline-block"
+                                    >
+                                      <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
+                                      />
+                                    </svg>
+                                    {p.label}
+                                  </a>
+                                </li>
+                              ))}
+                              {paceLink && (
+                                <li className="flex items-center gap-2">
+                                  <a
+                                    className="flex items-center gap-1 text-blue-600 hover:underline"
+                                    href={paceLink.href}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                  >
+                                    <svg
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      width="16"
+                                      height="16"
+                                      fill="none"
+                                      viewBox="0 0 24 24"
+                                      stroke="currentColor"
+                                      className="inline-block"
+                                    >
+                                      <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
+                                      />
+                                    </svg>
+                                    {paceLink.label}
+                                  </a>
+                                  {isResolvingPace && (
+                                    <>
+                                      <Spinner className="size-3 text-muted-foreground" />
+                                      <TooltipProvider delayDuration={150}>
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <button
+                                              type="button"
+                                              aria-label="PACE link resolution status"
+                                              className="text-muted-foreground hover:text-foreground"
+                                            >
+                                              <CircleHelp className="size-3" />
+                                            </button>
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            Checking for a direct PACE experiment link
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      </TooltipProvider>
+                                    </>
+                                  )}
+                                  {!isResolvingPace && showPaceFallbackInfo && (
+                                    <TooltipProvider delayDuration={150}>
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <button
+                                            type="button"
+                                            aria-label="PACE link fallback information"
+                                            className="text-muted-foreground hover:text-foreground"
+                                          >
+                                            <CircleHelp className="size-3" />
+                                          </button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                          Direct PACE experiment link not found. Search results may
+                                          still contain this run.
+                                        </TooltipContent>
+                                      </Tooltip>
+                                    </TooltipProvider>
+                                  )}
+                                </li>
+                              )}
+                            </ul>
+                          ) : (
+                            <div className="mb-2 text-sm text-muted-foreground">
+                              Links to performance metrics will appear here once available.
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                      <div>
+                        {Object.entries(simulation.groupedLinks)
+                          .filter(([key]) => key !== 'diagnostic' && key !== 'performance')
+                          .map(([key, linkList]) => (
+                            <div key={key} className="mb-4">
+                              <h4 className="text-sm font-medium capitalize">{key}</h4>
+                              <ul className="list-disc pl-5 text-sm">
+                                {linkList.map((link) => (
+                                  <li key={link.url} className="flex items-center gap-2">
+                                    <a
+                                      className="flex items-center gap-1 text-blue-600 hover:underline"
+                                      href={link.url}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                    >
+                                      <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        width="16"
+                                        height="16"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        stroke="currentColor"
+                                        className="inline-block"
+                                      >
+                                        <path
+                                          strokeLinecap="round"
+                                          strokeLinejoin="round"
+                                          strokeWidth={2}
+                                          d="M15 7h2a5 5 0 015 5v0a5 5 0 01-5 5h-2m-6 0H7a5 5 0 01-5-5v0a5 5 0 015-5h2m1 5h4"
+                                        />
+                                      </svg>
+                                      {link.label}
+                                    </a>
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          ))}
+                      </div>
+                    </>
+                  )}
                 </CardContent>
               </Card>
 
@@ -1079,7 +1348,7 @@ export const SimulationDetailsView = ({
                   {canEdit && isEditing && (
                     <div className="flex items-center justify-between gap-3">
                       <div className="text-xs text-muted-foreground">
-                        Save updates description, provenance, and notes fields only.
+                        Save updates metadata, notes, artifacts, and external links together.
                       </div>
                       <div className="flex items-center gap-2">
                         <Button variant="outline" onClick={handleCancelEdit} disabled={isSaving}>
@@ -1167,34 +1436,60 @@ export const SimulationDetailsView = ({
 
         {/* OUTPUTS TAB */}
         <TabsContent value="outputs" className="space-y-6">
-          <SimulationPathCard
-            kind="output"
-            title="Output Paths"
-            description="These are the primary output files generated by the simulation."
-            paths={outputArtifacts}
-            emptyText="No output paths available."
-          />
-          <SimulationPathCard
-            kind="archive"
-            title="Archive Paths"
-            description="These paths contain archived data files from the simulation."
-            paths={archiveArtifacts}
-            emptyText="No archive artifacts available."
-          />
-          <SimulationPathCard
-            kind="run_script"
-            title="Run Script Paths"
-            description="Scripts used to run the simulation."
-            paths={runScriptArtifacts}
-            emptyText="No run script artifacts available."
-          />
-          <SimulationPathCard
-            kind="postprocessing_script"
-            title="Post-processing Script Paths"
-            description="Scripts used after the main run to transform or analyze outputs."
-            paths={postprocessingScriptArtifacts}
-            emptyText="No post-processing script artifacts available."
-          />
+          {isEditing ? (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">Artifacts</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <EditableResourceList
+                  title="Saved Artifacts"
+                  description="Manage output, archive, run script, and post-processing artifact paths or URIs."
+                  items={artifactRows}
+                  kindOptions={ARTIFACT_KIND_OPTIONS}
+                  valueLabel="Path or URI"
+                  valuePlaceholder="/path/to/resource or s3://bucket/object"
+                  addLabel="Add artifact"
+                  onAdd={addArtifactRow}
+                  onKindChange={(index, kind) => updateArtifactRow(index, { kind })}
+                  onLabelChange={(index, value) => updateArtifactRow(index, { label: value })}
+                  onValueChange={(index, value) => updateArtifactRow(index, { value })}
+                  onRemove={removeArtifactRow}
+                />
+              </CardContent>
+            </Card>
+          ) : (
+            <>
+              <SimulationPathCard
+                kind="output"
+                title="Output Paths"
+                description="These are the primary output files generated by the simulation."
+                paths={outputArtifacts}
+                emptyText="No output paths available."
+              />
+              <SimulationPathCard
+                kind="archive"
+                title="Archive Paths"
+                description="These paths contain archived data files from the simulation."
+                paths={archiveArtifacts}
+                emptyText="No archive artifacts available."
+              />
+              <SimulationPathCard
+                kind="run_script"
+                title="Run Script Paths"
+                description="Scripts used to run the simulation."
+                paths={runScriptArtifacts}
+                emptyText="No run script artifacts available."
+              />
+              <SimulationPathCard
+                kind="postprocessing_script"
+                title="Post-processing Script Paths"
+                description="Scripts used after the main run to transform or analyze outputs."
+                paths={postprocessingScriptArtifacts}
+                emptyText="No post-processing script artifacts available."
+              />
+            </>
+          )}
         </TabsContent>
       </Tabs>
     </div>

--- a/frontend/src/features/simulations/components/SimulationDetailsView.tsx
+++ b/frontend/src/features/simulations/components/SimulationDetailsView.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, ChevronDown, CircleHelp, Plus, Trash2 } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, ChevronDown, CircleHelp, Plus, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -52,7 +52,7 @@ interface SimulationDetailsViewProps {
   maxCompareSelection?: number;
   canEdit?: boolean;
   isSaving?: boolean;
-  saveError?: string | null;
+  saveError?: SimulationSaveError | null;
   backHref?: string;
   backLabel?: string;
   paceLink?: {
@@ -77,6 +77,14 @@ interface SimulationDetailsViewProps {
   showLoginForAiSummary?: boolean;
   isCheckingAuth?: boolean;
   onLoginForSummary?: () => void;
+}
+
+export interface SimulationSaveError {
+  message: string;
+  validationDetails: Array<{
+    loc: Array<string | number>;
+    msg: string;
+  }>;
 }
 
 // -------------------- Small UI helpers --------------------
@@ -148,6 +156,15 @@ type EditableLinkRow = {
   value: string;
 };
 
+type EditableResourceField = 'kind' | 'label' | 'value';
+
+type ResourceRowFieldErrors = Partial<Record<EditableResourceField, string>>;
+
+type ResourceRowErrorsState = {
+  artifacts: ResourceRowFieldErrors[];
+  links: ResourceRowFieldErrors[];
+};
+
 const ARTIFACT_KIND_OPTIONS: ReadonlyArray<ResourceKindOption<ArtifactKind>> = [
   { value: 'output', label: 'Output' },
   { value: 'archive', label: 'Archive' },
@@ -195,25 +212,121 @@ const normalizeLinkRows = (rows: EditableLinkRow[]): ExternalLinkIn[] =>
     label: normalizeOptionalText(row.label),
   }));
 
-const validateResourceRows = (
+const createEmptyRowErrors = (count: number): ResourceRowFieldErrors[] =>
+  Array.from({ length: count }, () => ({}));
+
+const getClientResourceRowErrors = (
   artifactRows: EditableArtifactRow[],
   linkRows: EditableLinkRow[],
-): string | null => {
-  const hasBlankArtifactValue = artifactRows.some((row) => row.value.trim().length === 0);
-  if (hasBlankArtifactValue) {
-    return 'Artifact URI is required for every artifact row.';
+): ResourceRowErrorsState => ({
+  artifacts: artifactRows.map((row) =>
+    row.value.trim().length === 0 ? { value: 'Artifact URI is required.' } : {},
+  ),
+  links: linkRows.map((row) =>
+    row.value.trim().length === 0 ? { value: 'Link URL is required.' } : {},
+  ),
+});
+
+const normalizeValidationLoc = (loc: Array<string | number>): Array<string | number> =>
+  loc[0] === 'body' ? loc.slice(1) : loc;
+
+const toEditableField = (field: string): EditableResourceField | null => {
+  if (field === 'url' || field === 'uri') {
+    return 'value';
   }
 
-  const hasBlankLinkValue = linkRows.some((row) => row.value.trim().length === 0);
-  if (hasBlankLinkValue) {
-    return 'Link URL is required for every external link row.';
+  if (field === 'kind' || field === 'label') {
+    return field;
   }
 
   return null;
 };
 
+const toValidationPathLabel = (loc: Array<string | number>): string => {
+  const normalizedLoc = normalizeValidationLoc(loc);
+  if (normalizedLoc.length === 0) {
+    return 'Validation error';
+  }
+
+  return normalizedLoc
+    .map((segment) => (typeof segment === 'number' ? `${segment + 1}` : segment))
+    .join(' > ');
+};
+
+const mapSaveValidationErrors = (
+  validationDetails: SimulationSaveError['validationDetails'],
+  artifactCount: number,
+  linkCount: number,
+) => {
+  const rowErrors: ResourceRowErrorsState = {
+    artifacts: createEmptyRowErrors(artifactCount),
+    links: createEmptyRowErrors(linkCount),
+  };
+  const unmappedMessages: string[] = [];
+  let hasMappedLinkValueError = false;
+
+  for (const detail of validationDetails) {
+    const loc = normalizeValidationLoc(detail.loc);
+    const [resourceName, rowIndex, fieldName] = loc;
+
+    if (
+      resourceName === 'artifacts' &&
+      typeof rowIndex === 'number' &&
+      rowIndex >= 0 &&
+      rowIndex < artifactCount &&
+      typeof fieldName === 'string'
+    ) {
+      const field = toEditableField(fieldName);
+      if (field) {
+        rowErrors.artifacts[rowIndex] = {
+          ...rowErrors.artifacts[rowIndex],
+          [field]: detail.msg,
+        };
+        continue;
+      }
+    }
+
+    if (
+      resourceName === 'links' &&
+      typeof rowIndex === 'number' &&
+      rowIndex >= 0 &&
+      rowIndex < linkCount &&
+      typeof fieldName === 'string'
+    ) {
+      const field = toEditableField(fieldName);
+      if (field) {
+        rowErrors.links[rowIndex] = {
+          ...rowErrors.links[rowIndex],
+          [field]: detail.msg,
+        };
+        hasMappedLinkValueError ||= field === 'value';
+        continue;
+      }
+    }
+
+    unmappedMessages.push(`${toValidationPathLabel(detail.loc)}: ${detail.msg}`);
+  }
+
+  return {
+    rowErrors,
+    unmappedMessages,
+    hasMappedLinkValueError,
+  };
+};
+
 const areResourceListsEqual = (left: unknown, right: unknown): boolean =>
   JSON.stringify(left) === JSON.stringify(right);
+
+const mergeRowFieldErrors = (
+  primary: ResourceRowFieldErrors,
+  secondary: ResourceRowFieldErrors,
+): ResourceRowFieldErrors => ({
+  ...primary,
+  ...secondary,
+});
+
+const hasAnyRowErrors = (rowErrors: ResourceRowErrorsState): boolean =>
+  [...rowErrors.artifacts, ...rowErrors.links].some((row) => Object.keys(row).length > 0);
 
 const EditableResourceList = <TKind extends string>({
   title,
@@ -228,6 +341,7 @@ const EditableResourceList = <TKind extends string>({
   onLabelChange,
   onValueChange,
   onRemove,
+  rowErrors,
 }: {
   title: string;
   description?: string;
@@ -241,6 +355,7 @@ const EditableResourceList = <TKind extends string>({
   onLabelChange: (index: number, value: string) => void;
   onValueChange: (index: number, value: string) => void;
   onRemove: (index: number) => void;
+  rowErrors?: ResourceRowFieldErrors[];
 }) => (
   <div className="space-y-3">
     <div className="flex items-start justify-between gap-3">
@@ -262,8 +377,8 @@ const EditableResourceList = <TKind extends string>({
       <div className="space-y-3">
         {items.map((item, index) => (
           <div key={`${item.kind}-${index}`} className="rounded-md border p-3">
-            <div className="grid gap-3 md:grid-cols-[160px_minmax(0,1fr)_minmax(0,1.4fr)_auto] md:items-end">
-              <div>
+            <div className="grid gap-3 md:grid-cols-[160px_minmax(0,1fr)_minmax(0,1.4fr)_auto] md:items-start">
+              <div className="space-y-1">
                 <Label className="mb-1 block text-xs text-muted-foreground">Kind</Label>
                 <Select
                   value={item.kind}
@@ -280,24 +395,41 @@ const EditableResourceList = <TKind extends string>({
                     ))}
                   </SelectContent>
                 </Select>
+                <div className="min-h-4" aria-hidden="true" />
               </div>
-              <div>
+              <div className="space-y-1">
                 <Label className="mb-1 block text-xs text-muted-foreground">Label</Label>
                 <Input
                   value={item.label}
                   onChange={(event) => onLabelChange(index, event.target.value)}
                   placeholder="Optional label"
-                  className="h-9 text-sm"
+                  className={cn(
+                    'h-9 text-sm',
+                    rowErrors?.[index]?.label ? 'border-red-300 focus-visible:ring-red-200' : '',
+                  )}
                 />
+                {rowErrors?.[index]?.label ? (
+                  <p className="min-h-4 text-xs leading-4 text-red-600">{rowErrors[index].label}</p>
+                ) : (
+                  <div className="min-h-4" aria-hidden="true" />
+                )}
               </div>
-              <div>
+              <div className="space-y-1">
                 <Label className="mb-1 block text-xs text-muted-foreground">{valueLabel}</Label>
                 <Input
                   value={item.value}
                   onChange={(event) => onValueChange(index, event.target.value)}
                   placeholder={valuePlaceholder}
-                  className="h-9 text-sm"
+                  className={cn(
+                    'h-9 text-sm',
+                    rowErrors?.[index]?.value ? 'border-red-300 focus-visible:ring-red-200' : '',
+                  )}
                 />
+                {rowErrors?.[index]?.value ? (
+                  <p className="min-h-4 text-xs leading-4 text-red-600">{rowErrors[index].value}</p>
+                ) : (
+                  <div className="min-h-4" aria-hidden="true" />
+                )}
               </div>
               <Button
                 type="button"
@@ -305,6 +437,7 @@ const EditableResourceList = <TKind extends string>({
                 size="icon"
                 onClick={() => onRemove(index)}
                 aria-label={`Remove ${title} item ${index + 1}`}
+                className="mt-6 self-start"
               >
                 <Trash2 className="h-4 w-4" />
               </Button>
@@ -447,6 +580,11 @@ export const SimulationDetailsView = ({
     toEditableArtifactRows(simulation),
   );
   const [linkRows, setLinkRows] = useState<EditableLinkRow[]>(() => toEditableLinkRows(simulation));
+  const [serverRowErrors, setServerRowErrors] = useState<ResourceRowErrorsState>({
+    artifacts: [],
+    links: [],
+  });
+  const [saveSummaryMessage, setSaveSummaryMessage] = useState<string | null>(null);
   const performanceLinks = simulation.groupedLinks.performance ?? [];
   const outputArtifacts = getArtifactsByKind(
     simulation.artifacts,
@@ -510,7 +648,63 @@ export const SimulationDetailsView = ({
     }
   }, [canEdit, simulation]);
 
-  const resourceValidationError = validateResourceRows(artifactRows, linkRows);
+  useEffect(() => {
+    if (!saveError) {
+      setServerRowErrors({
+        artifacts: createEmptyRowErrors(artifactRows.length),
+        links: createEmptyRowErrors(linkRows.length),
+      });
+      setSaveSummaryMessage(null);
+      return;
+    }
+
+    const mappedErrors = mapSaveValidationErrors(
+      saveError.validationDetails,
+      artifactRows.length,
+      linkRows.length,
+    );
+
+    setServerRowErrors(mappedErrors.rowErrors);
+
+    if (mappedErrors.unmappedMessages.length > 0) {
+      setSaveSummaryMessage(mappedErrors.unmappedMessages.join(' '));
+      return;
+    }
+
+    if (mappedErrors.hasMappedLinkValueError) {
+      setSaveSummaryMessage('One or more links need a full URL including https://.');
+      return;
+    }
+
+    if (hasAnyRowErrors(mappedErrors.rowErrors)) {
+      setSaveSummaryMessage('Fix highlighted resource rows before saving.');
+      return;
+    }
+
+    setSaveSummaryMessage(saveError.message);
+  }, [artifactRows.length, linkRows.length, saveError]);
+
+  const clientRowErrors = getClientResourceRowErrors(artifactRows, linkRows);
+  const combinedRowErrors: ResourceRowErrorsState = {
+    artifacts: artifactRows.map((_, index) =>
+      mergeRowFieldErrors(
+        clientRowErrors.artifacts[index] ?? {},
+        serverRowErrors.artifacts[index] ?? {},
+      ),
+    ),
+    links: linkRows.map((_, index) =>
+      mergeRowFieldErrors(
+        clientRowErrors.links[index] ?? {},
+        serverRowErrors.links[index] ?? {},
+      ),
+    ),
+  };
+  const hasClientResourceErrors = hasAnyRowErrors(clientRowErrors);
+  const summaryErrorMessage = saveSummaryMessage
+    ? saveSummaryMessage
+    : hasClientResourceErrors
+      ? 'Fix highlighted resource rows before saving.'
+      : null;
 
   const updateField = (field: EditableField, value: string) => {
     onClearSaveError?.();
@@ -530,7 +724,7 @@ export const SimulationDetailsView = ({
 
   const handleSave = async () => {
     if (!onSave) return;
-    if (resourceValidationError) {
+    if (hasClientResourceErrors) {
       return;
     }
 
@@ -681,7 +875,7 @@ export const SimulationDetailsView = ({
               </Button>
               <Button
                 onClick={handleSave}
-                disabled={isSaving || !hasUnsavedChanges || resourceValidationError !== null}
+                disabled={isSaving || !hasUnsavedChanges || hasClientResourceErrors}
               >
                 {isSaving ? 'Saving…' : 'Save Changes'}
               </Button>
@@ -689,9 +883,6 @@ export const SimulationDetailsView = ({
           )}
         </div>
       </div>
-      {isEditing && (resourceValidationError || saveError) && (
-        <div className="text-sm text-red-600">{resourceValidationError ?? saveError}</div>
-      )}
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
@@ -1139,6 +1330,7 @@ export const SimulationDetailsView = ({
                         onLabelChange={(index, value) => updateLinkRow(index, { label: value })}
                         onValueChange={(index, value) => updateLinkRow(index, { value })}
                         onRemove={removeLinkRow}
+                        rowErrors={combinedRowErrors.links}
                       />
                       {paceLink ? (
                         <div className="rounded-md border bg-muted/20 px-3 py-3 text-sm">
@@ -1383,18 +1575,24 @@ export const SimulationDetailsView = ({
                         </Button>
                         <Button
                           onClick={handleSave}
-                          disabled={isSaving || !hasUnsavedChanges || resourceValidationError !== null}
+                          disabled={isSaving || !hasUnsavedChanges || hasClientResourceErrors}
                         >
                           {isSaving ? 'Saving…' : 'Save Changes'}
                         </Button>
                       </div>
                     </div>
                   )}
-                  {isEditing && (resourceValidationError || saveError) && (
-                    <p className="text-sm text-red-600">
-                      {resourceValidationError ?? saveError}
-                    </p>
-                  )}
+                  {isEditing && summaryErrorMessage ? (
+                    <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+                      <div className="flex items-start gap-2">
+                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                        <div>
+                          <p className="font-medium">Save blocked</p>
+                          <p className="mt-1 text-red-700">{summaryErrorMessage}</p>
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
                 </CardContent>
               </Card>
 
@@ -1489,6 +1687,7 @@ export const SimulationDetailsView = ({
                   onLabelChange={(index, value) => updateArtifactRow(index, { label: value })}
                   onValueChange={(index, value) => updateArtifactRow(index, { value })}
                   onRemove={removeArtifactRow}
+                  rowErrors={combinedRowErrors.artifacts}
                 />
               </CardContent>
             </Card>

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -153,7 +153,10 @@ export const SIMULATION_EDITABLE_FIELDS = [
 
 export type SimulationEditableField = (typeof SIMULATION_EDITABLE_FIELDS)[number];
 
-export type SimulationUpdate = Partial<Pick<SimulationCreate, SimulationEditableField>>;
+export interface SimulationUpdate extends Partial<Pick<SimulationCreate, SimulationEditableField>> {
+  artifacts?: ArtifactIn[];
+  links?: ExternalLinkIn[];
+}
 
 // Extends SimulationCreate with optional fields for file paths.
 export interface SimulationCreateForm extends SimulationCreate {


### PR DESCRIPTION
## Description

- Closes #222
- Adds backend PATCH support for full replacement of simulation artifacts and external links.
- Adds schema and API regression coverage for resource validation and replacement behavior.
- Adds Simulation Details edit UI for managing saved artifacts and external links while preserving grouped read-only rendering.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code
- [x] No new warnings
- [x] Tests added or updated (if needed)
- [x] All tests pass (locally and CI/CD)
- [ ] Documentation/comments updated (if needed)
- [ ] Breaking change noted (if applicable)

## Deployment Notes (if any)

- None.
